### PR TITLE
[packgen] Update CMake target's sources handling

### DIFF
--- a/tools/packgen/docs/README.md
+++ b/tools/packgen/docs/README.md
@@ -87,7 +87,7 @@ source folder when the `CMakeLists.txt` and `manifest.yml` are not located at th
 root folder. Paths inside the `manifest.yml` file shall be relative to the root folder.
 
 - The contents of include paths to be recursively copied into the pack can be
-filtered by setting whitelisted file extensions in the `extensions` tag, the
+filtered by setting allowed file extensions in the `extensions` tag, the
 default are `.h` and `.hpp`. These extensions are also used for handling file
 categories of source files coming from CMake targets.
 

--- a/tools/packgen/src/PackGen.cpp
+++ b/tools/packgen/src/PackGen.cpp
@@ -568,6 +568,10 @@ bool PackGen::ParseReply(void) {
               cerr << "packgen warning: file '" << src << "' listed by target '" << name << "' was not found" << endl;
               continue;
             }
+            if (!fs::is_regular_file(canonical)) {
+              cerr << "packgen warning: source '" << src << "' listed by target '" << name << "' is not a regular file" << endl;
+              continue;
+            }
             src = canonical.generic_string();
             if (src.find(m_repoRoot) == 0) {
               src.erase(0, m_repoRoot.length() + 1);

--- a/tools/packgen/test/data/TestProject/lib1/CMakeLists.txt
+++ b/tools/packgen/test/data/TestProject/lib1/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3)
 
-SET(SOURCE_FILES src/lib1.cpp inc/lib1.h)
+SET(SOURCE_FILES src/lib1.cpp inc/lib1.h inc)
 
 add_library(lib1 STATIC ${SOURCE_FILES})
 


### PR DESCRIPTION
Avoid adding a directory as a source file into a pack component.
Extend test case.
Update documentation using inclusive language.