### PR TITLE
Don't require file to exist when normalizing path

### DIFF
--- a/libs/rtefsutils/include/RteFsUtils.h
+++ b/libs/rtefsutils/include/RteFsUtils.h
@@ -248,9 +248,8 @@ public:
    * @brief normalize path by ensuring that it's absolute and canonical
    * @param path folder to be normalized
    * @param base root folder to form absolute
-   * @return true if path is normalized
   */
-  static bool NormalizePath(std::string& path, std::string base = "");
+  static void NormalizePath(std::string& path, const std::string& base = RteUtils::EMPTY_STRING);
   /**
    * @brief scan given directory for regular files with given extension
    * @param path directory to look in

--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -561,18 +561,10 @@ bool RteFsUtils::CreateDirectories(const string &_path) {
   return fs::exists(path, ec);
 }
 
-bool RteFsUtils::NormalizePath(string& path, string base) {
-  // [fs::canonical] make sure there are no backslashes and path must exist
-  path = fs::path(path).is_absolute() ? path : base + path;
-  error_code ec;
-  if (!fs::exists(path, ec)) {
-    return false;
-  }
-  path = fs::canonical(path, ec).generic_string();
-  if (ec) {
-    return false;
-  }
-  return true;
+void RteFsUtils::NormalizePath(string& path, const string& base) {
+  path = (fs::path(base) / fs::path(path)).lexically_normal().generic_string();
+  if (path.size() > 1 && path.back() == '/')
+    path.erase(path.size() - 1);
 }
 
 string RteFsUtils::FindFirstFileWithExt(const std::string &folder, const char *extension) {

--- a/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
+++ b/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
@@ -899,21 +899,12 @@ TEST_F(RteFsUtilsTest, FindFiles) {
 }
 
 TEST_F(RteFsUtilsTest, NormalizePath) {
-  error_code ec;
-  bool result;
   string path, base;
-  path = "Test";
+  path = "Test/.//foo/bar/../baz.h";
   base = dirnameBase + "/";
 
-  if (RteFsUtils::Exists(base + path)) {
-    fs::remove(base + path, ec);
-  }
-  result = RteFsUtils::NormalizePath(path, base);
-  EXPECT_FALSE(result);
-
-  RteFsUtils::CreateDirectories(path);
-  result = RteFsUtils::NormalizePath(path);
-  EXPECT_TRUE(result);
+  RteFsUtils::NormalizePath(path, base);
+  EXPECT_EQ(path, base + "Test/foo/baz.h");
 }
 
 TEST_F(RteFsUtilsTest, FindFirstFileWithExt) {

--- a/libs/rtemodel/src/RteKernel.cpp
+++ b/libs/rtemodel/src/RteKernel.cpp
@@ -339,7 +339,8 @@ string RteKernel::GetPdscFileFromPath(const RteAttributes& attributes, const str
   const string& version = attributes.GetAttribute("version");
 
   string packPath = attributes.GetAttribute("path");
-  if (!RteFsUtils::NormalizePath(packPath, cprjPath + '/')) {
+  RteFsUtils::NormalizePath(packPath, cprjPath + '/');
+  if (!RteFsUtils::Exists(packPath)) {
     GetRteCallback()->Err("R822", R822, packPath);
   } else {
     const auto& pdscFilesList = RteFsUtils::FindFiles(packPath, ".pdsc");

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -361,21 +361,24 @@ bool CbuildModel::EvaluateResult() {
     if (!define.empty()) m_targetDefines.push_back(define);
   }
   for (auto inc : m_cprjTarget->GetIncludePaths()) {
-    if (!RteFsUtils::NormalizePath(inc, m_prjFolder)) {
+    RteFsUtils::NormalizePath(inc, m_prjFolder);
+    if (!RteFsUtils::Exists(inc)) {
       LogMsg("M204", PATH(inc));
       return false;
     }
     if (!inc.empty()) m_targetIncludePaths.push_back(inc);
   }
   for (auto lib : m_cprjTarget->GetLibraries()) {
-    if (!RteFsUtils::NormalizePath(lib, m_prjFolder)) {
+    RteFsUtils::NormalizePath(lib, m_prjFolder);
+    if (!RteFsUtils::Exists(lib)) {
       LogMsg("M204", PATH(lib));
       return false;
     }
     if (!lib.empty()) m_libraries.push_back(lib);
   }
   for (auto obj : m_cprjTarget->GetObjects()) {
-    if (!RteFsUtils::NormalizePath(obj, m_prjFolder)) {
+    RteFsUtils::NormalizePath(obj, m_prjFolder);
+    if (!RteFsUtils::Exists(obj)) {
       LogMsg("M204", PATH(obj));
       return false;
     }
@@ -474,7 +477,8 @@ bool CbuildModel::EvalPreIncludeFiles() {
       const string& baseFolder = (file == "Pre_Include_Global.h" || file == preIncludeLocal) ?
         m_prjFolder + m_cprjProject->GetRteFolder() + "/_" + WildCards::ToX(m_cprjTarget->GetName()) + "/" :
         m_prjFolder;
-      if (!RteFsUtils::NormalizePath(file, baseFolder)) {
+      RteFsUtils::NormalizePath(file, baseFolder);
+      if (!RteFsUtils::Exists(file)) {
         LogMsg("M204", PATH(file));
         return false;
       }
@@ -653,7 +657,8 @@ bool CbuildModel::EvalGeneratedSourceFiles() {
               continue;
             }
             string filepath = file->GetName();
-            if (!RteFsUtils::NormalizePath(filepath, gpdscPath)) {
+            RteFsUtils::NormalizePath(filepath, gpdscPath);
+            if (!RteFsUtils::Exists(filepath)) {
               LogMsg("M204", PATH(filepath));
               return false;
             }
@@ -697,7 +702,8 @@ bool CbuildModel::EvalFile(RteItem* file, const string& group, const string& bas
     const string & path = f->GetAttribute("path");
     filepath = (path.empty() ? fs::path(filepath).remove_filename().generic_string() : path);
   }
-  if (!RteFsUtils::NormalizePath(filepath, base)) {
+  RteFsUtils::NormalizePath(filepath, base);
+  if (!RteFsUtils::Exists(filepath)) {
     LogMsg("M204", PATH(filepath));
     return false;
   }
@@ -1028,7 +1034,8 @@ bool CbuildModel::EvalFlags() {
       m_targetLdFlags = SplitArgs(ldflags->GetAttribute("add"));
       m_linkerScript = ldflags->GetAttribute("file");
       if (!m_linkerScript.empty()) {
-        if (!RteFsUtils::NormalizePath(m_linkerScript, m_prjFolder)) {
+        RteFsUtils::NormalizePath(m_linkerScript, m_prjFolder);
+        if (!RteFsUtils::Exists(m_linkerScript)) {
           LogMsg("M204", PATH(m_linkerScript));
           return false;
         }
@@ -1136,7 +1143,8 @@ bool CbuildModel::EvalRteSourceFiles(map<string, list<string>> &cSourceFiles, ma
     for (auto file : grp.second) {
       const RteFile::Category& cat = file.second.m_cat;
       string filepath = file.first;
-      if (!RteFsUtils::NormalizePath(filepath, m_cprjProject->GetProjectPath())) {
+      RteFsUtils::NormalizePath(filepath, m_cprjProject->GetProjectPath());
+      if (!RteFsUtils::Exists(filepath)) {
         LogMsg("M204", PATH(filepath));
         return false;
       }

--- a/tools/packgen/src/PackGen.cpp
+++ b/tools/packgen/src/PackGen.cpp
@@ -961,7 +961,8 @@ bool PackGen::CheckPack(void) {
 
     // External PDSC references
     for (auto& externalPdsc : m_externalPdsc) {
-      if (RteFsUtils::NormalizePath(externalPdsc, workingDir.generic_string() + "/")) {
+      RteFsUtils::NormalizePath(externalPdsc, workingDir.generic_string() + "/");
+      if (RteFsUtils::Exists(externalPdsc)) {
         pdscList += " -i \"" + externalPdsc + "\"";
       }
     }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -186,12 +186,14 @@ bool ProjMgrWorker::GetRequiredPdscFiles(ContextItem& context, const std::string
       }
     } else {
       string packPath = packItem.path;
-      if (!RteFsUtils::NormalizePath(packPath, context.csolution->directory + "/")) {
+      RteFsUtils::NormalizePath(packPath, context.csolution->directory + "/");
+      if (!RteFsUtils::Exists(packPath)) {
         errMsgs.insert("pack path: " + packItem.path + " does not exist");
         break;
       }
       string pdscFile = packItem.pack.vendor + '.' + packItem.pack.name + ".pdsc";
-      if (!RteFsUtils::NormalizePath(pdscFile, packPath + "/")) {
+      RteFsUtils::NormalizePath(pdscFile, packPath + "/");
+      if (!RteFsUtils::Exists(pdscFile)) {
         errMsgs.insert("pdsc file was not found in: " + packItem.path);
         break;
       } else {


### PR DESCRIPTION
Split path normalizing and existence check as a preparation to make existence check optional. This shouldn't affect behavior.

Prerequisite for #432

Contributed by STMicroelectronics

Signed-off-by: Erik LUNDIN <erik.lundin@st.com>