### PR TITLE
Fix CPackGetTests issues

### DIFF
--- a/tools/buildmgr/cbuildgen/installer/create_installer.sh
+++ b/tools/buildmgr/cbuildgen/installer/create_installer.sh
@@ -73,7 +73,7 @@ cp ../../docs/LICENSE.txt ${distdir}
 # Get cpackget
 cpackget_version="0.2.0"
 cpackget_base=https://github.com/Open-CMSIS-Pack/cpackget/releases/download/v${cpackget_version}/cpackget_${cpackget_version}
-curl --retry 3 -L ${cpackget_base}_windows_amd64.zip   -o temp.zip && unzip -p temp.zip '*cpackget.exe' > ${distdir}/bin/cpackget.exe && rm temp.zip
+curl --retry 3 -L ${cpackget_base}_windows_amd64.zip   -o temp.zip && unzip -p temp.zip '*/cpackget.exe' > ${distdir}/bin/cpackget.exe && rm temp.zip
 curl --retry 3 -L ${cpackget_base}_linux_amd64.tar.gz  -o - | tar xzfO - --wildcards    '*cpackget'     > ${distdir}/bin/cpackget.lin
 curl --retry 3 -L ${cpackget_base}_darwin_amd64.tar.gz -o - | tar xzfO - --wildcards    '*cpackget'     > ${distdir}/bin/cpackget.mac
 

--- a/tools/buildmgr/test/integrationtests/src/CPackGetTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CPackGetTests.cpp
@@ -109,25 +109,29 @@ TEST_F(CPackGetTests, PackAddFileNotAvailableTest) {
   RunPackAdd(param);
 }
 
-// Verify pack installer with missing input packlist file
+// Verify pack installer with valid arguments
 TEST_F(CPackGetTests, PackAddValidFileArgTest) {
   // Create a directory for this test only
   string localTestingDir = testout_folder + "/packrepo-valid-arg";
   TestParam paramInit = { "", "", " -R " + localTestingDir, "", true };
   RunInit(paramInit);
 
-  TestParam param = { "", "pack.cpinstall", " -R " + localTestingDir, "", true };
+  TestParam param = { "", "Testpack.cpinstall", " -R " + localTestingDir, "", true };
   RunPackAdd(param);
   RemoveDir(localTestingDir);
 }
 
-// Test valid installtion of packs
+// Test valid installation of packs
 TEST_F(CPackGetTests, PackAddPackInstallationTest) {
   TestParam param = { "", "Testpack.cpinstall", "", "", true };
 
   RunScript("prepackinstall.sh", testout_folder);
   RunPackAdd(param);
   RunScript("postpackinstall.sh", testout_folder);
+
+  // Try to re-install already installed pack
+  param = { "", "Testpack.cpinstall", "", "", false };
+  RunPackAdd(param);
 }
 
 // Install pack with missing build environment
@@ -147,13 +151,6 @@ TEST_F(CPackGetTests, PackAddNoEnvInvalidArgTest) {
 // Verify pack installer with invalid packlist file
 TEST_F(CPackGetTests, PackAddInvalidPackFileTest) {
   TestParam param = { "", "Invalid.cpinstall", "", "", false };
-
-  RunPackAdd(param);
-}
-
-// Install already installed pack
-TEST_F(CPackGetTests, PackAddAlreadyInstalledPackTest) {
-  TestParam param = { "", "pack.cpinstall", "", "", false };
 
   RunPackAdd(param);
 }


### PR DESCRIPTION
- Fix windows unzip command line for preventing local environment failings
- Move `PackAddAlreadyInstalledPackTest` into `PackAddPackInstallationTest` because it was not self-contained and it was failing depending on the test order.
- Update `PackAddValidFileArgTest` to download smaller packs
- Fix typos