### PR TITLE
packgen: update errors/warnings handling

### DIFF
--- a/tools/packgen/include/PackGen.h
+++ b/tools/packgen/include/PackGen.h
@@ -194,6 +194,7 @@ public:
   std::string m_outputRoot;
   bool m_verbose = false;
   bool m_regenerate = false;
+  bool m_noComponents = true;
 
   /**
    * @brief class constructor
@@ -219,10 +220,10 @@ public:
   bool CreateQuery(void);
 
   /**
-   * @brief parse CMake File API to retrieve CMake targets
+   * @brief parse CMake File API reply to retrieve CMake targets
    * @return true if no errors happened, false otherwise
   */
-  bool ParseTarget(void);
+  bool ParseReply(void);
 
   /**
    * @brief parse input manifest YAML file
@@ -275,6 +276,7 @@ protected:
 
   static void SetAttribute(XMLTreeElement* element, const std::string& name, const std::string& value);
   static bool CopyItem(const std::string& src, const std::string& dst, std::list<std::string>& ext);
+  static const uint32_t CountNodes(const YAML::Node node, const std::string& name);
   void AddComponentBuildInfo(const std::string& componentName, buildInfo& reference);
   void InsertBuildInfo(buildInfo& build, const std::string& targetName, const std::string& buildName);
   void GetBuildInfo(buildInfo& reference, const std::list<std::string>& targetNames, const std::list<std::string>& buildNames, const std::string& operation);

--- a/tools/packgen/test/data/CMakeTestProject/invalid_manifest2.yml
+++ b/tools/packgen/test/data/CMakeTestProject/invalid_manifest2.yml
@@ -1,0 +1,66 @@
+### CMSIS Pack manifest file ###
+
+build:
+  - name: "build1"
+    options: "cmake -G Ninja"
+
+# the 'list' key below is not handled by packgen, it should be 'packs' instead
+list:
+  - name: "TestPack"
+    description: "TestPack description"
+    vendor: "ARM"
+    license: "LICENSE"
+    url: "http://arm.com/"
+
+    requirements:
+      packages:
+        - attributes: {vendor: "ARM", name: "ExternalPack", version: "5.5.5"}
+
+    releases:
+      - version: "1.0.0"
+        date: "2021-08-09"
+        description: "Initial release"
+
+    apis:
+      - name: api1
+        attributes: {Cclass: "Cclass1", Cgroup: "Group1", Csub: "Subgroup1", Capiversion: "1.0.0"}
+        description: "Api1"
+        files:
+          - name: "lib1/api/interface.h"
+            attributes: {category: header, attr: config, version: "1.0.0"}
+
+    taxonomy:
+      - attributes: {Cclass: "Class1"}
+        description: "Class1 taxonomy"
+      - attributes: {Cclass: "Class2"}
+        description: "Class2 taxonomy"
+      - attributes: {Cclass: "Class3"}
+        description: "Class3 taxonomy"
+
+    components:
+      # this component is based only on CMake target lib1
+      - name: component1
+        target: lib1
+        attributes: {Cclass: "Class1", Cgroup: "Group1", Csub: "Subgroup1", Cversion: "1.1.1"}
+        description: "Component1"
+
+      # this component is based on CMake target lib2, which depends on CMake targets lib3 and lib4 (see CMakeLists)
+      # it also depends explicitly on component3, so it has to filter out build info and to generate condition accordingly
+      - name: component2
+        target: lib2
+        attributes: {Cclass: "Class2", Cgroup: "Group2", Csub: "Subgroup2", Cversion: "2.2.2"}
+        description: "Component2"
+        dependencies: component3
+        conditions:
+          - require: {Cclass: "External Class 1", Cgroup: "External Group 1", Csub: "External Sub 1"}
+        files:
+          - name: "lib1/config/config.h"
+            attributes: {category: header, attr: config, version: "1.0.0"}
+            conditions:
+              - require: {Cclass: "External Class 2", Cgroup: "External Group 2", Csub: "External Sub 2"}
+
+      # this component merges lib4 and lib5 even if there is no CMake dependency between them
+      - name: component3
+        target: [lib4, lib5]
+        attributes: {Cclass: "Class3", Cgroup: "Group3", Csub: "Subgroup3", Cversion: "3.3.3"}
+        description: "Component3"

--- a/tools/packgen/test/src/PackGenUnitTests.cpp
+++ b/tools/packgen/test/src/PackGenUnitTests.cpp
@@ -107,7 +107,7 @@ TEST_F(PackGenUnitTests, RunPackGen) {
   // Empty options
   EXPECT_EQ(0, RunPackGen(1, argv));
 
-  // help options
+  // Help options
   const string& manifest = testinput_folder + "/CMakeTestProject/manifest.yml";
   argv[1] = (char*)manifest.c_str();
   argv[2] = (char*)"--output";
@@ -120,7 +120,12 @@ TEST_F(PackGenUnitTests, RunPackGen) {
   argv[1] = (char*)invalidManifest.c_str();
   EXPECT_EQ(1, RunPackGen(2, argv));
 
-  // manifest file doesn't exist
+  // Invalid manifest file, missing 'packs' section
+  const string& invalidManifest2 = testinput_folder + "/CMakeTestProject/invalid_manifest2.yml";
+  argv[1] = (char*)invalidManifest2.c_str();
+  EXPECT_EQ(1, RunPackGen(2, argv));
+
+  // Manifest file doesn't exist
   const string& unknownManifest = testinput_folder + "/CMakeTestProject/Unknown_manifest.yml";
   argv[1] = (char*)unknownManifest.c_str();
   EXPECT_EQ(1, RunPackGen(2, argv));


### PR DESCRIPTION
- return an error when 'packs' mandatory section is missing
- return a warning when multiple 'components' sections are defined
- print all packchk results, including errors and warnings
- avoid calling CMake when no components are defined and verbose mode is disabled