### PR TITLE
packchk : multiple include pdsc seems not possible

### DIFF
--- a/tools/packchk/include/PackChk.h
+++ b/tools/packchk/include/PackChk.h
@@ -24,6 +24,8 @@ public:
 
   int Check(int argc, const char* argv[], const char* envp[]);
 
+  const RteGlobalModel& GetModel() { return m_rteModel; }
+
 protected:
   bool InitMessageTable();
   bool CheckPackage();

--- a/tools/packchk/src/CreateModel.cpp
+++ b/tools/packchk/src/CreateModel.cpp
@@ -56,6 +56,8 @@ bool CreateModel::CheckForOtherPdscFiles(const string& pdscFullPath)
     return false;
   }
 
+  LogMsg("M010");
+
   return true;
 }
 
@@ -96,6 +98,7 @@ bool CreateModel::AddPdsc(const string& pdscFile, bool bSkipCheckForOtherPdsc /*
   }
 
   LogMsg("M051", PATH(pdscFile));
+
   if(!RteFsUtils::Exists(pdscFile)) {
     LogMsg("M204", PATH(pdscFile));
     return false;
@@ -113,8 +116,11 @@ bool CreateModel::AddPdsc(const string& pdscFile, bool bSkipCheckForOtherPdsc /*
   }
 
   if(!m_reader.AddFile(pdscFile)) {
+    LogMsg("M201", PATH(pdscFile));
     return false;
   }
+
+  LogMsg("M010");
 
   return true;
 }
@@ -127,18 +133,7 @@ bool CreateModel::AddPdsc(const string& pdscFile, bool bSkipCheckForOtherPdsc /*
 bool CreateModel::AddRefPdsc(const std::set<std::string>& pdscRefFiles)
 {
   for(auto& refPdsc : pdscRefFiles) {
-    LogMsg("M051", PATH(refPdsc));
-    if(!RteFsUtils::Exists(refPdsc)) {
-      LogMsg("M204", PATH(refPdsc));
-      return false;
-    }
-
-    if(RteFsUtils::IsDirectory(refPdsc)) {
-      LogMsg("M202", PATH(refPdsc));
-      return false;
-    }
-
-    if(AddPdsc(refPdsc, true)) {
+    if(!AddPdsc(refPdsc, true)) {
       return false;
     }
   }

--- a/tools/packchk/src/PackChk.cpp
+++ b/tools/packchk/src/PackChk.cpp
@@ -93,7 +93,6 @@ bool PackChk::CheckPackage()
   const set<string>& pdscRefFiles = m_packOptions.GetPdscRefFullpath();
   createModel.AddRefPdsc(pdscRefFiles);
 
-  LogMsg("M010");
   LogMsg("M015");
   LogMsg("M023", VAL("CHECK", "1: Read PDSC files"));
 

--- a/tools/packchk/src/PackChk_Msgs.cpp
+++ b/tools/packchk/src/PackChk_Msgs.cpp
@@ -81,7 +81,7 @@ const MsgTable PackChk::msgTable = {
 
 // 200... Invocation Errors
   { "M200", { MsgLevel::LEVEL_ERROR,    CRLF_BE, "" } },
-  { "M201", { MsgLevel::LEVEL_ERROR,    CRLF_BE, "" } },
+  { "M201", { MsgLevel::LEVEL_ERROR,    CRLF_BE, "Error adding PDSC input file '%PATH%'!" } },
   { "M202", { MsgLevel::LEVEL_ERROR,    CRLF_BE, "No PDSC input file specified" } },
   { "M203", { MsgLevel::LEVEL_ERROR,    CRLF_B, "Error reading PDSC file(s) '%PATH%'!" } },
   { "M204", { MsgLevel::LEVEL_ERROR,    CRLF_B, "File not found: '%PATH%'!" } },

--- a/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
+++ b/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
@@ -195,3 +195,80 @@ TEST_F(PackChkIntegTests, SuppressValidationMsgs) {
     }
   }
 }
+
+TEST_F(PackChkIntegTests, AddRefPacks) {
+  const char* argv[10];
+
+  string outDir = PackChkIntegTestEnv::testoutput_dir + "/Packs";
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir));
+
+  string refNameTest = "TestPack";
+  string refName1 = "RefPack1";
+  string refName2 = "RefPack2";
+  string refName3 = "RefPack3";
+  string refName4 = "RefPack4";
+
+  string refPackTest = "/" + refNameTest;
+  string refPack1 = "/" + refName1;
+  string refPack2 = "/" + refName2;
+  string refPack3 = "/" + refName3;
+  string refPack4 = "/" + refName4;
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir + refPackTest));
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir + refPack1));
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir + refPack2));
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir + refPack3));
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(outDir + refPack4));
+
+  refPackTest += "/" + refNameTest + ".pdsc";
+  refPack1 += "/" + refName1 + ".pdsc";
+  refPack2 += "/" + refName2 + ".pdsc";
+  refPack3 += "/" + refName3 + ".pdsc";
+  refPack4 += "/" + refName4 + ".pdsc";
+  const string contentBegin = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
+                              "<package schemaVersion=\"1.3\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema-instance\" xs:noNamespaceSchemaLocation=\"PACK.xsd\">\n"\
+                              "  <name>";    
+  const string contentEnd =   "  </name>\n"\
+                              "</package>\n";
+
+  refPackTest = outDir + refPackTest;
+  refPack1 = outDir + refPack1;
+  refPack2 = outDir + refPack2;
+  refPack3 = outDir + refPack3;
+  refPack4 = outDir + refPack4;
+
+  ASSERT_TRUE(RteFsUtils::CreateFile(refPackTest, contentBegin + refNameTest + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateFile(refPack1, contentBegin + refName1 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateFile(refPack2, contentBegin + refName2 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateFile(refPack3, contentBegin + refName3 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateFile(refPack4, contentBegin + refName4 + contentEnd));
+
+  ASSERT_TRUE(RteFsUtils::Exists(refPackTest));
+  ASSERT_TRUE(RteFsUtils::Exists(refPack1));
+  ASSERT_TRUE(RteFsUtils::Exists(refPack2));
+  ASSERT_TRUE(RteFsUtils::Exists(refPack3));
+  ASSERT_TRUE(RteFsUtils::Exists(refPack4));
+
+  argv[0] = (char*)"";
+  argv[1] = (char*)refPackTest.c_str();
+  argv[2] = (char*)"-i";
+  argv[3] = (char*)refPack1.c_str();
+  argv[4] = (char*)"-i";
+  argv[5] = (char*)refPack2.c_str();
+  argv[6] = (char*)"-i";
+  argv[7] = (char*)refPack3.c_str();
+  argv[8] = (char*)"-i";
+  argv[9] = (char*)refPack4.c_str();
+
+  PackChk packChk;
+  packChk.Check(10, argv, nullptr);
+  
+  const RteGlobalModel& model = packChk.GetModel();
+  const RtePackageMap& packs = model.GetPackages();
+
+  for(auto& [name, pack] : packs) {
+    if(name != refNameTest && name != refName1 && name != refName2 && name != refName3 && name != refName4) {
+      FAIL() << "RefPack was not added";
+    }
+  }
+
+}


### PR DESCRIPTION
Issue caused by a wrong early exit.

Tested:
M051: Adding PDSC File: 'D:/Packs/Keil/STM32F1xx_DFP/2.3.0/Keil.STM32F1xx_DFP.pdsc'
M064: Checking for other PDSC files: 'D:/Packs/Keil/STM32F1xx_DFP/2.3.0/Keil.STM32F1xx_DFP.pdsc' OK OK
M051: Adding PDSC File: 'D:/Packs/ARM/CMSIS/5.8.0/ARM.CMSIS.pdsc' OK
M051: Adding PDSC File: 'D:/Packs/Keil/STM32F2xx_DFP/2.9.0/Keil.STM32F2xx_DFP.pdsc' OK
M051: Adding PDSC File: 'D:/Packs/Keil/STM32F4xx_DFP/2.15.0/Keil.STM32F4xx_DFP.pdsc' OK

Fixes issue #112.