### PR TITLE
Run macOS runners only on public repos

### DIFF
--- a/.github/matrix_includes_buildmgr.json
+++ b/.github/matrix_includes_buildmgr.json
@@ -1,0 +1,23 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "binary_extension":".mac",
+        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "binary_extension":".lin",
+        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "binary_extension":".exe",
+        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-win32.zip",
+        "runOn": "always"
+    }
+]

--- a/.github/matrix_includes_packchk.json
+++ b/.github/matrix_includes_packchk.json
@@ -1,0 +1,17 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "runOn": "always"
+    }
+]

--- a/.github/matrix_includes_packgen.json
+++ b/.github/matrix_includes_packgen.json
@@ -1,0 +1,20 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "binary": "packgen",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "binary": "packgen",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "binary": "packgen.exe",
+        "runOn": "always"
+    }
+]

--- a/.github/matrix_includes_projmgr.json
+++ b/.github/matrix_includes_projmgr.json
@@ -1,0 +1,20 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "binary": "csolution",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "binary": "csolution",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "binary": "csolution.exe",
+        "runOn": "always"
+    }
+]

--- a/.github/matrix_includes_test_libs.json
+++ b/.github/matrix_includes_test_libs.json
@@ -1,0 +1,17 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "runOn": "always"
+    }
+]

--- a/.github/matrix_includes_toolbox.json
+++ b/.github/matrix_includes_toolbox.json
@@ -1,0 +1,17 @@
+[
+    {
+        "runs_on":"macos-10.15",
+        "target":"darwin64",
+        "runOn": "publicRepo"
+    },
+    {
+        "runs_on":"ubuntu-20.04",
+        "target":"linux64",
+        "runOn": "always"
+    },
+    {
+        "runs_on":"windows-2019",
+        "target":"windows64",
+        "runOn": "always"
+    }
+]

--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -23,33 +23,37 @@ on:
     types: [ published ]
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_buildmgr.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
+
   build:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/buildmgr/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
-      matrix:
-        os: [ macos-10.15, ubuntu-20.04, windows-2019 ]
-        include:
-          - os: macos-10.15
-            target: darwin64
-            binary_extension: ".mac"
-          - os: ubuntu-20.04
-            target: linux64
-            binary_extension: ".lin"
-          - os: windows-2019
-            target: windows64
-            binary_extension: .exe
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -58,7 +62,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -70,15 +74,15 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build cbuildgen
         run: |
@@ -87,7 +91,7 @@ jobs:
         working-directory: ./build
 
       - name: Rename binary to be integrated to the installer
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         env:
           target: ${{ matrix.target }}
           binary_extension: ${{ matrix.binary_extension }}
@@ -107,7 +111,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
-
       - name: Checkout devtools
         uses: actions/checkout@v2
         with:
@@ -216,6 +219,7 @@ jobs:
           path: tools/buildmgr/cbuildgen/distribution/bin/
 
       - name: Download cbuildgen macos
+        if: ${{ !github.event.repository.private }}
         uses: actions/download-artifact@v2
         with:
           name: cbuildgen-darwin64
@@ -283,9 +287,9 @@ jobs:
           overwrite: true
 
   tests:
-    needs: [ create_installer ]
+    needs: [ matrix_prep, create_installer ]
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
     env:
       arm_gcc_install_base: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4
       CI_CBUILD_DEB_PKG: ${{ github.workspace }}
@@ -294,18 +298,10 @@ jobs:
       CI_GCC_TOOLCHAIN_ROOT: ${{ github.workspace }}/gcc-arm-none-eabi-10-2020-q4-major/bin
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-            installer_name: gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
-          - os: windows-2019
-            target: windows64
-            installer_name: gcc-arm-none-eabi-10-2020-q4-major-win32.zip
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             dos2unix \
@@ -313,7 +309,7 @@ jobs:
             wget
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -324,7 +320,7 @@ jobs:
             libxml2-utils
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y unzip wget ninja
 
       - name: Checkout devtools
@@ -333,7 +329,7 @@ jobs:
           submodules: true
 
       - name: Setup ARM GCC for Ubuntu and macOS
-        if: ${{ startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') || startsWith(matrix.runs_on, 'macos') }}
         env:
           installer_name: ${{ matrix.installer_name }}
         run: |
@@ -342,7 +338,7 @@ jobs:
           rm -rf ${installer_name}
 
       - name: Setup ARM GCC for Windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         env:
           installer_name: ${{ matrix.installer_name }}
         run: |
@@ -355,22 +351,22 @@ jobs:
         env:
           CACHE_NAME: cmsis_pack
         with:
-          key: ${{ env.CACHE_NAME }}-${{ matrix.os }}
+          key: ${{ env.CACHE_NAME }}-${{ matrix.runs_on }}
           path: ${{ env.CI_PACK_ROOT }}
 
       - name: Create build folder
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Download cbuild_install
         uses: actions/download-artifact@v2
@@ -385,7 +381,7 @@ jobs:
           path: ${{ github.workspace }}
 
       - name: Set correct cbuild_install file permission
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: chmod +x cbuild_install.sh
 
       - name: Build CbuildUnitTests
@@ -395,14 +391,14 @@ jobs:
         working-directory: build
 
       - name: Run CbuildUnitTests (for macOS and Ubuntu)
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         env:
           target: ${{ matrix.target }}
         run: ./tools/buildmgr/test/unittests/${target}/Debug/CbuildUnitTests --gtest_output=xml:unittest_report_${target}.xml
         working-directory: build
 
       - name: Run CbuildUnitTests (for Windows)
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         env:
           target: ${{ matrix.target }}
         # For some reason, the env variable usage $Env:target does not work properly.
@@ -430,21 +426,21 @@ jobs:
         working-directory: build
 
       - name: Run Cbuild Integration Tests (excl. AC5, AC6, MultiTargetAC6Tests) for Linux
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         env:
           target: ${{ matrix.target }}
         run: ./tools/buildmgr/test/integrationtests/${target}/Debug/CbuildIntegTests --gtest_filter=-*AC5*:*AC6*:*MultiTargetAC6Tests* --gtest_output=xml:integtest_report_${target}.xml
         working-directory: build
 
       - name: Run Cbuild Integration Tests (excl. DebPkgTests, AC5, AC6, MultiTargetAC6Tests) for macOS
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         env:
           target: ${{ matrix.target }}
         run: ./tools/buildmgr/test/integrationtests/${target}/Debug/CbuildIntegTests --gtest_filter=-*DebPkgTests*:*AC5*:*AC6*:*MultiTargetAC6Tests* --gtest_output=xml:integtest_report_${target}.xml
         working-directory: build
 
       - name: Run Cbuild Integration Tests (excl. DebPkgTests, AC5, AC6, MultiTargetAC6Tests) for Windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         env:
           target: ${{ matrix.target }}
         # For some reason the env variable usage $Env:target does not work properly.
@@ -466,9 +462,9 @@ jobs:
           report_paths: build/integtest_report_${{ matrix.target }}.xml
 
   sanity-check-native:
-    needs: [ create_installer ]
+    needs: [ create_installer, matrix_prep ]
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
     env:
       CI_PACK_ROOT: ${{ github.workspace }}/packs
       CI_ARMCC6_TOOLCHAIN_ROOT: ""
@@ -476,8 +472,7 @@ jobs:
       CI_GCC_TOOLCHAIN_ROOT: ""
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-18.04, windows-2016, windows-2022 ]
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Download cbuild_install
         uses: actions/download-artifact@v2
@@ -486,7 +481,7 @@ jobs:
           path: ${{ github.workspace }}
 
       - name: Set correct cbuild_install file permission
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: chmod +x cbuild_install.sh
 
       - name: Run cbuild_install.sh

--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -13,28 +13,37 @@ on:
     types: [published]
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_packchk.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
+
   build:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/packchk/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -43,7 +52,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -56,15 +65,15 @@ jobs:
           mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build packchk
         run: |
@@ -84,26 +93,21 @@ jobs:
 
   test:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/packchk/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -112,7 +116,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -125,15 +129,15 @@ jobs:
           mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build and run packchk unit tests
         run: |
@@ -164,13 +168,8 @@ jobs:
 
   coverage:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/packchk/')) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
-    strategy:
-      matrix:
-        os: [ ubuntu-20.04 ]
-      fail-fast: true
-
     steps:
       - name: Install dependencies
         run: |
@@ -189,9 +188,6 @@ jobs:
       - name: Create build folder
         run: mkdir build
 
-      - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-
       - name: Build and run packchk tests
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON ..
@@ -202,7 +198,6 @@ jobs:
         working-directory: ./build
 
       - name: Generate coverage report
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           lcov -c --directory . --output-file full_coverage.info
           lcov -e full_coverage.info '/tools/packchk/include/*' '*/tools/packchk/src/*' -o coverage.info
@@ -261,12 +256,8 @@ jobs:
 
   test-results-preparation:
     name: "Publish Tests Results"
-    needs: test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04 ]
+    needs: [ test ]
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -285,11 +276,12 @@ jobs:
           name: unit_test_result-linux64
           path: testreports/
 
-      # - name: Download unit test report macos
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: unit_test_result-darwin64
-      #     path: testreports/
+      - name: Download unit test report macos
+        if: ${{ !github.event.repository.private }}
+        uses: actions/download-artifact@v2
+        with:
+          name: unit_test_result-darwin64
+          path: testreports/
 
       - name: Download integ test report windows
         uses: actions/download-artifact@v2
@@ -303,11 +295,12 @@ jobs:
           name: integ_test_result-linux64
           path: testreports/
 
-      # - name: Download integ test report macos
-      #   uses: actions/download-artifact@v2
-      #   with:
-      #     name: integ_test_result-darwin64
-      #     path: testreports/
+      - name: Download integ test report macos
+        if: ${{ !github.event.repository.private }}
+        uses: actions/download-artifact@v2
+        with:
+          name: integ_test_result-darwin64
+          path: testreports/
 
       - name: Event File
         uses: actions/upload-artifact@v2

--- a/.github/workflows/packgen.yml
+++ b/.github/workflows/packgen.yml
@@ -14,31 +14,37 @@ on:
     types: [published]
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_packgen.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
+
   build:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/packgen/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-            binary: packgen
-          - os: windows-2019
-            target: windows64
-            binary: packgen.exe
-
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -47,7 +53,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -59,15 +65,15 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build packgen
         run: |
@@ -134,27 +140,21 @@ jobs:
 
   unittest:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/packgen/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
-
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -163,7 +163,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -175,15 +175,15 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build and run packgen unit tests
         run: |
@@ -206,4 +206,3 @@ jobs:
         with:
           check_name: "Packgen unit tests [${{ matrix.target }}]"
           report_paths: build/packgenunit_test_report.xml
-

--- a/.github/workflows/projmgr.yml
+++ b/.github/workflows/projmgr.yml
@@ -17,25 +17,31 @@ on:
     types: [published]
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_projmgr.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
   build:
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/projmgr/')) }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-            binary: csolution
-          - os: windows-2019
-            target: windows64
-            binary: csolution.exe
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
 
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja \
@@ -43,7 +49,7 @@ jobs:
             swig
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -54,7 +60,7 @@ jobs:
             swig
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja python swig
 
       - name: Checkout devtools
@@ -68,15 +74,15 @@ jobs:
           mkdir buildswig
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build projmgr
         run: |
@@ -93,21 +99,21 @@ jobs:
           if-no-files-found: error
 
       - name: Build projmgr swig libs windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DSWIG_LIBS=ON ..
           cmake --build . --target projmgr-python --config Release
         working-directory: ./buildswig
 
       - name: Build projmgr swig libs macos ubuntu
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DSWIG_LIBS=ON ..
           cmake --build . --target projmgr-python projmgr-go --config Release
         working-directory: ./buildswig
 
       - name: Archive projmgr swig python libs windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: actions/upload-artifact@v2
         with:
           name: projmgr-swig-python-${{ matrix.target }}
@@ -117,7 +123,7 @@ jobs:
           retention-days: 1
 
       - name: Archive projmgr swig python libs macos ubuntu
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         uses: actions/upload-artifact@v2
         with:
           name: projmgr-swig-python-${{ matrix.target }}
@@ -127,7 +133,7 @@ jobs:
           retention-days: 1
 
       - name: Archive projmgr swig go libs macos ubuntu
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         uses: actions/upload-artifact@v2
         with:
           name: projmgr-swig-go-${{ matrix.target }}
@@ -179,6 +185,7 @@ jobs:
           path: tools/projmgr/distribution/lib/linux64/python/
 
       - name: Download projmgr-swig-python macos
+        if: ${{ !github.event.repository.private }}
         uses: actions/download-artifact@v2
         with:
           name: projmgr-swig-python-darwin64
@@ -197,6 +204,7 @@ jobs:
           path: tools/projmgr/distribution/lib/linux64/go/
 
       - name: Download projmgr-swig-go macos
+        if: ${{ !github.event.repository.private }}
         uses: actions/download-artifact@v2
         with:
           name: projmgr-swig-go-darwin64
@@ -228,6 +236,7 @@ jobs:
           path: tools/testreport/linux64/
 
       - name: Download test report macos
+        if: ${{ !github.event.repository.private }}
         uses: actions/download-artifact@v2
         with:
           name: unittest-darwin64
@@ -267,27 +276,22 @@ jobs:
         github.event_name == 'pull_request' ||
         (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/projmgr/'))
       }}
-    runs-on: ${{ matrix.os }}
+    needs: matrix_prep
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
 
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -296,7 +300,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -308,15 +312,15 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build and run projmgr unit tests
         run: |
@@ -351,16 +355,10 @@ jobs:
         github.event_name == 'push' ||
         (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/projmgr/'))
       }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04 ]
-
     steps:
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -378,7 +376,6 @@ jobs:
         run: mkdir build
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
 
       - name: Build and run projmgr unit tests
         run: |
@@ -388,7 +385,6 @@ jobs:
         working-directory: ./build
 
       - name: Generate coverage report
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           lcov -c --directory . --output-file full_coverage.info
           lcov -e full_coverage.info '/tools/projmgr/include/*' '*/tools/projmgr/src/*' -o coverage.info
@@ -414,13 +410,12 @@ jobs:
 
   publish-test-results:
     name: "Publish Tests Results"
-    needs: unittest
-    runs-on: ${{ matrix.os }}
+    needs: [ matrix_prep, unittest ]
+    runs-on: ${{ matrix.runs_on }}
     if: ${{ false }}
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -6,27 +6,35 @@ on:
       - 'libs/**'
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_test_libs.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
   test_libs:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
+    needs: matrix_prep
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -35,7 +43,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -47,15 +55,15 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Build libs unittest
         run: |

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -12,6 +12,19 @@ on:
     types: [published]
 
 jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - id: set-matrix
+      run: |
+        publicRepo=$(echo '${{ github.event.repository.private && 'privateRepo' || 'publicRepo' }}')
+        matrix=$(jq --arg publicRepo "$publicRepo" 'map(. | select((.runOn==$publicRepo) or (.runOn=="always")) )' matrix_includes_toolbox.json)
+        echo ::set-output name=matrix::{\"include\":$(echo $matrix)}\"
+      working-directory: .github/
   create_installer:
     if: |
       ${{
@@ -118,30 +131,24 @@ jobs:
         github.event_name == 'pull_request' ||
         (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/toolbox/'))
       }}
-    needs: [ create_installer ]
+    needs: [ create_installer, matrix_prep ]
     timeout-minutes: 15
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
     env:
       CI_TOOLBOX_INSTALLER: ${{ github.workspace }}/cmsis-toolbox${{ needs.create_installer.outputs.VERSION }}.sh
     strategy:
       fail-fast: true
-      matrix:
-        os: [ ubuntu-20.04, windows-2019 ]
-        include:
-          - os: ubuntu-20.04
-            target: linux64
-          - os: windows-2019
-            target: windows64
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
 
     steps:
       - name: Install macos deps
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') }}
         run: |
           brew install \
             ninja
 
       - name: Install linux deps
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'ubuntu') }}
         run: |
           sudo apt update
           sudo apt-get install \
@@ -150,7 +157,7 @@ jobs:
             ninja-build
 
       - name: Install windows deps
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         run: choco install -y ninja
 
       - name: Checkout devtools
@@ -162,16 +169,16 @@ jobs:
         run: mkdir build
 
       - name: Configure windows build for amd64
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: amd64
 
       - uses: ammaraskar/gcc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
 
       - uses: ammaraskar/msvc-problem-matcher@master
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: ${{ startsWith(matrix.runs_on, 'windows') }}
 
       - name: Download cmsis-toolbox installer
         uses: actions/download-artifact@v2
@@ -180,7 +187,7 @@ jobs:
           path: ${{ github.workspace }}
 
       - name: Set correct cmsis-toolbox file permission
-        if: ${{ startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: chmod +x cmsis-toolbox${{ needs.create_installer.outputs.VERSION }}.sh
 
       - name: Build and run Toolbox tests


### PR DESCRIPTION
* Run macOS runners only on public repos

Creating an initial job `matrix_prep` to create a matrix set and its
includes.
In our case, it runs:
  * mac, windows, linux on public repos
  * windows and linux on private repos

The matrix data for each product can be found on:
  * .github/matrix_includes_*.json

In the JSON file, there is an attribute called `runOn` for each
combination which has two values:
  * always: always going to run regardless the repo type.
  * publicRepo: only run on public repos.