### PR TITLE
GitHub Actions: update devtools-build-action location

### DIFF
--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -53,10 +53,10 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build
-        uses: Arm-Examples/mcu-build-action@v1.1
-        id: mcu-build
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
+        id: devtools-build
         with:
           target: cbuildgen
           arch: ${{ matrix.arch }}
@@ -346,9 +346,9 @@ jobs:
         if: ${{ startsWith(matrix.runs_on, 'macos') || startsWith(matrix.runs_on, 'ubuntu') }}
         run: chmod +x cbuild_install.sh
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build CbuildUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           target: CbuildUnitTests
           build_type: Debug
@@ -372,9 +372,9 @@ jobs:
           check_name: "Cbuild Unittests [${{ matrix.target }}_${{ matrix.arch }}]"
           report_paths: build/cbuildunit_test_report.xml
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build CbuildIntegTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           target: CbuildIntegTests
           build_type: Debug

--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -48,9 +48,9 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build packchk
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           target: packchkdist
           arch: ${{ matrix.arch }}
@@ -78,9 +78,9 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build PackChkUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -91,9 +91,9 @@ jobs:
           ctest -V -R PackChkUnitTests
         working-directory: ./build
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build PackChkIntegTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -137,18 +137,18 @@ jobs:
         with:
           submodules: recursive
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build PackChkIntegTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64
           build_type: Debug
           target: PackChkIntegTests
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build PackChkUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64

--- a/.github/workflows/packgen.yml
+++ b/.github/workflows/packgen.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build
-        uses: Arm-Examples/mcu-build-action@v1.1
-        id: mcu-build
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
+        id: devtools-build
         with:
           target: packgen
           arch: ${{ matrix.arch }}
@@ -124,9 +124,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build PackGenUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           target: PackGenUnitTests
           build_type: Debug

--- a/.github/workflows/projmgr.yml
+++ b/.github/workflows/projmgr.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           target: projmgr
           arch: ${{ matrix.arch }}
@@ -71,10 +71,10 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build swig libs windows
         if: ${{ startsWith(matrix.runs_on, 'windows') }}
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           add_cmake_variables: -DSWIG_LIBS=ON
           add_cmake_build_args: --config Release
@@ -82,10 +82,10 @@ jobs:
           build_folder: buildswig
           target: projmgr-python
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build swig libs macos and ubuntu amd64
         if: ${{ startsWith(matrix.runs_on, 'macos') || ( startsWith(matrix.runs_on, 'ubuntu') && matrix.arch == 'amd64' ) }}
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           add_cmake_variables: -DSWIG_LIBS=ON
           add_cmake_build_args: --config Release
@@ -267,9 +267,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build ProjMgrUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug
@@ -317,9 +317,9 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build ProjMgrUnitTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           add_cmake_variables: -DCOVERAGE=ON
           arch: amd64

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Build all libs
-        uses: Arm-Examples/mcu-build-action@v1.1
-        id: mcu-build
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
+        id: devtools-build
         with:
           add_cmake_variables: '-DLIBS_ONLY=ON'
           arch: ${{ matrix.arch }}

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -213,7 +213,7 @@ jobs:
         with:
           submodules: true
 
-      # https://github.com/Arm-Examples/mcu-build-action
+      # https://github.com/Open-CMSIS-Pack/devtools-build-action
       - name: Download cmsis-toolbox installer
         uses: actions/download-artifact@v2
         with:
@@ -225,7 +225,7 @@ jobs:
         run: chmod +x cmsis-toolbox.sh
 
       - name: Build ToolboxTests
-        uses: Arm-Examples/mcu-build-action@v1.1
+        uses: Open-CMSIS-Pack/devtools-build-action@v1.1
         with:
           arch: ${{ matrix.arch }}
           build_type: Debug


### PR DESCRIPTION
Use the new Open-CMSIS-Pack/devtools-build-action location.