### PR TITLE
[buildmgr] AC5 use cbuild_set_defines to set CC_DEFINES

### DIFF
--- a/tools/buildmgr/cbuildgen/config/AC5.5.6.7.cmake
+++ b/tools/buildmgr/cbuildgen/config/AC5.5.6.7.cmake
@@ -90,9 +90,8 @@ set(CC_FLAGS)
 set(CC_BYTE_ORDER ${ASM_BYTE_ORDER})
 set(_PI "--preinclude=")
 
-foreach(ENTRY ${DEFINES})
-  string(APPEND CC_DEFINES "-D${ENTRY} ")
-endforeach()
+set(CC_DEFINES ${DEFINES})
+cbuild_set_defines(C CC_DEFINES)
 
 # C++ Compiler
 


### PR DESCRIPTION
Contributed by STMicroelectronics
Signed-off-by: Tarek BOCHKATI <tarek.bouchkati@st.com>