### PR TITLE
packchk: Add a check for using forward slashes in <license> element Github#373 (#242)

### DIFF
--- a/tools/packchk/src/ValidateSyntax.cpp
+++ b/tools/packchk/src/ValidateSyntax.cpp
@@ -165,6 +165,18 @@ bool ValidateSyntax::CheckLicense(RtePackage* pKg, CheckFilesVisitor& fileVisito
     return true;
   }
 
+  if(XmlValueAdjuster::IsAbsolute(licPath)) {
+    LogMsg("M326", PATH(licPath));   // error : absolute paths are not permitted
+  }
+  else if(licPath.find('\\') != string::npos) {
+    if(XmlValueAdjuster::IsURL(licPath)) {
+      LogMsg("M370", URL(licPath));  // error : backslash are non permitted in URL
+    }
+    else {
+      LogMsg("M327", PATH(licPath)); // error : backslash are not recommended
+    }
+  }
+
   CheckFiles& checkFiles = fileVisitor.GetCheckFiles();
   if(!checkFiles.CheckFileExists(licPath, -1)) {
     return false;

--- a/tools/packchk/test/data/TestLicense/TestVendor.TestPackLicense.pdsc
+++ b/tools/packchk/test/data/TestLicense/TestVendor.TestPackLicense.pdsc
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<package schemaVersion="1.4" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+  <vendor>TestVendor</vendor>
+  <url>http://www.testurl.com/pack/</url>
+  <name>TestPackLicense</name>
+  <description>TestPackLicense</description>
+  <license>licenses\license.dat</license>
+
+  <releases>
+    <release version="0.0.1" date="2022-06-20">>
+      Initial release of TestPackLicense.
+    </release>
+  </releases>
+
+  <keywords>
+    <keyword>TestPackLicense</keyword>
+  </keywords>
+
+  <conditions>
+    <condition id="Test_Condition">
+      <description>Test Device</description>
+      <require Dvendor="ARM:82"/>
+    </condition>
+  </conditions>
+
+  <components>
+    <component Cclass="TestClass" Cgroup="TestGlobal" Cversion="1.0.0" condition="Test_Condition">
+      <description>TestGlobal</description>
+    </component>
+  </components>
+
+</package>

--- a/tools/packchk/test/data/TestLicense/licenses/license.dat
+++ b/tools/packchk/test/data/TestLicense/licenses/license.dat
@@ -1,0 +1,1 @@
+Test License

--- a/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
+++ b/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
@@ -332,3 +332,34 @@ TEST_F(PackChkIntegTests, CheckSemVer) {
     FAIL() << "Occurrences of M329, M393, M394, M396 are wrong.";
   }
 }
+
+
+// Validate license path
+TEST_F(PackChkIntegTests, CheckPackLicense) {
+  const char* argv[2];
+
+  const string& pdscFile = PackChkIntegTestEnv::localtestdata_dir +
+    "/TestLicense/TestVendor.TestPackLicense.pdsc";
+  ASSERT_TRUE(RteFsUtils::Exists(pdscFile));
+
+  argv[0] = (char*)"";
+  argv[1] = (char*)pdscFile.c_str();
+
+  PackChk packChk;
+  EXPECT_EQ(0, packChk.Check(2, argv, nullptr));
+
+  auto errMsgs = ErrLog::Get()->GetLogMessages();
+  bool bFound = false;
+  for (const string& msg : errMsgs) {
+    size_t s;
+    if ((s = msg.find("M327")) != string::npos) {
+      bFound = true;
+      break;
+    }
+  }
+
+  if (!bFound) {
+    FAIL() << "error: missing warning M327";
+  }
+
+}


### PR DESCRIPTION
added: check license path for slashes