### PR TITLE
Ensure that projectDir path ends with '/'.

### DIFF
--- a/tools/buildmgr/cbuild/include/CbuildUtils.h
+++ b/tools/buildmgr/cbuild/include/CbuildUtils.h
@@ -42,6 +42,13 @@ public:
   static const RteFile::Category GetFileType(const RteFile::Category cat, const std::string& file);
 
   /**
+   * @brief Adds a slash '/' to the end of non-empty strings if missing
+   * @param path string possibly ending with '/'
+   * @return string with ending '/' or empty string
+  */
+  static const std::string ensureEndWithSlash(const std::string& path);
+
+  /**
    * @brief remove slashes from string
    * @param path string containing slashes
    * @return string without slashes

--- a/tools/buildmgr/cbuild/src/CbuildUtils.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildUtils.cpp
@@ -62,6 +62,13 @@ const RteFile::Category CbuildUtils::GetFileType(const RteFile::Category cat, co
   }
 }
 
+const std::string CbuildUtils::ensureEndWithSlash(const std::string& path) {
+  if (path.length() > 0 && path.rfind(SS) < path.length() - 1) {
+    return path + SS;
+  }
+  return path;
+}
+
 const string CbuildUtils::RemoveSlash(const string& path) {
   size_t s = 0;
   string result = path;

--- a/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
@@ -35,8 +35,8 @@ BuildSystemGenerator::~BuildSystemGenerator(void) {
 
 bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *model, const string& outdir, const string& intdir) {
   error_code ec;
-  m_projectDir = StrConv(RteFsUtils::AbsolutePath(inputFile).remove_filename().generic_string());
-  m_workingDir = fs::current_path(ec).generic_string() + SS;
+  m_projectDir = CbuildUtils::ensureEndWithSlash(StrConv(RteFsUtils::AbsolutePath(inputFile).remove_filename().generic_string()));
+  m_workingDir = CbuildUtils::ensureEndWithSlash(fs::current_path(ec).generic_string());
 
   // Find toolchain config
   m_toolchainConfig = StrNorm(model->GetToolchainConfig());
@@ -59,7 +59,7 @@ bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *m
   if (!fs::exists(m_outdir, ec)) {
     fs::create_directories(m_outdir, ec);
   }
-  m_outdir = fs::canonical(m_outdir, ec).generic_string() + SS;
+  m_outdir = CbuildUtils::ensureEndWithSlash(fs::canonical(m_outdir, ec).generic_string());
 
   if (!intdir.empty()) {
     m_intdir = StrConv(intdir);
@@ -77,7 +77,7 @@ bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *m
   if (!fs::exists(m_intdir, ec)) {
     fs::create_directories(m_intdir, ec);
   }
-  m_intdir = fs::canonical(m_intdir, ec).generic_string() + SS;
+  m_intdir = CbuildUtils::ensureEndWithSlash(fs::canonical(m_intdir, ec).generic_string());
 
   // Target attributes
   m_projectName = fs::path(inputFile).stem().generic_string();


### PR DESCRIPTION
Fixes issue #54 where folder paths where concatenated badly when
--intdir/--outdir are not specified on the command-line

Also applied helper function to intdir/outdir/workingdir

Contributed by STMicroelectronics

Signed-off-by: Samuel HULTGREN <samuel.hultgren@st.com>