### PR TITLE
MCU-Build-Actions: Change location

### DIFF
--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -53,9 +53,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         id: mcu-build
         with:
           target: cbuildgen
@@ -346,9 +346,9 @@ jobs:
         if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: chmod +x cbuild_install.sh
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build CbuildUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           target: CbuildUnitTests
           build_type: Debug
@@ -372,9 +372,9 @@ jobs:
           check_name: "Cbuild Unittests [${{ matrix.target }}_${{ matrix.arch }}]"
           report_paths: build/cbuildunit_test_report.xml
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build CbuildIntegTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           target: CbuildIntegTests
           build_type: Debug

--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -48,9 +48,9 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build packchk
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           target: packchkdist
           arch: ${{ matrix.arch }}
@@ -78,9 +78,9 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build PackChkUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -91,9 +91,9 @@ jobs:
           ctest -V -R PackChkUnitTests
         working-directory: ./build
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build PackChkIntegTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -137,18 +137,18 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build PackChkIntegTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64
           build_type: Debug
           target: PackChkIntegTests
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build PackChkUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64

--- a/.github/workflows/packgen.yml
+++ b/.github/workflows/packgen.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         id: mcu-build
         with:
           target: packgen
@@ -124,9 +124,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build PackGenUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           target: PackGenUnitTests
           build_type: Debug

--- a/.github/workflows/projmgr.yml
+++ b/.github/workflows/projmgr.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           target: projmgr
           arch: ${{ matrix.arch }}
@@ -71,10 +71,10 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build swig libs windows
         if: ${{ startsWith(matrix.runs_on, 'windows') }}
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           add_cmake_variables: -DSWIG_LIBS=ON
           add_cmake_build_args: --config Release
@@ -82,10 +82,10 @@ jobs:
           build_folder: buildswig
           target: projmgr-python
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build swig libs macos and ubuntu amd64
         if: ${{ startsWith(matrix.runs_on, 'macos') || ( startsWith(matrix.runs_on, 'ubuntu') && matrix.arch == 'amd64' ) }}
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           add_cmake_variables: -DSWIG_LIBS=ON
           add_cmake_build_args: --config Release
@@ -267,9 +267,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build ProjMgrUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -317,9 +317,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build ProjMgrUnitTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Build all libs
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         id: mcu-build
         with:
           add_cmake_variables: '-DLIBS_ONLY=ON'

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -213,7 +213,7 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Debug/mcu-build-action
+      # https://github.com/Arm-Examples/mcu-build-action
       - name: Download cmsis-toolbox installer
         uses: actions/download-artifact@v2
         with:
@@ -225,7 +225,7 @@ jobs:
         run: chmod +x cmsis-toolbox.sh
 
       - name: Build ToolboxTests
-        uses: Arm-Debug/mcu-build-action@v1.1
+        uses: Arm-Examples/mcu-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug


### PR DESCRIPTION
Arm-Debug cannot have public repos, moving to a temporary location until
I move this repo to Arm-Software.