### PR TITLE
[buildmgr] Align AC6 test golden references with GCC

### DIFF
--- a/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
@@ -35,7 +35,7 @@ BuildSystemGenerator::~BuildSystemGenerator(void) {
 
 bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *model, const string& outdir, const string& intdir) {
   error_code ec;
-  m_projectDir = StrConv(RteFsUtils::AbsolutePath(inputFile).remove_filename().generic_string() + SS);
+  m_projectDir = StrConv(RteFsUtils::AbsolutePath(inputFile).remove_filename().generic_string());
   m_workingDir = fs::current_path(ec).generic_string() + SS;
 
   // Find toolchain config

--- a/tools/buildmgr/test/testinput/Examples/AC6/Flags/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Flags/CMakeLists.txt.ref
@@ -19,19 +19,19 @@ set(LD_FLAGS_GLOBAL "--callgraph --entry=Reset_Handler --info sizes --info summa
 set(LD_SCRIPT "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Flags/RTE/Device/ARMCM3/ARMCM3_ac6.sct")
 
 set(DEFINES
-  ARMCM3
   DEF_TARGET_CC
   DEF_RTE_Components=\"RTE_Components.h\"
+  ARMCM3
   _RTE_
 )
 
 set(INC_PATHS
+  "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Flags/RTE/CMSIS"
+  "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Flags/RTE/_Target"
   "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/CMSIS/Core/Include"
   "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/CMSIS/RTOS2/Include"
   "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/CMSIS/RTOS2/RTX/Include"
   "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/Device/ARM/ARMCM3/Include"
-  "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Flags/RTE/CMSIS"
-  "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Flags/RTE/_Target"
 )
 
 set(CC_SRC_FILES

--- a/tools/buildmgr/test/testinput/Examples/AC6/RelativePath/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/RelativePath/CMakeLists.txt.ref
@@ -12,18 +12,18 @@ set(INT_DIR "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Relative
 set(LD_SCRIPT "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/RelativePath/RTE/Device/ARMCM0/ARMCM0_ac6.sct")
 
 set(DEFINES
-  ARMCM0
   DEF1
   DEF2=2
+  ARMCM0
   _RTE_
 )
 
 set(INC_PATHS
-  "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0/CMSIS/Core/Include"
-  "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0/Device/ARM/ARMCM0/Include"
   "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/RelativePath/RTE/_Project"
   "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/RelativePath/inc"
   "C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/RelativePath/inc2"
+  "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0/CMSIS/Core/Include"
+  "C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.7.0/Device/ARM/ARMCM0/Include"
 )
 
 set(CC_SRC_FILES


### PR DESCRIPTION
Remove superfluous double trailing directory separator