### PR TITLE
[projmgr] Open door to vendor specific data addon: schema polishing

### DIFF
--- a/tools/projmgr/schemas/cdefault.schema.json
+++ b/tools/projmgr/schemas/cdefault.schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "default": {
       "$ref": "./common.schema.json#/definitions/DefaultDescType"
-    },
-    "additionalProperties": false
+    }
   },
   "required": [ "default" ]
 }

--- a/tools/projmgr/schemas/clayer.schema.json
+++ b/tools/projmgr/schemas/clayer.schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "layer": {
       "$ref": "./common.schema.json#/definitions/LayerDescType"
-    },
-    "additionalProperties": false
+    }
   },
   "required": [ "layer" ]
 }

--- a/tools/projmgr/schemas/cproject.schema.json
+++ b/tools/projmgr/schemas/cproject.schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "project": {
       "$ref": "./common.schema.json#/definitions/ProjectDescType"
-    },
-    "additionalProperties": false
+    }
   },
   "required": [ "project" ]
 }

--- a/tools/projmgr/schemas/csolution.schema.json
+++ b/tools/projmgr/schemas/csolution.schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "solution": {
       "$ref": "./common.schema.json#/definitions/SolutionDescType"
-    },
-    "additionalProperties": false
+    }
   },
   "required": [ "solution" ]
 }


### PR DESCRIPTION
Previous JSON schema was valid (https://www.jsonschemavalidator.net/) but possibly not best.
Removes useless lines preventing https://quicktype.io/ to run.
`"additionalProperties": false` is part already of `./common.schema.json`