### PR TITLE
Add $B processing to RteCallback::ExpandString() (#229)

### DIFF
--- a/libs/rtemodel/include/RteCallback.h
+++ b/libs/rtemodel/include/RteCallback.h
@@ -38,12 +38,18 @@ static const unsigned int RTE_MB_ICONQUESTION    = 0x00000020;
 static const unsigned int RTE_MB_ICONEXCLAMATION = 0x00000030;
 static const unsigned int RTE_MB_ICONASTERISK    = 0x00000040;
 
+class RteKernel;
 /**
  * @brief Class to allow RTE to call application or API functions, defaults do nothing
 */
 class RteCallback : public XMLTreeCallback
 {
 public:
+
+  /**
+   * @brief default constructor
+  */
+  RteCallback();
 
   /**
    * @brief clear output buffer or console
@@ -112,7 +118,7 @@ public:
    * @param str string to expand
    * @return expanded string
   */
-  virtual std::string ExpandString(const std::string& str) { return str; } // default simply returns the input string
+  virtual std::string ExpandString(const std::string& str);
 
   /**
    * @brief send message to the application main window by calling a function specific to OS
@@ -175,7 +181,7 @@ public:
 
 
   /**
-   * @brief get RteCallback object
+   * @brief get global RteCallback object
    * @return return RteCallback pointer or default one, never NULL
   */
   static RteCallback* GetGlobal();
@@ -185,7 +191,21 @@ public:
    * @param callback given RteCallback object
   */
   static void SetGlobal(RteCallback* callback);
+
+  /**
+   * @brief set RteKernel to use
+   * @param rteKernel pointer to RteKernel object
+  */
+  void SetRteKernel(RteKernel* rteKernel) { m_rteKernel = rteKernel;}
+
+  /**
+   * @brief get RteKernel object
+   * @return pointer RteKernel  object or nullptr;
+  */
+  const RteKernel* GetRteKernel() const { return m_rteKernel; };
+
 protected:
+  RteKernel* m_rteKernel;
   static RteCallback* theGlobalCallback;
 };
 

--- a/libs/rtemodel/src/RteCallback.cpp
+++ b/libs/rtemodel/src/RteCallback.cpp
@@ -13,9 +13,22 @@
 /******************************************************************************/
 #include "RteCallback.h"
 
+#include "RteKernel.h"
+#include "RteProject.h"
+#include "RteTarget.h"
+#include "RteBoard.h"
+
+#include "RteUtils.h"
+
 using namespace std;
 
 RteCallback* RteCallback::theGlobalCallback = nullptr;
+
+RteCallback::RteCallback():
+m_rteKernel(nullptr)
+{
+
+}
 
 
 void RteCallback::OutputMessages(const std::list<string>& messages)
@@ -50,4 +63,43 @@ void RteCallback::SetGlobal(RteCallback* callback)
 {
   theGlobalCallback = callback;
 }
+
+string RteCallback::ExpandString(const string& str) {
+
+  const RteKernel* kernel = GetRteKernel();
+  if (!kernel) {
+    return RteUtils::EMPTY_STRING;
+  }
+
+  const auto activeProject = kernel->GetActiveProject();
+  if (!activeProject) {
+    return RteUtils::EMPTY_STRING;
+  }
+  const auto activeTarget = kernel->GetActiveTarget();
+  if (!activeTarget) {
+    return RteUtils::EMPTY_STRING;
+  }
+
+  const string& prjPath(activeProject->GetProjectPath());
+  const string& prjPathFile(prjPath + activeProject->GetName() + ".cprj");
+  const string& packPath(activeTarget->GetDevicePackage()->GetAbsolutePackagePath());
+  const string& deviceName(activeTarget->GetDeviceName());
+
+  if (prjPath.empty() || prjPathFile.empty() || packPath.empty() || deviceName.empty()) {
+    return RteUtils::EMPTY_STRING;
+  }
+
+  RteBoard* board = activeTarget->GetBoard();
+  const string& boardName = board ? board->GetName() : RteUtils::EMPTY_STRING;
+
+  string res(str);
+  RteUtils::ReplaceAll(res, "$P", prjPath);
+  RteUtils::ReplaceAll(res, "#P", prjPathFile);
+  RteUtils::ReplaceAll(res, "$S", packPath);
+  RteUtils::ReplaceAll(res, "$D", deviceName);
+  RteUtils::ReplaceAll(res, "$B", boardName);
+
+  return res;
+}
+
 // end of RteCallback.cpp

--- a/libs/rteutils/include/RteUtils.h
+++ b/libs/rteutils/include/RteUtils.h
@@ -131,6 +131,16 @@ public:
    * @return true if name is CMSIS-conformed
   */
   static bool CheckCMSISName(const std::string& s);
+
+  /**
+   * @brief replace all substring occurrences in the supplied string
+   * @param str reference to string to be manipulated
+   * @param toReplace substring to replace
+   * @param with substitute string
+   * @return reference supplied string
+   */
+  static std::string& ReplaceAll(std::string& str, const std::string& toReplace, const std::string& with);
+
   /**
    * @brief replace blank(s) with underscore(s)
    * @param s string to be manipulated

--- a/libs/rteutils/src/RteUtils.cpp
+++ b/libs/rteutils/src/RteUtils.cpp
@@ -136,6 +136,14 @@ bool RteUtils::CheckCMSISName(const string& s)
   return true;
 }
 
+std::string& RteUtils::ReplaceAll(std::string& str, const string& toReplace, const string& with)
+{
+  for (size_t pos = str.find(toReplace); pos != string::npos; pos = str.find(toReplace, pos + toReplace.size())) {
+    str.replace(pos, toReplace.size(), with);
+  }
+  return str;
+}
+
 
 string RteUtils::SpacesToUnderscore(const string& s)
 {

--- a/tools/buildmgr/cbuild/src/CbuildCallback.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildCallback.cpp
@@ -55,19 +55,16 @@ string CbuildCallback::ExpandString(const string& str) {
     return RteUtils::EMPTY_STRING;
   }
 
-  auto replace = [](string &str, const string &toReplace, const string &with) {
-    size_t pos = str.find(toReplace);
-    while (pos != string::npos) {
-      str.replace(pos, 2, with);
-      pos = str.find(toReplace, pos + toReplace.size());
-    }
-  };
+  const RteTarget* activeTarget = model->GetTarget();
+  RteBoard* board = activeTarget ? activeTarget->GetBoard() : nullptr;
+  const string& boardName = board ? board->GetName() : RteUtils::EMPTY_STRING;
 
   string res(str);
-  replace(res, "$P", prjPath);
-  replace(res, "#P", prjPathFile);
-  replace(res, "$S", rtePath);
-  replace(res, "$D", deviceName);
+  RteUtils::ReplaceAll(res, "$P", prjPath);
+  RteUtils::ReplaceAll(res, "#P", prjPathFile);
+  RteUtils::ReplaceAll(res, "$S", rtePath);
+  RteUtils::ReplaceAll(res, "$D", deviceName);
+  RteUtils::ReplaceAll(res, "$B", boardName);
 
   return res;
 }

--- a/tools/buildmgr/cbuild/src/CbuildKernel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildKernel.cpp
@@ -20,6 +20,9 @@ static CbuildKernel *theCbuildKernel = 0;
 CbuildKernel::CbuildKernel(RteCallback* callback) : RteKernel(callback) {
   m_model = new CbuildModel();
   m_callback = dynamic_cast<CbuildCallback*>(callback);
+  if (m_callback) {
+    m_callback->SetRteKernel(this);
+  }
 }
 
 CbuildKernel::~CbuildKernel() {

--- a/tools/projmgr/include/ProjMgrCallback.h
+++ b/tools/projmgr/include/ProjMgrCallback.h
@@ -79,17 +79,6 @@ public:
   */
   virtual void Err(const std::string& id, const std::string& message, const std::string& object = RteUtils::EMPTY_STRING) override;
 
-  /**
-   * @brief expand string components:
-            $P  PATH to current project
-            #P  PATH and name of the current project
-            $S  PATH to Pack folder containing the Device description used by the current project
-            $D  Name of the device configured in the current project
-   * @param str string to be expanded
-   * @return expanded string
-  */
-  virtual std::string ExpandString(const std::string& str) override;
-
 protected:
   std::list<std::string> m_errorMessages;
   std::list<std::string> m_warningMessages;

--- a/tools/projmgr/src/ProjMgrCallback.cpp
+++ b/tools/projmgr/src/ProjMgrCallback.cpp
@@ -49,46 +49,4 @@ void ProjMgrCallback::OutputMessage(const string& message)
   }
 }
 
-string ProjMgrCallback::ExpandString(const string& str) {
-
-  const auto kernel = ProjMgrKernel::Get();
-  if (!kernel) {
-    return RteUtils::EMPTY_STRING;
-  }
-  const auto model = kernel->GetGlobalModel();
-  if (!model) {
-    return RteUtils::EMPTY_STRING;
-  }
-  const auto activeProject = model->GetActiveProject();
-  if (!activeProject) {
-    return RteUtils::EMPTY_STRING;
-  }
-  const auto activeTarget = activeProject->GetActiveTarget();
-  if (!activeTarget) {
-    return RteUtils::EMPTY_STRING;
-  }
-  const string& prjPath(activeProject->GetProjectPath());
-  const string& prjPathFile(prjPath + activeProject->GetName() + ".cprj");
-  const string& packPath(activeTarget->GetDevicePackage()->GetAbsolutePackagePath());
-  const string& deviceName(activeProject->GetActiveTarget()->GetDeviceName());
-
-  if (prjPath.empty() || prjPathFile.empty() || packPath.empty() || deviceName.empty()) {
-    return RteUtils::EMPTY_STRING;
-  }
-
-  auto replace = [](string& str, const string& toReplace, const string& with) {
-    size_t pos = str.find(toReplace);
-    while (pos != string::npos) {
-      str.replace(pos, 2, with);
-      pos = str.find(toReplace, pos + toReplace.size());
-    }
-  };
-
-  string res(str);
-  replace(res, "$P", prjPath);
-  replace(res, "#P", prjPathFile);
-  replace(res, "$S", packPath);
-  replace(res, "$D", deviceName);
-
-  return res;
-}
+// end of ProjMgrCallback.cpp

--- a/tools/projmgr/src/ProjMgrKernel.cpp
+++ b/tools/projmgr/src/ProjMgrKernel.cpp
@@ -21,6 +21,7 @@ static unique_ptr<ProjMgrKernel> theProjMgrKernel = 0;
 ProjMgrKernel::ProjMgrKernel() {
   m_callback = make_unique<ProjMgrCallback>();
   SetRteCallback(m_callback.get());
+  m_callback.get()->SetRteKernel(this);
 }
 
 ProjMgrKernel::~ProjMgrKernel() {


### PR DESCRIPTION
* Add $B processing to RteCallback::ExpandString()

Expands board name for the active target

* Add $B processing to RteCallback::ExpandString()

Expands board name for the active target
fix in RteUtils::ReplaceAll()

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>