### PR TITLE
[projmgr] Support Bversion alongside Brevision for backward compatibility (#290)

### DIFF
--- a/tools/buildmgr/cbuildgen/config/CPRJ.xsd
+++ b/tools/buildmgr/cbuildgen/config/CPRJ.xsd
@@ -17,12 +17,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  $Date:        06. July 2022
-  $Revision:    1.0.2
+  $Date:        30. August 2022
+  $Revision:    1.0.3
 
   $Project: Schema File for CMSIS Project Description File Format Specification
 
-  SchemaVersion=1.0.2
+  SchemaVersion=1.0.3
+
+  1.0.3: Added Brevision attribute, Bversion to be deprecated
 
   1.0.2: Added custom RTE attribute
 
@@ -319,8 +321,10 @@
     <xs:attribute name="Bvendor"  type="xs:string"   use="optional" />
     <!-- Board Name -->
     <xs:attribute name="Bname"    type="xs:string"   use="optional" />
+    <!-- Board Revision -->
+    <xs:attribute name="Brevision" type="xs:string"  use="optional" />
     <!-- Board Version -->
-    <xs:attribute name="Bversion" type="xs:string"   use="optional" />
+    <xs:attribute name="Bversion" type="xs:string"   use="optional" /> <!-- Deprecated -->
     <!-- Device Vendor -->
     <xs:attribute name="Dvendor"  type="xs:string"   use="optional" />
     <!-- Device Name -->

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -153,7 +153,7 @@ void ProjMgrGenerator::GenerateCprjTarget(XMLTreeElement* element, const Context
   }
 
   // board attributes
-  constexpr const char* BOARD_ATTRIBUTES[] = { "Bvendor", "Bname", "Brevision" };
+  constexpr const char* BOARD_ATTRIBUTES[] = { "Bvendor", "Bname", "Brevision", "Bversion" /*deprecated*/};
   for (const auto& name : BOARD_ATTRIBUTES) {
     const string& value = attributes[name];
     SetAttribute(element, name, value);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -454,6 +454,7 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
     context.targetAttributes["Bname"]    = matchedBoard->GetName();
     context.targetAttributes["Bvendor"]  = matchedBoard->GetVendorName();
     context.targetAttributes["Brevision"] = matchedBoard->GetRevision();
+    context.targetAttributes["Bversion"] = matchedBoard->GetRevision(); // deprecated
  
     // find device from the matched board
     list<RteItem*> mountedDevices;

--- a/tools/projmgr/test/data/TestProject/test_only_board.cprj
+++ b/tools/projmgr/test/data/TestProject/test_only_board.cprj
@@ -14,7 +14,7 @@
     <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
-  <target Bname="RteTest Test board-3" Brevision="1.1.1" Bvendor="Keil" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+  <target Bname="RteTest Test board-3" Brevision="1.1.1" Bvendor="Keil" Bversion="1.1.1" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
     <output intdir="tmp/test" name="test" outdir="out/test" rtedir="../data/TestProject/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestProject/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
   </target>

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0_board_package.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Debug+CM0_board_package.cprj
@@ -15,7 +15,7 @@
     <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
-  <target Bname="RteTest board listing" Brevision="Rev.C" Bvendor="Keil" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+  <target Bname="RteTest board listing" Brevision="Rev.C" Bvendor="Keil" Bversion="Rev.C" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
     <output intdir="tmp/test1/CM0/Debug" name="test1.Debug+CM0" outdir="out/test1/CM0/Debug" rtedir="../data/TestSolution/TestProject1/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
   </target>

--- a/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0_board_package.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/test1.Release+CM0_board_package.cprj
@@ -15,7 +15,7 @@
     <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
-  <target Bname="RteTest board listing" Brevision="Rev.C" Bvendor="Keil" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+  <target Bname="RteTest board listing" Brevision="Rev.C" Bvendor="Keil" Bversion="Rev.C" Dendian="Little-endian" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
     <output intdir="tmp/test1/CM0/Release" name="test1.Release+CM0" outdir="out/test1/CM0/Release" rtedir="../data/TestSolution/TestProject1/RTE" type="exe"/>
     <ldflags compiler="GCC" file="../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/gcc_arm.ld"/>
   </target>


### PR DESCRIPTION
* [projmgr] Support Bversion alongside Brevision for backward compatibility

* [buildmgr] Update CPRJ.xsd version