### PR TITLE
Test case for device dependent components (#287)

### DIFF
--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -299,8 +299,13 @@ TEST_F(RteModelPrjTest, LoadCprjConfigVer) {
   EXPECT_TRUE(RteFsUtils::Exists(deviceDir + ".system_ARMCM3.c@1.0.1"));
   EXPECT_FALSE(RteFsUtils::Exists(deviceDir + ".system_ARMCM3.c@1.0.2"));
   EXPECT_TRUE(RteFsUtils::Exists(deviceDir + "system_ARMCM3.c@1.0.2"));
-}
 
+  const string depsDir = rteDir + "Dependency/RteTest_ARMCM3/";
+  EXPECT_TRUE(RteFsUtils::Exists(depsDir + ".DeviceDependency.c@1.1.1"));
+  EXPECT_TRUE(RteFsUtils::Exists(depsDir + "DeviceDependency.c"));
+  EXPECT_TRUE(RteFsUtils::Exists(depsDir + ".BoardDependency.c@1.2.2"));
+  EXPECT_TRUE(RteFsUtils::Exists(depsDir + "BoardDependency.c"));
+}
 
 TEST_F(RteModelPrjTest, GetLocalPdscFile) {
   RteKernelSlim rteKernel;

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -250,19 +250,37 @@
       <require Cclass="RteTest" Cgroup="CORE"/>
     </condition>
 
+    <condition id="DeviceDependent">
+      <description>Checks device dependency</description>
+      <accept condition="ARMCM0 RteTest"/>
+      <accept condition="ARMCM3 RteTest"/>
+      <accept condition="ARMCM4 RteTest"/>
+    </condition>
 
      <condition id="BoardTest1">
-      <description>Generic Arm Cortex-M4 device startup and depends on CMSIS Core</description>
+      <description>Test component filtering on selected board 1</description>
       <require Dvendor="ARM:82" Dname="*ARMCM*"/>
       <require Bname="RteTest Test board*" Bvendor="Keil" Brevision="1.1.1"/>
     </condition>
 
     <condition id="BoardTest2">
-      <description>Generic Arm Cortex-M4 device startup and depends on CMSIS Core</description>
+      <description>Test component filtering on selected board 2</description>
       <require Dvendor="ARM:82" Dname="*ARMCM*"/>
       <require Bname="RteTest Test board*" Bvendor="Keil" Brevision="2.2.2"/>
     </condition>
 
+    <condition id="BoardTest3">
+      <description>Test component filtering on selected board 3</description>
+      <require Dvendor="ARM:82" Dname="*ARMCM*"/>
+      <require Bname="RteTest Dummy board" Bvendor="Keil" Brevision="1.2.3"/>
+    </condition>
+    
+    <condition id="BoardDependent">
+      <description>Checks board dependency</description>
+      <accept condition="BoardTest1"/>
+      <accept condition="BoardTest2"/>
+      <accept condition="BoardTest3"/>
+    </condition>
   </conditions>
 
   <apis>
@@ -384,6 +402,19 @@
       </files>
     </component>
 
+    <component Cclass="Dependency" Cgroup="Board" Cversion="1.2.2" condition="BoardDependent">
+      <description>Dependency on board</description>
+      <files>
+        <file attr="config" category="sourceC" name="Components/BoardDependency.c" />
+      </files>
+    </component>
+
+    <component Cclass="Dependency" Cgroup="Device" Cversion="1.1.1" condition="DeviceDependent">
+      <description>Dependency on device</description>
+      <files>
+        <file attr="config" category="sourceC" name="Components/DeviceDependency.c" />
+      </files>
+    </component>
 
   </components>
 

--- a/test/packs/ARM/RteTest_DFP/0.2.0/Components/BoardDependency.c
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/Components/BoardDependency.c
@@ -1,0 +1,2 @@
+// Board_Dependency
+

--- a/test/packs/ARM/RteTest_DFP/0.2.0/Components/DeviceDependency.c
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/Components/DeviceDependency.c
@@ -1,0 +1,2 @@
+// Device_Dependency
+

--- a/test/projects/RteTestM3/RteTestM3_ConfigFolder.cprj
+++ b/test/projects/RteTestM3/RteTestM3_ConfigFolder.cprj
@@ -38,6 +38,12 @@
   </target>
 
   <components>
+    <component Cclass="Dependency" Cgroup="Device" Cvendor="ARM" Cversion="1.1.1">
+      <file attr="config" category="sourceC" name="Components/DeviceDependency.c" version="1.1.1"/>
+    </component>
+    <component Cclass="Dependency" Cgroup="Board" Cvendor="ARM" Cversion="1.2.2">
+      <file attr="config" category="sourceC" name="Components/BoardDependency.c" version="1.2.2"/>
+    </component>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" layer="LayerOne">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>


### PR DESCRIPTION
* Bugfix to check if component is device dependent

follow referenced condition instead of returning false
unit test
