### PR TITLE
Update GH Actions macOS environment

### DIFF
--- a/.github/matrix_includes_buildmgr.json
+++ b/.github/matrix_includes_buildmgr.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "binary_extension":".mac",

--- a/.github/matrix_includes_packchk.json
+++ b/.github/matrix_includes_packchk.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "runOn": "publicRepo"

--- a/.github/matrix_includes_packgen.json
+++ b/.github/matrix_includes_packgen.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "binary": "packgen",

--- a/.github/matrix_includes_projmgr.json
+++ b/.github/matrix_includes_projmgr.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "binary": "csolution",

--- a/.github/matrix_includes_test_libs.json
+++ b/.github/matrix_includes_test_libs.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "runOn": "publicRepo"

--- a/.github/matrix_includes_toolbox.json
+++ b/.github/matrix_includes_toolbox.json
@@ -1,6 +1,6 @@
 [
     {
-        "runs_on":"macos-10.15",
+        "runs_on":"macos-12",
         "target":"darwin64",
         "arch": "amd64",
         "runOn": "publicRepo"

--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/buildmgr.yml'
+      - '.github/matrix_includes_buildmgr.json'
       - 'CMakeLists.txt'
       - 'libs/crossplatform/**'
       - 'libs/errlog/**'
@@ -18,7 +19,17 @@ on:
       - main
     paths:
       - '.github/workflows/buildmgr.yml'
-      - 'tools/buildmgr/docs/**'
+      - '.github/matrix_includes_buildmgr.json'
+      - 'CMakeLists.txt'
+      - 'libs/crossplatform/**'
+      - 'libs/errlog/**'
+      - 'libs/xmlreader/**'
+      - 'libs/xmltree/**'
+      - 'libs/xmltreeslim/**'
+      - 'libs/rteutils/**'
+      - 'libs/rtemodel/**'
+      - 'libs/rtefsutils/**'
+      - 'tools/buildmgr/**'
   release:
     types: [ published ]
 

--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - '.github/workflows/packchk.yml'
       - '.github/workflows/unit_test_results.yml'
+      - '.github/matrix_includes_packchk.json'
       - 'CMakeLists.txt'
       - 'tools/packchk/**'
   pull_request:
     paths:
       - '.github/workflows/packchk.yml'
       - '.github/workflows/unit_test_results.yml'
+      - '.github/matrix_includes_packchk.json'
       - 'CMakeLists.txt'
       - 'tools/packchk/**'
   release:

--- a/.github/workflows/packgen.yml
+++ b/.github/workflows/packgen.yml
@@ -1,8 +1,22 @@
 name: packgen
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/packgen.yml'
+      - '.github/matrix_includes_packgen.json'
+      - 'CMakeLists.txt'
+      - 'libs/crossplatform/**'
+      - 'libs/rtefsutils/**'
+      - 'libs/xmlreader/**'
+      - 'libs/xmltree/**'
+      - 'libs/xmltreeslim/**'
+      - 'tools/packgen/**'
   pull_request:
     paths:
       - '.github/workflows/packgen.yml'
+      - '.github/matrix_includes_packgen.json'
       - 'CMakeLists.txt'
       - 'libs/crossplatform/**'
       - 'libs/rtefsutils/**'

--- a/.github/workflows/projmgr.yml
+++ b/.github/workflows/projmgr.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - '.github/workflows/projmgr.yml'
+      - '.github/matrix_includes_projmgr.json'
       - 'CMakeLists.txt'
       - 'libs/crossplatform/**'
       - 'libs/rtefsutils/**'
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/projmgr.yml'
+      - '.github/matrix_includes_projmgr.json'
       - 'CMakeLists.txt'
       - 'libs/crossplatform/**'
       - 'libs/rtefsutils/**'

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -1,8 +1,16 @@
 name: test_libs
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/test_libs.yml'
+      - '.github/matrix_includes_test_libs.json'
+      - 'libs/**'
   pull_request:
     paths:
       - '.github/workflows/test_libs.yml'
+      - '.github/matrix_includes_test_libs.json'
       - 'libs/**'
 
 jobs:

--- a/.github/workflows/toolbox.yml
+++ b/.github/workflows/toolbox.yml
@@ -1,8 +1,17 @@
 name: toolbox
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/toolbox.yml'
+      - '.github/matrix_includes_toolbox.json'
+      - 'CMakeLists.txt'
+      - 'tools/toolbox/**'
   pull_request:
     paths:
       - '.github/workflows/toolbox.yml'
+      - '.github/matrix_includes_toolbox.json'
       - 'CMakeLists.txt'
       - 'tools/toolbox/**'
   release:

--- a/libs/crossplatform/src/LinuxDarwin_Process.cpp
+++ b/libs/crossplatform/src/LinuxDarwin_Process.cpp
@@ -105,7 +105,7 @@ bool ProcessRunner::Terminate(ProcInfo pinfo) {
 
 bool ProcessRunner::IsRunning(ProcInfo pinfo, unsigned int waitTimeSec) {
   int status;
-  waitpid(pinfo.pid, &status, WNOHANG);
+  int w = waitpid(pinfo.pid, &status, WNOHANG);
 
-  return !(WIFEXITED(status) || WIFSTOPPED(status));
+  return (w == 0) || !(WIFEXITED(status) || WIFSTOPPED(status));
 }


### PR DESCRIPTION
The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583