### PR TITLE
list all cmake targets (#50)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(GetCMakeTargets)
 
 cmake_policy(SET CMP0091 NEW)
 
@@ -79,6 +80,9 @@ if(NOT LIBS_ONLY)
   add_subdirectory(tools/packchk)
   add_subdirectory(tools/packgen)
 endif()
+
+# Prepare a list of CMake targets
+get_targets()
 
 # Google Test Framework
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)

--- a/README.md
+++ b/README.md
@@ -184,37 +184,14 @@ Follow the respective commands:
     cmake --build . --config Debug
     ```
 
-- Users can build specific target of their choice and build:
-  - Select the CMake generated target from the list below:
-    - cbuild
-    - cbuildgen
-    - cbuildgenlib
-    - CbuildUnitTests
-    - CbuildIntegTests
-    - CrossPlatform
-    - CrossPlatformUnitTests
-    - ErrLog
-    - ErrLogUnitTests
-    - packchk
-    - packchklib
-    - PackChkUnitTests
-    - PackChkIntegTests
-    - packgen
-    - packgenlib
-    - PackGenUnitTests
-    - RteFsUtils
-    - RteFsUtilsUnitTests
-    - RteModel
-    - RteModelUnitTests
-    - RteUtils
-    - RteUtilsUnitTests
-    - XmlReader
-    - XmlReaderUnitTests
-    - XmlTree
-    - XmlTreeUnitTests
-    - XmlTreeSlim
-    - XmlTreeSlimUnitTests
+- Users can build specific target of their choice:
+  - Get the list of valid CMake generated targets
 
+    ```bash
+    cat ./targets
+    ```
+
+  - Select the target
   - Build the selected target and run command
     > **cmake --build . --config <Debug/Release> --target \<target_name\>**
 

--- a/cmake/GetCMakeTargets.cmake
+++ b/cmake/GetCMakeTargets.cmake
@@ -1,0 +1,30 @@
+function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+endfunction()
+
+macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+        get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+endmacro()
+
+function(get_targets)
+  # prepare list of targets
+  get_all_targets(all_targets)
+
+  # sort target name alphabetically
+  list(SORT all_targets)
+  list(TRANSFORM all_targets PREPEND "  -- ")
+  list(TRANSFORM all_targets APPEND "\n")
+  list(INSERT all_targets 0 "CMake Targets ${CMAKE_BINARY_DIR}\n")
+  string (REPLACE ";" "" all_targets "${all_targets}")
+  
+  # write to file
+  file(WRITE ${CMAKE_BINARY_DIR}/targets "${all_targets}")
+endfunction()

--- a/cmake/GetCMakeTargets.cmake
+++ b/cmake/GetCMakeTargets.cmake
@@ -28,3 +28,4 @@ function(get_targets)
   # write to file
   file(WRITE ${CMAKE_BINARY_DIR}/targets "${all_targets}")
 endfunction()
+


### PR DESCRIPTION
Currently, we are listing all the CMake targets in README.md file. Any new addition of targets or changing names of targets would need a change in the README.md. With these changes, we don't need to maintain any target list. The list will be created on the fly and users can open the list with a simple command. The generated list should look like:
`$ cat./targets`
![image](https://user-images.githubusercontent.com/73165318/142177396-e7089773-7569-4814-a915-dea8b55b58fe.png)
