### PR TITLE
Publish tests fix

### DIFF
--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/packchk.yml'
+      - '.github/workflows/unit_test_results.yml'
       - 'CMakeLists.txt'
       - 'tools/packchk/**'
   release:

--- a/.github/workflows/unit_test_results.yml
+++ b/.github/workflows/unit_test_results.yml
@@ -37,4 +37,4 @@ jobs:
           event_file: artifacts/Event File/event.json
           report_individual_runs: true
           event_name: ${{ github.event.workflow_run.event }}
-          files: testreports/**/*.xml
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/unit_test_results.yml
+++ b/.github/workflows/unit_test_results.yml
@@ -3,6 +3,8 @@ name: Publish Test Results
 on:
   workflow_run:
     workflows: ["packchk"]
+    # avoid running once merged on main branch, this should be run only on PRs     
+    branches-ignore: ["main"]
     types:
       - completed
 


### PR DESCRIPTION
This patch aims to fix Publish Tests on PRs.

This only affects packchk. There is no support for other tools yet.

Fixed:
- Avoid running it after the PR is merged on `main`.
- Using the correct path to look for the test result files.