### PR TITLE
[projmgr] Open door to vendor specific data addon adding open-cmsis scope

### DIFF
--- a/tools/projmgr/schemas/clayer.schema.json
+++ b/tools/projmgr/schemas/clayer.schema.json
@@ -4,10 +4,15 @@
   "title": "CMSIS Project Manager clayer",
   "version": "0.9.1",
   "properties": {
-    "layer": {
-      "$ref": "./common.schema.json#/definitions/LayerDescType"
+    "open-cmsis": {
+      "properties": {
+        "layer": {
+          "$ref": "./common.schema.json#/definitions/LayerDescType"
+        },
+        "additionalProperties": false
+      },
+      "required": ["layer"]
     }
   },
-  "additionalProperties": false,
-  "required": [ "layer" ]
+  "required": ["open-cmsis"]
 }

--- a/tools/projmgr/schemas/cproject.schema.json
+++ b/tools/projmgr/schemas/cproject.schema.json
@@ -4,10 +4,14 @@
   "title": "CMSIS Project Manager cproject",
   "version": "0.9.1",
   "properties": {
-    "project": {
-      "$ref": "./common.schema.json#/definitions/ProjectDescType"
+    "open-cmsis": {
+      "properties": {
+        "project": {
+          "$ref": "./common.schema.json#/definitions/ProjectDescType"
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": false,
-  "required": [ "project" ]
+  "required": ["open-cmsis", "project"]
 }

--- a/tools/projmgr/schemas/csolution.schema.json
+++ b/tools/projmgr/schemas/csolution.schema.json
@@ -4,10 +4,15 @@
   "title": "CMSIS Project Manager csolution",
   "version": "0.9.1",
   "properties": {
-    "solution": {
-      "$ref": "./common.schema.json#/definitions/SolutionDescType"
+    "open-cmsis": {
+      "properties": {
+        "solution": {
+          "$ref": "./common.schema.json#/definitions/SolutionDescType"
+        },
+        "additionalProperties": false
+      },
+      "required": ["solution"]
     }
   },
-  "additionalProperties": false,
-  "required": [ "solution" ]
+  "required": ["open-cmsis"]
 }


### PR DESCRIPTION
Proposal in sync. #83
Such will preserve current OpenCMSIS proposal but adding `open-cmsis` scope.
Is allowing integrator to promote its own schema on top of.
Introducing scope may helps clarity I guess plus may be useful if #88 `devtools` having only to consider if `open-cmsis` scope is available or not while iterating on csolution.yml referenced *.cproject.yml file(s)