### PR TITLE
Correct API introduced by #65

### DIFF
--- a/libs/rtemodel/include/RteInstance.h
+++ b/libs/rtemodel/include/RteInstance.h
@@ -1387,18 +1387,18 @@ public:
 
   /**
    * @brief check if a new version of a config file is available (for specified target)
+     RTE folder path used for placing files is taken from target's parent project
    * @param targetName target name
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return true if newer version of config file is available
   */
-  int HasNewVersion(const std::string& targetName, const std::string& rteFolder) const;
+  int HasNewVersion(const std::string& targetName) const;
 
   /**
    * @brief check if a new version of a config file is available (for any target)
-   * @param rteFolder the "RTE" folder path used for placing files
+     RTE folder path used for placing files is taken from target's parent project
    * @return true if newer version of config file is available
   */
-  int HasNewVersion(const std::string& rteFolder) const;
+  int HasNewVersion() const;
 
   /**
    * @brief get file category
@@ -1474,11 +1474,12 @@ public:
 
   /**
    * @brief get the original file resolved to this instance for specified target
+   * rteFolder is taken from target's parent project
    * @param targetName target name to resolve file
-   * @param rteFolder the "RTE" folder path used for placing files
+   * @param
    * @return pointer to RteFile if resolved, nullptr otherwise
   */
-  RteFile* GetFile(const std::string& targetName, const std::string& rteFolder) const;
+  RteFile* GetFile(const std::string& targetName) const;
 
   /**
    * @brief copy a config file from pack location to the designated project directory

--- a/libs/rtemodel/include/RteProject.h
+++ b/libs/rtemodel/include/RteProject.h
@@ -150,8 +150,16 @@ public:
   */
   void SetName(const std::string& name) { m_ID = name; }
 
-
+  /**
+   * @brief set custom RTE folder name to store config files,
+   * @param rteFolder RTE folder name, default "RTE"
+  */
   void SetRteFolder(std::optional<std::string> rteFolder) { m_rteFolder = rteFolder; }
+
+  /**
+   * @brief get project's RTE folder where config and generated files are stored
+   * @return RTE folder name, default "RTE"
+  */
   const std::string& GetRteFolder() const;
 
   /**
@@ -690,20 +698,18 @@ public:
    * @brief get file name and path of "RTE_Components.h" determined by the specified target and prefix
    * @param targetName given target name
    * @param prefix given prefix to be added at beginning of the file path
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return string containing file name and path
   */
-  static std::string GetRteComponentsH(const std::string& targetName, const std::string& prefix, const std::string& rteFolder);
+  std::string GetRteComponentsH(const std::string& targetName, const std::string& prefix) const;
 
   /**
    * @brief get file name and path locating in folder "RTE" determined by the specified name, target and prefix
    * @param name given file name
    * @param targetName given target name
    * @param prefix given prefix to be added at beginning of the file path
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return string containing file name and path
   */
-  static std::string GetRteHeader(const std::string& name, const std::string & targetName, const std::string& prefix, const std::string& rteFolder);
+  std::string GetRteHeader(const std::string& name, const std::string & targetName, const std::string& prefix) const;
 
 protected:
   virtual RteTarget* CreateTarget(RteModel* filteredModel, const std::string& name, const std::map<std::string, std::string>& attributes);
@@ -768,6 +774,10 @@ protected:
   std::map<int, std::string> m_targetIDs;
   std::string m_sActiveTarget;
   std::optional<std::string> m_rteFolder;
+
+public:
+  static const std::string DEFAULT_RTE_FOLDER;
+
 };
 
 #endif // RteProject_H

--- a/libs/rtemodel/include/RteTarget.h
+++ b/libs/rtemodel/include/RteTarget.h
@@ -46,17 +46,15 @@ struct RteFileInfo
   /**
    * @brief compare file version of the given target and the instance
    * @param targetName target name
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return 0 if both file versions are same, > 0 if file version of the given target is newer, otherwise < 0
   */
-  int HasNewVersion(const std::string& targetName, const std::string& rteFolder) const;
+  int HasNewVersion(const std::string& targetName) const;
 
   /**
    * @brief compare file version of this instance with the ones of other targets
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return 0 if equal to all others target, > 0 if file version of any other target is newer, otherwise < 0
   */
-  int HasNewVersion(const std::string& rteFolder) const;
+  int HasNewVersion() const;
 
   RteFile::Category m_cat;    //file category
   RteComponentInstance* m_ci; // pointer to an object of type RteComponentInstance
@@ -218,12 +216,27 @@ public:
   RteFile* FindFile(const std::string& fileName, RteComponent* c) const;
 
   /**
+   * @brief get parent project's RTE folder where config and generated files are stored
+   * @return RTE folder name, default "RTE"
+  */
+  const std::string& GetRteFolder() const;
+
+  /**
    * @brief determine file given by instances of type RteFileInstance and RteComponent
+   * RTE folder is taken from parent project
    * @param fi given pointer of type RteFileInstance
    * @param c given pointer of type RteComponent
-   * @param rteFolder the "RTE" folder path used for placing files
    * @return pointer of type RteFile
   */
+  RteFile* GetFile(const RteFileInstance* fi, RteComponent* c) const;
+
+  /**
+ * @brief determine file given by instances of type RteFileInstance and RteComponent
+ * @param fi given pointer of type RteFileInstance
+ * @param c given pointer of type RteComponent
+ * @param rteFolder the "RTE" folder path used for placing files
+ * @return pointer of type RteFile
+*/
   RteFile* GetFile(const RteFileInstance* fi, RteComponent* c, const std::string& rteFolder) const;
 
   /**
@@ -543,10 +556,9 @@ public:
 
   /**
    * @brief collect settings of given component instance
-   * @param rteFolder the "RTE" folder path used for placing files
    * @param ci pointer to RteComponentInstance object
   */
-  void CollectComponentSettings(RteComponentInstance* ci, const std::string& rteFolder);
+  void CollectComponentSettings(RteComponentInstance* ci);
 
   /**
    * @brief collect documentation files from component groups

--- a/libs/rtemodel/src/RteInstance.cpp
+++ b/libs/rtemodel/src/RteInstance.cpp
@@ -719,20 +719,20 @@ RteFile::Category RteFileInstance::GetCategory() const
   return RteFile::CategoryFromString(GetAttribute("category"));
 }
 
-int RteFileInstance::HasNewVersion(const string& targetName, const string& rteFolder) const
+int RteFileInstance::HasNewVersion(const string& targetName) const
 {
-  RteFile* f = GetFile(targetName, rteFolder);
+  RteFile* f = GetFile(targetName);
   if (!f)
     return 0;
   int res = VersionCmp::Compare(f->GetVersionString(), GetVersionString());
   return res;
 }
 
-int RteFileInstance::HasNewVersion(const string& rteFolder) const
+int RteFileInstance::HasNewVersion() const
 {
   int newVersion = 0;
   for (auto it = m_targetInfos.begin(); it != m_targetInfos.end(); it++) {
-    int newVer = HasNewVersion(it->first, rteFolder);
+    int newVer = HasNewVersion(it->first);
     if (newVer > newVersion) {
       newVersion = newVer;
       if (newVersion > 2)
@@ -838,12 +838,12 @@ string RteFileInstance::GetAbsolutePath() const
   return s;
 }
 
-RteFile* RteFileInstance::GetFile(const string& targetName, const string& rteFolder) const
+RteFile* RteFileInstance::GetFile(const string& targetName) const
 {
   RteTarget* t = GetTarget(targetName);
   if (t) {
     RteComponent* c = GetComponent(targetName);
-    return t->GetFile(this, c, rteFolder);
+    return t->GetFile(this, c);
   }
   return NULL;
 }

--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -25,7 +25,7 @@
 
 using namespace std;
 
-const std::string DEFAULT_RTE_FOLDER = "RTE";
+const std::string RteProject::DEFAULT_RTE_FOLDER = "RTE";
 
 ////////////////////////////
 RteProject::RteProject() :
@@ -1090,15 +1090,15 @@ void RteProject::CollectSettings()
 }
 
 
-string RteProject::GetRteComponentsH(const string & targetName, const string & prefix, const string& rteFolder)
+string RteProject::GetRteComponentsH(const string & targetName, const string & prefix) const
 {
-  return GetRteHeader(string("/RTE_Components.h"), targetName, prefix, rteFolder);
+  return GetRteHeader(string("/RTE_Components.h"), targetName, prefix);
 }
 
-string RteProject::GetRteHeader(const string& name, const string & targetName, const string & prefix, const string& rteFolder)
+string RteProject::GetRteHeader(const string& name, const string & targetName, const string & prefix) const
 {
   string rteHeader = prefix;
-  rteHeader += rteFolder + "/_";
+  rteHeader += GetRteFolder() + "/_";
   rteHeader += WildCards::ToX(targetName);
   rteHeader += "/";
   rteHeader += name;
@@ -1116,7 +1116,7 @@ void RteProject::CollectSettings(const string& targetName)
   // collect includes, libs and RTE_Components_h defines for active target
   for (auto itc = m_components.begin(); itc != m_components.end(); itc++) {
     RteComponentInstance* ci = itc->second;
-    t->CollectComponentSettings(ci, GetRteFolder());
+    t->CollectComponentSettings(ci);
   }
   t->CollectClassDocs();
 
@@ -1164,7 +1164,7 @@ void RteProject::CollectSettings(const string& targetName)
   // check if RTE components are used before setting RTE_Components.h include path and adding to target as well as setting -D_RTE_ at the command line.
   // add .\RTE\_TargetName\RTE_Components.h filePath
   if (GetComponentCount() > 0) {
-    string rteComponentsH = GetRteComponentsH(targetName, "./", GetRteFolder());
+    string rteComponentsH = GetRteComponentsH(targetName, "./");
     t->AddIncludePath(RteUtils::ExtractFilePath(rteComponentsH, false));
     t->AddFile("RTE_Components.h", RteFile::HEADER, "Component selection"); // add ".\RTE\_TargetName\RTE_Components.h" folder to all target includes
     t->InsertDefine("_RTE_");

--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -45,17 +45,17 @@ RteFileInfo::RteFileInfo(RteFile::Category cat, RteComponentInstance* ci, RteFil
 {
 };
 
-int RteFileInfo::HasNewVersion(const string& targetName, const string& rteFolder) const
+int RteFileInfo::HasNewVersion(const string& targetName) const
 {
   if (m_fi)
-    return m_fi->HasNewVersion(targetName, rteFolder);
+    return m_fi->HasNewVersion(targetName);
   return 0;
 }
 
-int RteFileInfo::HasNewVersion(const string& rteFolder) const
+int RteFileInfo::HasNewVersion() const
 {
   if (m_fi)
-    return m_fi->HasNewVersion(rteFolder);
+    return m_fi->HasNewVersion();
   return 0;
 }
 
@@ -657,7 +657,7 @@ void RteTarget::AddAlgorithm(RteItem* algo, RteItem* holder)
   m_algos.insert(pathName);
 }
 
-void RteTarget::CollectComponentSettings(RteComponentInstance* ci, const std::string& rteFolder)
+void RteTarget::CollectComponentSettings(RteComponentInstance* ci)
 {
   int count = ci->GetInstanceCount(GetName());
   if (count <= 0)
@@ -683,6 +683,7 @@ void RteTarget::CollectComponentSettings(RteComponentInstance* ci, const std::st
   if (files.empty())
     return;
   string deviceName = GetFullDeviceName();
+  const string& rteFolder = GetRteFolder();
   for (auto itf = files.begin(); itf != files.end(); itf++) {
     RteFile* f = *itf;
     if (!f)
@@ -1262,11 +1263,26 @@ RteFile* RteTarget::FindFile(const string& fileName, RteComponent* c) const
   return NULL;
 }
 
+const std::string& RteTarget::GetRteFolder() const {
+  RteProject* rteProject = GetProject();
+  if (rteProject) {
+    return rteProject->GetRteFolder();
+  }
+  return RteProject::DEFAULT_RTE_FOLDER;
+}
+
+
+RteFile* RteTarget::GetFile(const RteFileInstance* fi, RteComponent* c) const
+{
+  return GetFile(fi, c, GetRteFolder());
+}
+
 
 RteFile* RteTarget::GetFile(const RteFileInstance* fi, RteComponent* c, const std::string& rteFolder) const
 {
-  if (!fi)
-    return NULL;
+  if (!fi) {
+    return nullptr;
+  }
   const set<RteFile*>& filteredFiles = GetFilteredFiles(c);
   const string& deviceName = GetFullDeviceName();
   int index = fi->GetInstanceIndex();
@@ -1277,7 +1293,7 @@ RteFile* RteTarget::GetFile(const RteFileInstance* fi, RteComponent* c, const st
       return f;
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 void RteTarget::EvaluateComponentDependencies()
@@ -1574,7 +1590,7 @@ const bool RteTarget::GenerateRteHeaderFile(const string& headerName, const stri
   if (!project)
     return false;
 
-  string rteCompH = RteProject::GetRteHeader(headerName, GetName(), project->GetProjectPath(), project->GetRteFolder());
+  string rteCompH = project->GetRteHeader(headerName, GetName(), project->GetProjectPath());
 
   if (!RteFsUtils::MakeSureFilePath(rteCompH))
     return false;

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -243,7 +243,7 @@ const bool CbuildModel::GenerateFixedCprj(const string& update) {
 
             for (auto configFile : configFiles) {
               if (configFile.second->GetComponent(m_targetName)->Compare(component)) {
-                map<string, string> fileAttributes = configFile.second->GetFile(m_targetName, m_cprjProject->GetRteFolder())->GetAttributes();
+                map<string, string> fileAttributes = configFile.second->GetFile(m_targetName)->GetAttributes();
                 fileAttributes["name"] = RteUtils::BackSlashesToSlashes(fileAttributes["name"]);
 
                 // Iterate over component files
@@ -311,7 +311,7 @@ const bool CbuildModel::GenerateAuditData() {
               string instanceName = configFile.second->GetInstanceName();
               RteFsUtils::NormalizePath(instanceName, m_prjFolder);
               auditData << EOL << "    - ConfigFile: " << instanceName << ":" << configFile.second->GetVersionString();
-              if (configFile.second->HasNewVersion(m_targetName) > 0) auditData << " [" << configFile.second->GetFile(m_targetName, m_cprjProject->GetRteFolder())->GetVersionString() << "]";
+              if (configFile.second->HasNewVersion(m_targetName) > 0) auditData << " [" << configFile.second->GetFile(m_targetName)->GetVersionString() << "]";
             }
           }
         }
@@ -498,7 +498,7 @@ const bool CbuildModel::EvalConfigFiles() {
     for (auto fi : compConfigFiles) {
       const string& prjFile = RteUtils::BackSlashesToSlashes(fi.second->GetInstanceName().c_str());
       const string& absPrjFile = m_cprjProject->GetProjectPath() + prjFile;
-      const string& pkgFile = RteUtils::BackSlashesToSlashes(fi.second->GetFile(m_targetName, m_cprjProject->GetRteFolder())->GetOriginalAbsolutePath());
+      const string& pkgFile = RteUtils::BackSlashesToSlashes(fi.second->GetFile(m_targetName)->GetOriginalAbsolutePath());
       error_code ec;
       if (!fs::exists(absPrjFile, ec)) {
         // Copy config file from pack if it's missing


### PR DESCRIPTION
Remove unnecessary rteFolder arguments (target knows its parent project)
Done to ensure backward compatibility with the code already using RteModel library

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>