### PR TITLE
[buildmgr] Update duplicated filename test case (#289)

### DIFF
--- a/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/main.c
+++ b/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/main.c
@@ -1,6 +1,11 @@
 #include "RTE_Components.h"
 #include CMSIS_device_header
 
+extern int Dummy1(int i);
+extern int Dummy2(int i);
+
 int main (void) {
+  Dummy1(0);
+  Dummy2(0);
   return 1;
 }


### PR DESCRIPTION
Call functions from the different sources so the symbols presence is checked during linking phase.