### PR TITLE
[buildmgr] Fix EscapeQuotes function to handle multiple escapes (#67)

### DIFF
--- a/tools/buildmgr/cbuild/src/CbuildUtils.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildUtils.cpp
@@ -98,6 +98,13 @@ const string CbuildUtils::ReplaceSpacesByQuestionMarks(const string& path) {
 const string CbuildUtils::EscapeQuotes(const string& path) {
   size_t s = 0;
   string result = path;
+  // escape backslashes
+  while ((s = result.find("\\", s)) != string::npos) {
+    result.replace(s, 1, "\\\\");
+    s += 2;
+  }
+  s = 0;
+  // escape quotes
   while ((s = result.find("\"", s)) != string::npos) {
     result.replace(s, 1, "\\\"");
     s += 2;

--- a/tools/buildmgr/test/unittests/src/UtilsTests.cpp
+++ b/tools/buildmgr/test/unittests/src/UtilsTests.cpp
@@ -192,3 +192,10 @@ TEST_F(CbuildUtilsTests, ExecCommand) {
   fs::current_path(CBuildUnitTestEnv::workingDir);
   RemoveDir(testdir);
 }
+
+TEST_F(CbuildUtilsTests, EscapeQuotes) {
+  string result = CbuildUtils::EscapeQuotes("-DFILE=\"config.h\"");
+  EXPECT_EQ(result, "-DFILE=\\\"config.h\\\"");
+  result = CbuildUtils::EscapeQuotes("-DFILE=\\\"config.h\\\"");
+  EXPECT_EQ(result, "-DFILE=\\\\\\\"config.h\\\\\\\"");
+}


### PR DESCRIPTION
This function is used when inserting toolchain flags into cmake variables `LD_FLAGS_GLOBAL` as well as `AS_FLAGS_*`, `CC_FLAGS_*` and `CXX_FLAGS_*` at all levels (global, groups, files).