### PR TITLE
Updating cmake_minimum_required version from 3.14 to 3.18 (#31)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# 11.02.2021 : verify merge of feature/cmsis-rte to master
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/libs/crossplatform/CMakeLists.txt
+++ b/libs/crossplatform/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(CrossPlatform VERSION 1.0.0)
 
 message(STATUS "Building for: " ${CMAKE_SYSTEM_NAME})

--- a/libs/crossplatform/test/CMakeLists.txt
+++ b/libs/crossplatform/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 # Create the Test target
 add_executable(TestProg src/TestProg.cpp)
 add_definitions(-DTEST_EXE="$<TARGET_FILE:TestProg>")

--- a/libs/errlog/CMakeLists.txt
+++ b/libs/errlog/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(ErrLog VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/errlog/test/CMakeLists.txt
+++ b/libs/errlog/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES src/ErrLogTest.cpp)
 
 add_executable(ErrLogUnitTests ${TEST_SOURCE_FILES})

--- a/libs/rtefsutils/CMakeLists.txt
+++ b/libs/rtefsutils/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(RteFsUtils VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/rtefsutils/test/CMakeLists.txt
+++ b/libs/rtefsutils/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES src/RteFsUtilsTest.cpp)
 
 add_executable(RteFsUtilsUnitTests ${TEST_SOURCE_FILES} ${TEST_HEADER_FILES})

--- a/libs/rtemodel/CMakeLists.txt
+++ b/libs/rtemodel/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(RteModel VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/rtemodel/test/CMakeLists.txt
+++ b/libs/rtemodel/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES src/RteModelTest.cpp src/RteExampleTest.cpp
  src/RteModelTestConfig.h src/RteModelTestConfig.cpp)
 

--- a/libs/rteutils/CMakeLists.txt
+++ b/libs/rteutils/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(RteUtils VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/rteutils/test/CMakeLists.txt
+++ b/libs/rteutils/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES src/RteUtilsTest.cpp)
 
 add_executable(RteUtilsUnitTests ${TEST_SOURCE_FILES})

--- a/libs/xmlreader/CMakeLists.txt
+++ b/libs/xmlreader/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(XmlReader VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/xmlreader/test/CMakeLists.txt
+++ b/libs/xmlreader/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES XmlReaderTest.cpp)
 
 add_executable(XmlReaderUnitTests ${TEST_SOURCE_FILES} ${TEST_HEADER_FILES})

--- a/libs/xmltree/CMakeLists.txt
+++ b/libs/xmltree/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(XmlTree VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/xmltree/test/CMakeLists.txt
+++ b/libs/xmltree/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES src/XmlFormatterTest.cpp src/XmlTreeTest.cpp)
 
 add_executable(XmlTreeUnitTests ${TEST_SOURCE_FILES})

--- a/libs/xmltreeslim/CMakeLists.txt
+++ b/libs/xmltreeslim/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(XmlTreeSlim VERSION 1.0.0)
 
 add_subdirectory("test")

--- a/libs/xmltreeslim/test/CMakeLists.txt
+++ b/libs/xmltreeslim/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(TEST_SOURCE_FILES XmlTreeSlimTest.cpp)
 
 add_executable(XmlTreeSlimUnitTests ${TEST_SOURCE_FILES} ${TEST_HEADER_FILES})

--- a/tools/buildmgr/CMakeLists.txt
+++ b/tools/buildmgr/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 include(DumpCMakeProjectVersion)
 include(ProjectVersionFromGitTag)
 get_version_from_git_tag("tools/buildmgr/")

--- a/tools/buildmgr/cbuild/CMakeLists.txt
+++ b/tools/buildmgr/cbuild/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(SOURCE_FILES CbuildCallback.cpp CbuildProject.cpp CbuildUtils.cpp
   Cbuild.cpp CbuildLayer.cpp CbuildMsgs.cpp CbuildKernel.cpp CbuildModel.cpp)
 SET(HEADER_FILES CbuildKernel.h CbuildModel.h CbuildCallback.h CbuildProject.h CbuildUtils.h

--- a/tools/buildmgr/cbuildgen/CMakeLists.txt
+++ b/tools/buildmgr/cbuildgen/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(LIB_SOURCES BuildSystemGenerator.cpp CMakeListsGenerator.cpp AuxCmd.cpp)
 SET(LIB_HEADER BuildSystemGenerator.h CMakeListsGenerator.h AuxCmd.h)
 SET(SOURCE_FILES Console.cpp)

--- a/tools/buildmgr/test/integrationtests/CMakeLists.txt
+++ b/tools/buildmgr/test/integrationtests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 SET(SOURCE_FILES CPInitTests.cpp CPInstallTests.cpp InstallerTests.cpp
   CBuildTestFixture.cpp CBuildAC6Tests.cpp CBuildGCCTests.cpp
   CBuildGenTestFixture.cpp CBuildGenTests.cpp SetupTests.cpp CBuildIntegTestEnv.cpp

--- a/tools/buildmgr/test/unittests/CMakeLists.txt
+++ b/tools/buildmgr/test/unittests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 set(TEST_SOURCE_FILES CBuildUnitTestEnv.cpp ModelTests.cpp UtilsTests.cpp
     CLayerTests.cpp BuildSystemGeneratorTests.cpp)
 set(TEST_HEADER_FILES CBuildUnitTestEnv.h)

--- a/tools/packgen/CMakeLists.txt
+++ b/tools/packgen/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 include(DumpCMakeProjectVersion)
 include(ProjectVersionFromGitTag)
 get_version_from_git_tag("tools/packgen/")


### PR DESCRIPTION
As mentioned in [documentation ](https://github.com/Open-CMSIS-Pack/devtools/blob/main/README.md) min version required is 3.18

- Updated min version from 3.14 to 3.18
- Deleted min version from all children CMakeLists.txt and use cmake_minimum_required from parent