### PR TITLE
[toolbox] Update version references

### DIFF
--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -47,7 +47,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: "Open-CMSIS-Pack/devtools"
-          version: tags/tools/buildmgr/0.11.0
+          version: tags/tools/buildmgr/0.11.1
           file: cbuild_install.sh
           target: tools/toolbox/cbuild/cbuild_install.sh
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: "Open-CMSIS-Pack/devtools"
-          version: tags/tools/projmgr/0.9.4
+          version: tags/tools/projmgr/0.9.5
           file: projmgr.zip
           target: tools/toolbox/projmgr/projmgr.zip
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -88,6 +88,12 @@ jobs:
           cp docs/LICENSE.txt distribution
           cp docs/index.html distribution/doc
         working-directory: tools/toolbox
+
+      - name: Add execution permission to the binaries and set files ownership
+        run: |
+          sudo chmod -R +x bin/*
+          sudo chown -R root:root *
+        working-directory: tools/toolbox/distribution
 
       - name: Create installer
         id: installer

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -597,8 +597,9 @@ bool ProjMgrWorker::ProcessToolchain(ContextItem& context) {
   if (delimiter == string::npos) {
     static const map<string, string> DEF_MIN_VERSIONS = {
       {"AC5","5.6.7"},
-      {"AC6","6.16.0"},
+      {"AC6","6.18.0"},
       {"GCC","10.2.1"},
+      {"IAR","8.50.6"},
     };
     for (const auto& defMinVersion: DEF_MIN_VERSIONS) {
       if (context.toolchain.name == defMinVersion.first) {

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Debug+CM0/test-access-sequences1.Debug+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Debug+CM0/test-access-sequences1.Debug+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Debug+CM3/test-access-sequences1.Debug+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Debug+CM3/test-access-sequences1.Debug+CM3.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM0/test-access-sequences1.Release+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM0/test-access-sequences1.Release+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM3/test-access-sequences1.Release+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM3/test-access-sequences1.Release+CM3.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Debug+CM0/test-access-sequences2.Debug+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Debug+CM0/test-access-sequences2.Debug+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Debug+CM3/test-access-sequences2.Debug+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Debug+CM3/test-access-sequences2.Debug+CM3.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM0/test-access-sequences2.Release+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM0/test-access-sequences2.Release+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM3/test-access-sequences2.Release+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM3/test-access-sequences2.Release+CM3.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Debug/test-access-sequences3.Debug.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Debug/test-access-sequences3.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release/test-access-sequences3.Release.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release/test-access-sequences3.Release.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/build-types/project.AC6/project.AC6.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/build-types/project.AC6/project.AC6.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/build-types/project.IAR/project.IAR.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/build-types/project.IAR/project.IAR.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="IAR" version="0.0.0"/>
+    <compiler name="IAR" version="8.50.6"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/full/project.Debug/project.Debug.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/full/project.Debug/project.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/full/project.Release/project.Release.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/full/project.Release/project.Release.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="IAR" version="0.0.0"/>
+    <compiler name="IAR" version="8.50.6"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cprj
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dname="RteTestGen_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestLayers/Layer1/layer1.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/Layer1/layer1.clayer.yml
@@ -7,7 +7,7 @@ layer:
     - DEF_LAYER1
   add-paths:
     - path/to/layer1
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   misc:
     - C:
       - --layer1-flag

--- a/tools/projmgr/test/data/TestLayers/Layer1/layer1.clayer_pname.yml
+++ b/tools/projmgr/test/data/TestLayers/Layer1/layer1.clayer_pname.yml
@@ -7,7 +7,7 @@ layer:
     - DEF_LAYER1
   add-paths:
     - path/to/layer1
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   misc:
     - C:
       - --layer1-flag

--- a/tools/projmgr/test/data/TestLayers/ref/testlayers.Debug/testlayers.Debug.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/testlayers.Debug/testlayers.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestLayers/ref/testlayers.Release/testlayers.Release.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/testlayers.Release/testlayers.Release.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestLayers/ref2/testlayers.Debug.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref2/testlayers.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestLayers/ref2/testlayers.Release.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref2/testlayers.Release.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestLayers/testlayers.cproject.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
 
   layers:
     - layer: ./Layer1/layer1.clayer.yml

--- a/tools/projmgr/test/data/TestLayers/testlayers.cproject_no_device_name.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.cproject_no_device_name.yml
@@ -2,7 +2,7 @@
 
 project:
   device: :cm0_core0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
 
   layers:
     - layer: ./Layer2/layer2.clayer_package_with_pname.yml

--- a/tools/projmgr/test/data/TestLayers/testlayers.cproject_pname.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.cproject_pname.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/0.9.5/tools/projmgr/schemas/cproject.schema.json
 
 project:
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   device: :cm0_core0
 
   layers:

--- a/tools/projmgr/test/data/TestProject/GenerateCprjTest.cprj
+++ b/tools/projmgr/test/data/TestProject/GenerateCprjTest.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestProject/test-api.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test-api.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test-dependency.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test-dependency.cproject.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: Startup
   groups:

--- a/tools/projmgr/test/data/TestProject/test.cprj
+++ b/tools/projmgr/test/data/TestProject/test.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestProject/test.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_and_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_and_device.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Dummy board
   device: ARM::RteTest_ARMCM0_Dual:cm0_core1
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_device_variant.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_device_variant.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test device variant
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_multi_mounted_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_multi_mounted_device.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test board
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_multi_variant.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_multi_variant.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test board-4
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_multi_variant_and_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_multi_variant_and_device.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Test board-4
   device: RteTest_ARMCM4_FP
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_name_invalid.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_name_invalid.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest_unknown
   device: ARM::RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_no_mounted_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_no_mounted_device.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test board no mounted device
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_board_vendor_invalid.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_board_vendor_invalid.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: UNKNOWN::RteTest Dummy board
   device: ARM::RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_correct_board_wrong_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_correct_board_wrong_device.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Dummy board
   device: ARM::RteTest_ARMCM_Unknown
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_correct_device_wrong_board.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_correct_device_wrong_board.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest unknown board
   device: ARM::RteTest_ARMCM0_Dual
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_device_pname_unavailable_in_board.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_device_pname_unavailable_in_board.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Dummy board
   device: RteTest_ARMCM0_Dual:cm0_core7
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_device_unavailable_in_board.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_device_unavailable_in_board.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Dummy board
   device: RteTest_ARMCM7
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_device_unknown.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_device_unknown.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARM_UNKNOWN
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_device_unknown_processor.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_device_unknown_processor.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0:NOT_AVAILABLE
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: Startup
     - component: CORE

--- a/tools/projmgr/test/data/TestProject/test.cproject_device_unknown_vendor.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_device_unknown_vendor.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: TEST::RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_duplicate_package.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_duplicate_package.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_exact_package.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_exact_package.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_invalid_schema.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_invalid_schema.yml
@@ -5,7 +5,7 @@ project:
   name: Project 1
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_mounted_device_differs_selected_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_mounted_device_differs_selected_device.yml
@@ -4,7 +4,7 @@ project:
   description: Project 1
   board: Keil::RteTest Dummy board
   device: ARM::RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_no_board_no_device.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_no_board_no_device.yml
@@ -2,7 +2,7 @@
 
 project:
   description: Project 1
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_no_compiler.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_no_compiler.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  # No compilercompiler: AC6@6.16.0
+  # No compilercompiler: AC6@6.18.0
   packages:
     - package: ARM::RteTest@0.1.0
   components:

--- a/tools/projmgr/test/data/TestProject/test.cproject_no_packages.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_no_packages.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_only_board.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_only_board.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test board-3
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_only_board_no_pname.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_only_board_no_pname.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   board: Keil::RteTest Test board-2
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_schema_validation_failed.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_schema_validation_failed.yml
@@ -6,7 +6,7 @@ project:
   board: Keil::RteTest (Test) Dummy board
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test.cproject_unknown_package.yml
+++ b/tools/projmgr/test/data/TestProject/test.cproject_unknown_package.yml
@@ -3,7 +3,7 @@
 project:
   description: Project 1
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test_component_multiple_matches1.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_multiple_matches1.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: Device:Test variant 2
     - component: CORE

--- a/tools/projmgr/test/data/TestProject/test_component_multiple_matches2.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_multiple_matches2.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: Device
     - component: CORE

--- a/tools/projmgr/test/data/TestProject/test_component_variant1.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_variant1.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: Device:Test variant
     - component: CORE

--- a/tools/projmgr/test/data/TestProject/test_component_variant2.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_variant2.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   components:
     - component: ARM::Device:Test variant
     - component: CORE

--- a/tools/projmgr/test/data/TestProject/test_linker_script.cprj
+++ b/tools/projmgr/test/data/TestProject/test_linker_script.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestProject/test_linker_script.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_linker_script.cproject.yml
@@ -2,7 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
-  compiler: AC6@6.16.0
+  compiler: AC6@6.18.0
   processor:
     fpu: off
     endian: little

--- a/tools/projmgr/test/data/TestProject/test_only_board.cprj
+++ b/tools/projmgr/test/data/TestProject/test_only_board.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Bname="RteTest Test board-3" Bvendor="Keil" Bversion="1.1.1" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/multicore+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/multicore+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Non-secure" Dvendor="ARM:82" Pname="cm0_core1">

--- a/tools/projmgr/test/data/TestSolution/ref/pack_path+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/pack_path+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0/test1.Debug+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0/test1.Debug+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0/test1.Debug+CM0_board_package.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0/test1.Debug+CM0_board_package.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Bname="RteTest board listing" Bvendor="Keil" Bversion="Rev.C" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0_pack_selection.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0_pack_selection.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Non-secure" Dvendor="ARM:82" Pname="cm0_core1">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0_pname.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM0/test2.Debug+CM0_pname.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Non-secure" Dvendor="ARM:82" Pname="cm0_core1">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM3/test2.Debug+CM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM3/test2.Debug+CM3.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM3/test2.Debug+CM3_pname.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+CM3/test2.Debug+CM3_pname.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test2.Debug+TestGen/test2.Debug+TestGen.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test2.Debug+TestGen/test2.Debug+TestGen.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dname="RteTestGen_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Debug+CM33.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Debug+CM33.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Non-secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Debug+CM35P.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Debug+CM35P.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM35P_DSP_FP_TZ" Dsecure="Non-secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Release+CM33.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Release+CM33.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Non-secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Release+CM35P.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/NonSecureCode/NonSecure.Release+CM35P.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM35P_DSP_FP_TZ" Dsecure="Non-secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Debug+CM33.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Debug+CM33.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Debug+CM35P.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Debug+CM35P.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM35P_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Release+CM33.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Release+CM33.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Release+CM35P.cprj
+++ b/tools/projmgr/test/data/TrustZoneSolution/SecureCode/Secure.Release+CM35P.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.16.0"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Ddsp="DSP" Dfpu="SP_FPU" Dname="ARMCM35P_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -31,7 +31,7 @@ void ProjMgrWorkerUnitTests::SetCsolutionPacks(CsolutionItem* csolution, std::ve
 TEST_F(ProjMgrWorkerUnitTests, ProcessToolchain) {
   ToolchainItem expected;
   expected.name = "AC6";
-  expected.version = "6.16.0";
+  expected.version = "6.18.0";
   ProjMgrParser parser;
   ContextDesc descriptor;
   const string& filename = testinput_folder + "/TestProject/test.cproject.yml";
@@ -56,7 +56,7 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessToolchainOptions) {
   {
     { "", {false, "", "", ""}},
     { "TEST", {true, "", "TEST", "0.0.0"}},
-    { "AC6", {true, "AC6", "ARMCC", "6.16.0"}}
+    { "AC6", {true, "AC6", "ARMCC", "6.18.0"}}
   };
 
   for (auto input : testInput) {

--- a/tools/toolbox/installer/install.sh
+++ b/tools/toolbox/installer/install.sh
@@ -134,7 +134,7 @@ case $OS in
     install_dir_default_path=./cmsis-toolbox
     cmsis_pack_root_default_path=$(unixpath "${LOCALAPPDATA}/Arm/Packs")
     cmsis_compiler_root_default_path=$(unixpath "${LOCALAPPDATA}/Arm/Compilers")
-    compiler6_default_path=$(unixpath "${PROGRAMFILES}/ARMCompiler6.16/bin")
+    compiler6_default_path=$(unixpath "${PROGRAMFILES}/ArmCompilerforEmbedded6.18/bin")
     compiler5_default_path=$(unixpath "${PROGRAMFILES} (x86)/ARM_Compiler_5.06u7/bin")
     gcc_default_path=$(unixpath "${PROGRAMFILES} (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin")
     iar_default_path=$(unixpath "${PROGRAMFILES} (x86)/IAR Systems/Embedded Workbench 8.4/arm/bin")
@@ -148,7 +148,7 @@ case $OS in
     programfiles=$(cmd.exe /c "echo|set /p=%PROGRAMFILES%")
     cmsis_pack_root_default_path=$(wslpath "${localappdata}\Arm\Packs")
     cmsis_compiler_root_default_path=$(wslpath "${localappdata}\Arm\Compilers")
-    compiler6_default_path=$(wslpath "${programfiles}/ARMCompiler6.16/bin")
+    compiler6_default_path=$(wslpath "${programfiles}/ArmCompilerforEmbedded6.18/bin")
     compiler5_default_path=$(wslpath "${programfiles} (x86)/ARM_Compiler_5.06u7/bin")
     gcc_default_path=$(wslpath "${programfiles} (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin")
     iar_default_path=$(wslpath "${programfiles} (x86)/IAR Systems/Embedded Workbench 8.4/arm/bin")
@@ -159,7 +159,7 @@ case $OS in
     install_dir_default_path=./cmsis-toolbox
     cmsis_pack_root_default_path=${HOME}/.cache/arm/packs
     cmsis_compiler_root_default_path=${HOME}/.cache/arm/compilers
-    compiler6_default_path=${HOME}/ARMCompiler6.16/bin
+    compiler6_default_path=${HOME}/ArmCompilerforEmbedded6.18/bin
     compiler5_default_path=${HOME}/ARM_Compiler_5.06u7/bin
     gcc_default_path=${HOME}/gcc-arm-none-eabi-10-2020-q4-major/bin
     iar_default_path=/opt/iarsystems/bxarm/arm/bin
@@ -182,7 +182,7 @@ else
 fi
 
 # ask for AC6 compiler installation path
-read -e -p "Enter the installed Arm Compiler 6.16 directory [${compiler6_default_path}]: " compiler6_root
+read -e -p "Enter the installed Arm Compiler 6.18 directory [${compiler6_default_path}]: " compiler6_root
 compiler6_root=${compiler6_root:-${compiler6_default_path}}
 if [[ -d "${compiler6_root}" ]]
   then
@@ -313,7 +313,7 @@ if [[ $OS == "Windows" ]]
 fi
 
 # update toolchain config files
-script="${cmsis_compiler_root}/AC6.6.16.0.cmake"
+script="${cmsis_compiler_root}/AC6.6.18.0.cmake"
 sed -e "s|set(TOOLCHAIN_ROOT.*|set(TOOLCHAIN_ROOT \"${compiler6_root}\")|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 sed -e "s|set(EXT.*|set(EXT ${extension})|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 

--- a/tools/toolbox/scripts/set-default.sh
+++ b/tools/toolbox/scripts/set-default.sh
@@ -17,7 +17,7 @@ case $1 in
     ;;
   'Linux' | 'Darwin')
     # linux/macos
-    compiler6_default_path=~/ARMCompiler6.16/bin
+    compiler6_default_path=~/ArmCompilerforEmbedded6.18/bin
     compiler5_default_path=~/ARM_Compiler_5.06u7/bin
     gcc_default_path=~/gcc-arm-none-eabi-10-2020-q4-major/bin
     iar_default_path=/opt/iarsystems/bxarm/arm/bin
@@ -26,7 +26,7 @@ case $1 in
 esac
 
 # update toolchain config files
-script="$2/AC6.6.16.0.cmake"
+script="$2/AC6.6.18.0.cmake"
 sed -e "s|set(TOOLCHAIN_ROOT.*|set(TOOLCHAIN_ROOT \"${compiler6_default_path}\")|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 sed -e "s|set(EXT.*|set(EXT ${extension})|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 

--- a/tools/toolbox/test/src/InstallerTests.cpp
+++ b/tools/toolbox/test/src/InstallerTests.cpp
@@ -56,7 +56,7 @@ void ToolBoxInstallerTests::CheckInstallationDir(
               "index.html"}},
 
     { "etc", vector<string>{
-                "AC5.5.6.7.cmake", "AC6.6.16.0.cmake",
+                "AC5.5.6.7.cmake", "AC6.6.18.0.cmake",
                 "CPRJ.xsd", "GCC.10.2.1.cmake",
                 "IAR.8.50.6.cmake", "setup",
                 "{{ProjectName}}.cproject.yml",
@@ -91,7 +91,7 @@ void ToolBoxInstallerTests::CheckExtractedDir(const string& path, bool expect) {
               "index.html"}},
 
     { "etc", vector<string>{
-                "AC5.5.6.7.cmake", "AC6.6.16.0.cmake",
+                "AC5.5.6.7.cmake", "AC6.6.18.0.cmake",
                 "CPRJ.xsd", "GCC.10.2.1.cmake",
                 "IAR.8.50.6.cmake", "setup",
                 "{{ProjectName}}.cproject.yml",


### PR DESCRIPTION
- Update AC6.18 references
- Update supported compiler minimum versions
- Update buildmgr and projmgr release versions
- Add execution permission flags and set files ownership