### PR TITLE
[projmgr][buildmgr] Upgrade GCC support (#254)

### DIFF
--- a/.github/matrix_includes_buildmgr.json
+++ b/.github/matrix_includes_buildmgr.json
@@ -4,7 +4,9 @@
         "target":"darwin64",
         "arch": "amd64",
         "binary_extension":".mac",
+        "arm_gcc_install_base": "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4",
         "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2",
+        "toolchain_root": "gcc-arm-none-eabi-10-2020-q4-major/bin",
         "runOn": "publicRepo"
     },
     {
@@ -12,7 +14,9 @@
         "target":"linux64",
         "arch": "amd64",
         "binary_extension":".lin",
-        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2",
+        "arm_gcc_install_base": "https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel",
+        "installer_name": "gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz",
+        "toolchain_root": "gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin",
         "runOn": "always"
     },
     {
@@ -20,7 +24,9 @@
         "target":"linux64",
         "arch": "aarch64",
         "binary_extension":".lin",
-        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2",
+        "arm_gcc_install_base": "https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel",
+        "installer_name": "gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz",
+        "toolchain_root": "gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin",
         "runOn": "always"
     },
     {
@@ -28,7 +34,9 @@
         "target":"windows64",
         "arch": "amd64",
         "binary_extension":".exe",
-        "installer_name": "gcc-arm-none-eabi-10-2020-q4-major-win32.zip",
+        "arm_gcc_install_base": "https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel",
+        "installer_name": "gcc-arm-11.2-2022.02-mingw-w64-i686-arm-none-eabi.zip",
+        "toolchain_root": "gcc-arm-11.2-2022.02-mingw-w64-i686-arm-none-eabi/bin",
         "runOn": "always"
     }
 ]

--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -269,11 +269,11 @@ jobs:
     timeout-minutes: 15
     runs-on: ${{ matrix.runs_on }}
     env:
-      arm_gcc_install_base: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4
+      arm_gcc_install_base: ${{ matrix.arm_gcc_install_base }}
       CI_CBUILD_DEB_PKG: ${{ github.workspace }}
       CI_CBUILD_INSTALLER: ${{ github.workspace }}/cbuild_install.sh
       CI_PACK_ROOT: ${{ github.workspace }}/packs
-      CI_GCC_TOOLCHAIN_ROOT: ${{ github.workspace }}/gcc-arm-none-eabi-10-2020-q4-major/bin
+      CI_GCC_TOOLCHAIN_ROOT: ${{ github.workspace }}/${{ matrix.toolchain_root }}
     strategy:
       fail-fast: true
       matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
@@ -319,7 +319,7 @@ jobs:
           installer_name: ${{ matrix.installer_name }}
         run: |
           wget -q $Env:arm_gcc_install_base/$Env:installer_name
-          unzip $Env:installer_name
+          unzip -o $Env:installer_name
           del $Env:installer_name
 
       - name: Cache CMSIS Pack
@@ -424,10 +424,10 @@ jobs:
         (github.event_name == 'push') ||
         (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/buildmgr/'))
     env:
-        installer_name: "gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
-        arm_gcc_install_base: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4
+        installer_name: "gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz"
+        arm_gcc_install_base: https://developer.arm.com/-/media/Files/downloads/gnu/11.2-2022.02/binrel
         CI_PACK_ROOT: ${{ github.workspace }}/packs
-        CI_GCC_TOOLCHAIN_ROOT: ${{ github.workspace }}/gcc-arm-none-eabi-10-2020-q4-major/bin
+        CI_GCC_TOOLCHAIN_ROOT: ${{ github.workspace }}/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:

--- a/tools/buildmgr/cbuildgen/config/GCC.11.2.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/GCC.11.2.1.cmake
@@ -1,6 +1,6 @@
 # This file maps the CMSIS project options to toolchain settings.
 #
-#   - Applies to toolchain: GNU Arm Embedded Toolchain 10-2020-q4-major 10.2.1
+#   - Applies to toolchain: GNU Toolchain for the Arm Architecture 11.2.1 (11.2-2022.02)
 
 ############### EDIT BELOW ###############
 # Set base directory of toolchain
@@ -155,8 +155,8 @@ else()
 endif()
 
 set (CC_SYS_INC_PATHS_LIST
-  "${TOOLCHAIN_ROOT}/../lib/gcc/arm-none-eabi/10.2.1/include"
-  "${TOOLCHAIN_ROOT}/../lib/gcc/arm-none-eabi/10.2.1/include-fixed"
+  "${TOOLCHAIN_ROOT}/../lib/gcc/arm-none-eabi/11.2.1/include"
+  "${TOOLCHAIN_ROOT}/../lib/gcc/arm-none-eabi/11.2.1/include-fixed"
   "${TOOLCHAIN_ROOT}/../arm-none-eabi/include"
 )
 foreach(ENTRY ${CC_SYS_INC_PATHS_LIST})
@@ -172,9 +172,9 @@ set(CXX_SECURE "${CC_SECURE}")
 set(CXX_FLAGS "${CC_FLAGS}")
 
 set (CXX_SYS_INC_PATHS_LIST
-  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/10.2.1"
-  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/10.2.1/arm-none-eabi"
-  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/10.2.1/backward"
+  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/11.2.1"
+  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/11.2.1/arm-none-eabi"
+  "${TOOLCHAIN_ROOT}/../arm-none-eabi/include/c++/11.2.1/backward"
   "${CC_SYS_INC_PATHS_LIST}"
 )
 foreach(ENTRY ${CXX_SYS_INC_PATHS_LIST})
@@ -221,7 +221,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMakeASM")
 set(CMAKE_ASM_COMPILER_FORCED TRUE)
 set(CMAKE_C_COMPILER_ID "GNU")
 set(CMAKE_C_COMPILER_ID_RUN TRUE)
-set(CMAKE_C_COMPILER_VERSION "10.2.1")
+set(CMAKE_C_COMPILER_VERSION "11.2.1")
 set(CMAKE_C_COMPILER_FORCED TRUE)
 set(CMAKE_C_COMPILER_WORKS TRUE)
 set(CMAKE_CXX_COMPILER_ID "${CMAKE_C_COMPILER_ID}")

--- a/tools/buildmgr/cbuildgen/installer/install.sh
+++ b/tools/buildmgr/cbuildgen/installer/install.sh
@@ -136,7 +136,7 @@ case $OS in
     cmsis_compiler_root_default_path=$(unixpath "${LOCALAPPDATA}/Arm/Compilers")
     compiler6_default_path=$(unixpath "${PROGRAMFILES}/ArmCompilerforEmbedded6.18/bin")
     compiler5_default_path=$(unixpath "${PROGRAMFILES} (x86)/ARM_Compiler_5.06u7/bin")
-    gcc_default_path=$(unixpath "${PROGRAMFILES} (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin")
+    gcc_default_path=$(unixpath "${PROGRAMFILES} (x86)/Arm GNU Toolchain arm-none-eabi/11.2 2022.02/bin")
     iar_default_path=$(unixpath "${PROGRAMFILES} (x86)/IAR Systems/Embedded Workbench 8.4/arm/bin")
     extension=".exe"
     ;;
@@ -150,7 +150,7 @@ case $OS in
     cmsis_compiler_root_default_path=$(wslpath "${localappdata}\Arm\Compilers")
     compiler6_default_path=$(wslpath "${programfiles}/ArmCompilerforEmbedded6.18/bin")
     compiler5_default_path=$(wslpath "${programfiles} (x86)/ARM_Compiler_5.06u7/bin")
-    gcc_default_path=$(wslpath "${programfiles} (x86)/GNU Arm Embedded Toolchain/10 2020-q4-major/bin")
+    gcc_default_path=$(wslpath "${programfiles} (x86)/Arm GNU Toolchain arm-none-eabi/11.2 2022.02/bin")
     iar_default_path=$(wslpath "${programfiles} (x86)/IAR Systems/Embedded Workbench 8.4/arm/bin")
     extension=".exe"
     ;;
@@ -161,7 +161,7 @@ case $OS in
     cmsis_compiler_root_default_path=${HOME}/.cache/arm/compilers
     compiler6_default_path=${HOME}/ArmCompilerforEmbedded6.18/bin
     compiler5_default_path=${HOME}/ARM_Compiler_5.06u7/bin
-    gcc_default_path=${HOME}/gcc-arm-none-eabi-10-2020-q4-major/bin
+    gcc_default_path=${HOME}/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi/bin
     iar_default_path=/opt/iarsystems/bxarm/arm/bin
     extension=""
     ;;
@@ -202,7 +202,7 @@ else
 fi
 
 # ask for gcc installation path
-read -e -p "Enter the installed GNU Arm Embedded Toolchain Version 10.2.1 (10-2020-q4-major) directory [${gcc_default_path}]: " gcc_root
+read -e -p "Enter the installed GNU Arm Embedded Toolchain Version 11.2.1 (11.2-2022.02) directory [${gcc_default_path}]: " gcc_root
 gcc_root=${gcc_root:-${gcc_default_path}}
 if [[ -d "${gcc_root}" ]]
   then
@@ -321,7 +321,7 @@ script="${cmsis_compiler_root}/AC5.5.6.7.cmake"
 sed -e "s|set(TOOLCHAIN_ROOT.*|set(TOOLCHAIN_ROOT \"${compiler5_root}\")|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 sed -e "s|set(EXT.*|set(EXT ${extension})|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 
-script="${cmsis_compiler_root}/GCC.10.2.1.cmake"
+script="${cmsis_compiler_root}/GCC.11.2.1.cmake"
 sed -e "s|set(TOOLCHAIN_ROOT.*|set(TOOLCHAIN_ROOT \"${gcc_root}\")|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 sed -e "s|set(EXT.*|set(EXT ${extension})|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 

--- a/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
@@ -49,7 +49,7 @@ void DebPkgTests::ExtractPackage(const string& pkg, const string& extPath) {
 void DebPkgTests::ValidateExtract(const string& extPath) {
   vector<string> pathVec = {
     "./etc/cmsis-build/AC5.5.6.7.cmake", "./etc/cmsis-build/AC6.6.18.0.cmake",
-    "./etc/cmsis-build/CPRJ.xsd", "./etc/cmsis-build/GCC.10.2.1.cmake",
+    "./etc/cmsis-build/CPRJ.xsd", "./etc/cmsis-build/GCC.11.2.1.cmake",
     "./etc/cmsis-build/setup",
     "./etc/profile.d/cmsis-build.sh", "./usr/bin/cbuild.sh",
     "./usr/bin/cpackget",
@@ -59,7 +59,7 @@ void DebPkgTests::ValidateExtract(const string& extPath) {
     "./usr/lib/cmsis-build/bin/cbuildgen",
     "./usr/lib/cmsis-build/bin/cpackget",
     "./usr/lib/cmsis-build/etc/AC5.5.6.7.cmake", "./usr/lib/cmsis-build/etc/AC6.6.18.0.cmake",
-    "./usr/lib/cmsis-build/etc/CPRJ.xsd", "./usr/lib/cmsis-build/etc/GCC.10.2.1.cmake",
+    "./usr/lib/cmsis-build/etc/CPRJ.xsd", "./usr/lib/cmsis-build/etc/GCC.11.2.1.cmake",
     "./usr/lib/cmsis-build/etc/setup",
     "./usr/share/doc/cmsis-build/copyright",
     "./usr/share/doc/cmsis-build/doc/index.html"

--- a/tools/buildmgr/test/integrationtests/src/InstallerTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/InstallerTests.cpp
@@ -48,7 +48,7 @@ void InstallerTests::CheckInstallationDir(const string& path, bool expect) {
 #endif
     { "doc", vector<string>{ "index.html", "html"} },
     { "etc", vector<string>{ "AC5.5.6.7.cmake", "AC6.6.18.0.cmake", "CPRJ.xsd",
-      "GCC.10.2.1.cmake", "IAR.8.50.6.cmake", "setup"} }
+      "GCC.11.2.1.cmake", "IAR.8.50.6.cmake", "setup"} }
   };
 
   error_code ec;
@@ -72,7 +72,7 @@ void InstallerTests::CheckExtractedDir(const string& path, bool expect) {
       "cpackget.lin", "cpackget.exe"} },
     { "doc", vector<string>{ "index.html", "html"} },
     { "etc", vector<string>{"AC5.5.6.7.cmake", "AC6.6.18.0.cmake", "CPRJ.xsd",
-      "GCC.10.2.1.cmake", "IAR.8.50.6.cmake", "setup"} }
+      "GCC.11.2.1.cmake", "IAR.8.50.6.cmake", "setup"} }
   };
 
   error_code ec;

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -637,7 +637,7 @@ bool ProjMgrWorker::ProcessToolchain(ContextItem& context) {
     static const map<string, string> DEF_MIN_VERSIONS = {
       {"AC5","5.6.7"},
       {"AC6","6.18.0"},
-      {"GCC","10.2.1"},
+      {"GCC","11.2.1"},
       {"IAR","8.50.6"},
     };
     for (const auto& defMinVersion: DEF_MIN_VERSIONS) {

--- a/tools/projmgr/test/data/TestDefault/ref/build-types/project.Debug.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/build-types/project.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/build-types/project.Release.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/build-types/project.Release.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/GCC/test1.Release+TypeA.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/GCC/test1.Release+TypeA.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/GCC/test1.Release+TypeB.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/GCC/test1.Release+TypeB.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0.cprj
@@ -11,7 +11,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0_board_package.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0_board_package.cprj
@@ -12,7 +12,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="10.2.1"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Bname="RteTest board listing" Bvendor="Keil" Bversion="Rev.C" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">


### PR DESCRIPTION
Don't upgrade GCC in MacOS CI due to the following bug:
https://bugs.linaro.org/show_bug.cgi?id=5867