### PR TITLE
Revert "Packgen update parent"

### DIFF
--- a/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
+++ b/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
@@ -6,7 +6,7 @@
   <url>www.keil.com/pack/</url>
   <description>
     Testing pack reader and RTE model features.
-    Some packchk warnings are expected: missing version of config file
+    Some PackChk warnings are expected: missing version of config file
   </description>
 
   <releases>

--- a/tools/packgen/docs/README.md
+++ b/tools/packgen/docs/README.md
@@ -16,10 +16,10 @@ paths and defines.
  dependencies have been installed. It is a requirement to be able to
  successfully run the CMake generation step in the current environment.
 
-For validating and compressing pack files, the `packchk` and `7z` utilities
+For validating and compressing pack files, the `PackChk` and `7z` utilities
 shall be in the `PATH`:
 
-- packchk: <https://github.com/ARM-software/CMSIS_5/tree/master/CMSIS/Utilities/>
+- PackChk: <https://github.com/ARM-software/CMSIS_5/tree/master/CMSIS/Utilities/>
 - 7z: <https://www.7-zip.org/>
 
 ## Quick Start

--- a/tools/packgen/src/PackGen.cpp
+++ b/tools/packgen/src/PackGen.cpp
@@ -127,7 +127,7 @@ int PackGen::RunPackGen(int argc, char *argv[]) {
     return 1;
   }
 
-  // Run packchk
+  // Run PackChk
   if (!nocheck) {
     if (!generator.CheckPack()) {
       return 1;
@@ -887,13 +887,13 @@ bool PackGen::CheckPack(void) {
     // Change working dir
     fs::current_path(pack.outputDir, ec);
 
-    // packchk
-    result = ExecCommand("packchk \"" + pack.vendor + "." + pack.name + ".pdsc\"");
+    // Packchk
+    result = ExecCommand("PackChk \"" + pack.vendor + "." + pack.name + ".pdsc\"");
     if (result.second) {
       cerr << "packgen error: packchk failed" << endl << result.first << endl;
       return false;
     } else {
-      // packchk report
+      // Packchk report
       cout << result.first << endl;
     }
   }


### PR DESCRIPTION
The `PackChk` utility that is currently available is written in camel case:
https://github.com/ARM-software/CMSIS_5/tree/master/CMSIS/Utilities/
I suggest to revert the PR #12 now and remerge it when `packchk` will be released only with lower case characters.