### PR TITLE
[buildmgr] Add duplicated filenames test case (#285)

### DIFF
--- a/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
+++ b/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
@@ -249,6 +249,14 @@
         <file category="other" name="Dummy/DummyFile.txt"/>
       </files>
     </component>
+
+    <component Cclass="RteTest" Cgroup="DupFilename" Cversion="0.9.9">
+      <description>Component having source files with the same filename</description>
+      <files>
+        <file category="sourceC" name="Dummy/dummy.c"/>
+        <file category="sourceC" name="Dummy/Subfolder/dummy.c"/>
+      </files>
+    </component>
   </components>
 
   <examples>

--- a/test/packs/ARM/RteTest/0.1.0/Dummy/Subfolder/dummy.c
+++ b/test/packs/ARM/RteTest/0.1.0/Dummy/Subfolder/dummy.c
@@ -1,0 +1,4 @@
+
+int Dummy2(int i) {
+    return 1;
+}

--- a/test/packs/ARM/RteTest/0.1.0/Dummy/dummy.c
+++ b/test/packs/ARM/RteTest/0.1.0/Dummy/dummy.c
@@ -1,0 +1,4 @@
+
+int Dummy1(int i) {
+    return 1;
+}

--- a/tools/buildmgr/test/integrationtests/src/CBuildGCCTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildGCCTests.cpp
@@ -222,6 +222,15 @@ TEST_F(CBuildGCCTests, Minimal) {
   CheckCMakeLists         (param);
 }
 
+// Validate project compilation having components sources with same filenames
+TEST_F(CBuildGCCTests, DupFilename) {
+  TestParam param = { "GCC/DupFilename", "Project" };
+
+  RunCBuildScriptClean(param);
+  RunCBuildScript(param);
+  CheckCMakeLists(param);
+}
+
 // Validate project with preincluded header paths and their usage
 TEST_F(CBuildGCCTests, PreInclude) {
   TestParam param = { "GCC/Pre Include", "Target", "", "", true };

--- a/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
@@ -10,10 +10,12 @@ using namespace std;
 
 string scripts_folder   = string(TEST_SRC_FOLDER) + "scripts";
 string testinput_folder = string(TEST_SRC_FOLDER) + "testinput";
+string testpacks_folder = string(TEST_SRC_FOLDER) + "../../../test/packs";
 string cbuildgen_bin    = string(CBUILDGEN_BIN);
 string testout_folder   = string(TEST_BUILD_FOLDER) + "testoutput";
 string testdata_folder  = string(TEST_BUILD_FOLDER) + "/testdata";
 string examples_folder  = testdata_folder + "/Examples";
+string packs_folder     = testdata_folder + "/Packs";
 
 std::string CBuildIntegTestEnv::ci_installer_path;
 std::string CBuildIntegTestEnv::ac6_toolchain_path;
@@ -41,6 +43,7 @@ void CBuildIntegTestEnv::SetUp() {
 
   // Copy test data from input test folder
   fs::copy(fs::path(testinput_folder), fs::path(testdata_folder), fs::copy_options::recursive, ec);
+  fs::copy(fs::path(testpacks_folder), fs::path(packs_folder), fs::copy_options::recursive, ec);
 
   examples_folder  = fs::canonical(examples_folder, ec).generic_string();
   scripts_folder   = fs::canonical(scripts_folder, ec).generic_string();

--- a/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/CMakeLists.txt.ref
@@ -1,0 +1,61 @@
+# CMSIS Build CMakeLists generated on 2022-08-23T15:48:24
+
+cmake_minimum_required(VERSION 3.18)
+
+# Target options
+
+set(TARGET Project)
+set(CPU Cortex-M0)
+set(PRJ_DIR "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Examples/GCC/DupFilename")
+set(OUT_DIR "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Examples/GCC/DupFilename/OutDir")
+set(INT_DIR "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Examples/GCC/DupFilename/IntDir")
+set(FPU NO_FPU)
+set(SECURE Non-secure)
+set(CC_FLAGS_GLOBAL "-O -Wall -gdwarf-2 -mapcs-frame -mthumb")
+set(LD_FLAGS_GLOBAL "--specs=nosys.specs -mcpu=cortex-m3 -mthumb")
+
+set(DEFINES
+  ARMCM0
+  _RTE_
+)
+
+set(INC_PATHS
+  "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Examples/GCC/DupFilename/RTE/_Project"
+  "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Packs/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include"
+)
+
+set(CC_SRC_FILES
+  "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Examples/GCC/DupFilename/main.c"
+  "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Packs/ARM/RteTest/0.1.0/Dummy/Subfolder/dummy.c"
+  "C:/sandbox/build/tools/buildmgr/test/integrationtests/testdata/Packs/ARM/RteTest/0.1.0/Dummy/dummy.c"
+)
+
+# Toolchain config map
+
+include ("C:/sandbox/build/tools/buildmgr/test/integrationtests/testoutput/cbuild/etc/GCC.11.2.1.cmake")
+
+# Setup project
+
+project(${TARGET} LANGUAGES C)
+
+# Global Flags
+
+set(CMAKE_C_FLAGS "${CC_CPU} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
+set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
+
+# Compilation Database
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different "${INT_DIR}/compile_commands.json" "${OUT_DIR}")
+
+# Setup Target
+
+add_executable(${TARGET} ${CC_SRC_FILES})
+set(CMAKE_EXECUTABLE_SUFFIX ${EXE_SUFFIX})
+set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${OUT_DIR})
+target_include_directories(${TARGET} PUBLIC ${INC_PATHS})
+
+# Bin and Hex Conversion
+
+add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} ${ELF2HEX})
+add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} ${ELF2BIN})

--- a/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/Project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/Project.cprj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-08-23T15:23:33" tool="csolution 1.0.0"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest" path="../../../Packs/ARM/RteTest/0.1.0" vendor="ARM" version="0.1.0:0.1.0"/>
+    <package name="RteTest_DFP" path="../../../Packs/ARM/RteTest_DFP/0.2.0" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="GCC" version="9.2.1"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output name="Project" rtedir="RTE" type="exe"/>
+    <ldflags add=" --specs=nosys.specs -mcpu=cortex-m3 -mthumb" compiler="GCC" />
+    <cflags add="-O -Wall -gdwarf-2 -mapcs-frame -mthumb" compiler="GCC"/>
+  </target>
+
+  <components>
+    <component Cclass="RteTest" Cgroup="DupFilename" Cvendor="ARM" Cversion="0.9.9"/>
+  </components>
+
+  <files>
+    <group name="Sources">
+      <file category="sourceC" name="main.c"/>
+    </group>
+  </files>
+</cprj>

--- a/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/main.c
+++ b/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/main.c
@@ -1,0 +1,6 @@
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+int main (void) {
+  return 1;
+}


### PR DESCRIPTION
Validate project compilation having component sources with same filenames