### PR TITLE
Add support for output-dirs[gendir] and $G

### DIFF
--- a/libs/rtemodel/include/RteTarget.h
+++ b/libs/rtemodel/include/RteTarget.h
@@ -854,15 +854,16 @@ public:
   RteDeviceProperty* GetDeviceEnvironment() const { return m_deviceEnvironment; }
 
   /**
-   * @brief get the generator input file path
-   * @return generator input file
+   * @brief get the absolute path to the generator input file
+   * @return absolute path to the generator input file
   */
-  const std::string& GetGeneratorInputFilePath() const { return m_generatorInputFilePath; }
+  const std::string& GetGeneratorInputFile() const { return m_generatorInputFile; }
 
   /**
    * @brief set the generator input file path
+   * @param newGeneratorInputFile the new absolute path to the generator input file
   */
-  void SetGeneratorInputFilePath(const std::string& newGeneratorInputFilePath) { m_generatorInputFilePath = newGeneratorInputFilePath; }
+  void SetGeneratorInputFile(const std::string& newGeneratorInputFile) { m_generatorInputFile = newGeneratorInputFile; }
 
   /**
    * @brief get <environment> property of device with given name
@@ -961,7 +962,7 @@ protected:
   std::set<std::string> m_objects;
   std::set<std::string> m_docs;
   std::map<std::string, RteComponent*> m_scvdFiles; // component viewer description files
-  std::string m_generatorInputFilePath; // Absolute path to the generator input file
+  std::string m_generatorInputFile; // Absolute path to the generator input file
 
   // header file content
   std::set<std::string> m_RTE_Component_h; // defines put into the file

--- a/libs/rtemodel/include/RteTarget.h
+++ b/libs/rtemodel/include/RteTarget.h
@@ -854,6 +854,17 @@ public:
   RteDeviceProperty* GetDeviceEnvironment() const { return m_deviceEnvironment; }
 
   /**
+   * @brief get the generator input file path
+   * @return generator input file
+  */
+  const std::string& GetGeneratorInputFilePath() const { return m_generatorInputFilePath; }
+
+  /**
+   * @brief set the generator input file path
+  */
+  void SetGeneratorInputFilePath(const std::string& newGeneratorInputFilePath) { m_generatorInputFilePath = newGeneratorInputFilePath; }
+
+  /**
    * @brief get <environment> property of device with given name
    * @param tag given name
    * @return device environment string
@@ -950,6 +961,8 @@ protected:
   std::set<std::string> m_objects;
   std::set<std::string> m_docs;
   std::map<std::string, RteComponent*> m_scvdFiles; // component viewer description files
+  std::string m_generatorInputFilePath; // Absolute path to the generator input file
+
   // header file content
   std::set<std::string> m_RTE_Component_h; // defines put into the file
   std::set<std::string> m_PreIncludeGlobal; // defines put into the global pre-include file

--- a/libs/rtemodel/src/RteCallback.cpp
+++ b/libs/rtemodel/src/RteCallback.cpp
@@ -84,6 +84,7 @@ string RteCallback::ExpandString(const string& str) {
   const string& prjPathFile(prjPath + activeProject->GetName() + ".cprj");
   const string& packPath(activeTarget->GetDevicePackage()->GetAbsolutePackagePath());
   const string& deviceName(activeTarget->GetDeviceName());
+  const string& generatorInputFilePath(activeTarget->GetGeneratorInputFilePath());
 
   if (prjPath.empty() || prjPathFile.empty() || packPath.empty() || deviceName.empty()) {
     return RteUtils::EMPTY_STRING;
@@ -97,6 +98,7 @@ string RteCallback::ExpandString(const string& str) {
   RteUtils::ReplaceAll(res, "$S", packPath);
   RteUtils::ReplaceAll(res, "$D", deviceName);
   RteUtils::ReplaceAll(res, "$B", boardName);
+  RteUtils::ReplaceAll(res, "$G", generatorInputFilePath);
 
   return res;
 }

--- a/libs/rtemodel/src/RteCallback.cpp
+++ b/libs/rtemodel/src/RteCallback.cpp
@@ -84,7 +84,7 @@ string RteCallback::ExpandString(const string& str) {
   const string& prjPathFile(prjPath + activeProject->GetName() + ".cprj");
   const string& packPath(activeTarget->GetDevicePackage()->GetAbsolutePackagePath());
   const string& deviceName(activeTarget->GetDeviceName());
-  const string& generatorInputFilePath(activeTarget->GetGeneratorInputFilePath());
+  const string& generatorInputFile(activeTarget->GetGeneratorInputFile());
 
   if (prjPath.empty() || prjPathFile.empty() || packPath.empty() || deviceName.empty()) {
     return RteUtils::EMPTY_STRING;
@@ -98,7 +98,7 @@ string RteCallback::ExpandString(const string& str) {
   RteUtils::ReplaceAll(res, "$S", packPath);
   RteUtils::ReplaceAll(res, "$D", deviceName);
   RteUtils::ReplaceAll(res, "$B", boardName);
-  RteUtils::ReplaceAll(res, "$G", generatorInputFilePath);
+  RteUtils::ReplaceAll(res, "$G", generatorInputFile);
 
   return res;
 }

--- a/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
@@ -43,6 +43,7 @@
       <exe>
       <command host="win">Generator/script.bat</command>
       <command host="linux">Generator/script.sh</command>
+      <command host="mac">Generator/script.sh</command>
         <!-- path is specified either absolute or relative to PDSC or GPDSC file. If not specified it is the project directory configured by the environment -->
         <!-- D = Device (Dname/Dvariant as configured by environment) -->
         <argument>$D</argument>
@@ -65,6 +66,7 @@
       <exe>
       <command host="win"   key="RTE_GENERATOR_WITH_KEY">script.bat</command>
       <command host="linux" key="RTE_GENERATOR_WITH_KEY">script.sh</command>
+      <command host="mac"   key="RTE_GENERATOR_WITH_KEY">script.sh</command>
         <!-- path is specified either absolute or relative to PDSC or GPDSC file. If not specified it is the project directory configured by the environment -->
         <!-- D = Device (Dname/Dvariant as configured by environment) -->
         <argument>$D</argument>

--- a/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
@@ -50,6 +50,8 @@
         <argument>#P</argument>
         <!-- absolute or relative to workingDir. $S = Device Family Pack base folder -->
         <argument>$S</argument>
+        <!-- absolute path to the generator input file -->
+        <argument>$G</argument>
       </exe>
       <!-- path is either absolute or relative to working directory -->
       <gpdsc name="$PRTE/Device/$D/RteTest.gpdsc"/>
@@ -70,6 +72,8 @@
         <argument>#P</argument>
         <!-- absolute or relative to workingDir. $S = Device Family Pack base folder -->
         <argument>$S</argument>
+        <!-- absolute path to the generator input file -->
+        <argument>$G</argument>
       </exe>
       <!-- path is either absolute or relative to working directory -->
       <gpdsc name="$PRTE/Device/$D/RteTest.gpdsc"/>
@@ -91,6 +95,15 @@
       <description>Configuration via RteTest script</description>
       <RTE_Components_h>
         #define RTE_TEST_GENERATOR_WITH_KEY
+      </RTE_Components_h>
+      <files>
+        <file category="other" name="Templates/RteTest.gpdsc.template" version ="1.0.0"/>
+      </files>
+    </component>
+    <component generator="RteTestGeneratorIdentifier" Cclass="Device" Cgroup="RteTest Generated Component" Csub="RteTestSimple" Cversion="1.1.0">
+      <description>Configuration via RteTest script</description>
+      <RTE_Components_h>
+        #define RTE_TEST_GENERATOR_SIMPLE
       </RTE_Components_h>
       <files>
         <file category="other" name="Templates/RteTest.gpdsc.template" version ="1.0.0"/>

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
@@ -2,6 +2,7 @@
 echo %1 
 echo %2 
 echo %3
+echo %4
 
 mkdir %1
 copy "%3\Templates\RteTest.gpdsc.template" "%1\RteTest.gpdsc"

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -2,6 +2,7 @@
 echo $1 
 echo $2 
 echo $3
+echo $4
 
 mkdir $1
 cp "$3/Templates/RteTest.gpdsc.template" "$1/RteTest.gpdsc"

--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -131,6 +131,7 @@ struct RteDirItem {
  *        rte directory,
 */
 struct DirectoriesItem {
+  std::string gendir;
   std::string intdir;
   std::string outdir;
   std::string cprj;

--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -27,9 +27,10 @@ public:
   /**
    * @brief emit context info
    * @param context
-   * @return true if success otherwise false
+   * @param destinationPath A folder where the generator should place the resulting generated files
+   * @return Returns the file path of the created generator input file if success
   */
-  static bool EmitContextInfo(const ContextItem& context, const std::string& dst);
+  static std::optional<std::string> EmitContextInfo(const ContextItem& context, const std::string& destinationPath);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -54,6 +54,7 @@ static constexpr const char* YAML_OPTIMIZE = "optimize";
 static constexpr const char* YAML_OUTPUTTYPE = "output-type";
 static constexpr const char* YAML_OUTPUTDIRS = "output-dirs";
 static constexpr const char* YAML_OUTPUT_CPRJDIR = "cprjdir";
+static constexpr const char* YAML_OUTPUT_GENDIR = "gendir";
 static constexpr const char* YAML_OUTPUT_INTDIR = "intdir";
 static constexpr const char* YAML_OUTPUT_OUTDIR = "outdir";
 static constexpr const char* YAML_OUTPUT_RTEDIR = "rtedir";

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -97,6 +97,7 @@
     "OutputDirectoriesType": {
       "type": "object",
       "properties": {
+        "gendir":   { "type": "string" },
         "rtedir":   { "type": "string" },
         "intdir":   { "type": "string" },
         "outdir":   { "type": "string" },

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1992,7 +1992,7 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
     }
 
     // Update RteTarget with current generatorInputFilePath that was created
-    context.rteActiveTarget->SetGeneratorInputFilePath(*generatorInputFilePath);
+    context.rteActiveTarget->SetGeneratorInputFile(*generatorInputFilePath);
 
     // TODO: review RteGenerator::GetExpandedCommandLine and variables
     //const string generatorCommand = m_kernel->GetCmsisPackRoot() + "/" + generator->GetPackagePath() + generator->GetCommand();

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -437,6 +437,7 @@ void ProjMgrYamlParser::ParseOutputDirs(const YAML::Node& parent, struct Directo
     const YAML::Node& outputDirsNode = parent[YAML_OUTPUTDIRS];
     map<const string, string&> outputDirsChildren = {
       {YAML_OUTPUT_CPRJDIR, directories.cprj},
+      {YAML_OUTPUT_GENDIR, directories.gendir},
       {YAML_OUTPUT_INTDIR, directories.intdir},
       {YAML_OUTPUT_OUTDIR, directories.outdir},
       {YAML_OUTPUT_RTEDIR, directories.rte},
@@ -635,6 +636,7 @@ const set<string> buildTypeKeys = {
 
 const set<string> outputDirsKeys = {
   YAML_OUTPUT_CPRJDIR,
+  YAML_OUTPUT_GENDIR,
   YAML_OUTPUT_INTDIR,
   YAML_OUTPUT_OUTDIR,
   YAML_OUTPUT_RTEDIR,

--- a/tools/projmgr/test/data/TestSolution/TestProject3/TestProject3.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/TestProject3/TestProject3.cproject.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.0.0/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  description: Project 3
+  components:
+    - component: Startup
+    - component: CORE
+    - component: Device:RteTest Generated Component:RteTestSimple

--- a/tools/projmgr/test/data/TestSolution/TestProject3/main.c
+++ b/tools/projmgr/test/data/TestSolution/TestProject3/main.c
@@ -1,0 +1,5 @@
+#include "RTE_Components.h"
+
+int main (void) {
+  return 1;
+}

--- a/tools/projmgr/test/data/TestSolution/gendir.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/gendir.csolution.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.0.0/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: TypeA
+      device: RteTestGen_ARMCM0
+
+  build-types:
+    - type: Debug
+      compiler: GCC@0.0.0
+
+  projects:
+    - project: ./TestProject3/TestProject3.cproject.yml
+
+  output-dirs:
+    outdir: $Project$/outdir/
+    gendir: $Project$/gendir/

--- a/tools/projmgr/test/data/TestSolution/outdirs.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/outdirs.csolution.yml
@@ -21,3 +21,4 @@ solution:
     intdir: $OutDir(test1)$/$TargetType$
     outdir: $Project$/$BuildType$
     rtedir: $Source()$/Custom/RTEDIR
+    gendir: $Project$/gendir/$TargetType$

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -8,6 +8,7 @@
 #include "ProjMgrTestEnv.h"
 #include "gtest/gtest.h"
 #include <regex>
+#include <filesystem>
 
 using namespace std;
 
@@ -32,4 +33,23 @@ TEST_F(ProjMgrGeneratorUnitTests, GetLocalTimestamp) {
   string timestamp = ProjMgrGenerator().GetLocalTimestamp();
   EXPECT_TRUE(regex_match(timestamp,
   std::regex("^([0-9]){4}(-([0-9]){2}){2}T([0-9]){2}(:([0-9]){2}){2}$")));
+}
+
+TEST_F(ProjMgrGeneratorUnitTests, GenDir) {
+  char* argv[6];
+
+  const string& csolution = testinput_folder + "/TestSolution/gendir.csolution.yml";
+  argv[1] = (char*)"run";
+  argv[2] = (char*)"--solution";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-g";
+  argv[5] = (char*)"RteTestGeneratorIdentifier";
+
+  EXPECT_EQ(0, ProjMgr::RunProjMgr(6, argv));
+
+  const string generatorInputFile = testinput_folder + "/TestSolution/TestProject3/outdir/TestProject3.Debug+TypeA.generate.yml";
+  const string generatedGPDSC = testinput_folder + "/TestSolution/TestProject3/gendir/RteTestGen_ARMCM0/RteTest.gpdsc";
+
+  EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));
+  EXPECT_EQ(true, std::filesystem::exists(generatedGPDSC));
 }

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1312,7 +1312,7 @@ TEST_F(ProjMgrUnitTests, ExecuteGenerator) {
   EXPECT_TRUE(PopulateContexts());
   EXPECT_TRUE(m_worker.ParseContextSelection(m_context));
   const string& hostType = CrossPlatformUtils::GetHostType();
-  if (hostType == "linux" || hostType == "win") {
+  if (hostType == "linux" || hostType == "win" || hostType == "mac") {
     EXPECT_TRUE(m_worker.ExecuteGenerator(m_codeGenerator));
   } else {
     EXPECT_FALSE(m_worker.ExecuteGenerator(m_codeGenerator));

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -17,6 +17,11 @@
 
 using namespace std;
 
+bool shouldHaveGeneratorForHostType(const string& hostType) {
+  return hostType == "linux" || hostType == "win" || hostType == "mac";
+}
+
+
 class ProjMgrUnitTests : public ProjMgr, public ::testing::Test {
 protected:
   ProjMgrUnitTests() {}
@@ -1223,7 +1228,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ExecuteGenerator) {
   argv[7] = (char*)"test-gpdsc.Debug+CM0";
 
   const string& hostType = CrossPlatformUtils::GetHostType();
-  if (hostType == "linux" || hostType == "win") {
+  if (shouldHaveGeneratorForHostType(hostType)) {
     EXPECT_EQ(0, RunProjMgr(8, argv));
   } else {
     EXPECT_EQ(1, RunProjMgr(8, argv));
@@ -1240,7 +1245,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ExecuteGeneratorEmptyContext) {
   argv[5] = (char*)csolution.c_str();
 
   const string& hostType = CrossPlatformUtils::GetHostType();
-  if (hostType == "linux" || hostType == "win") {
+  if (shouldHaveGeneratorForHostType(hostType)) {
     EXPECT_EQ(0, RunProjMgr(6, argv));
   } else {
     EXPECT_EQ(1, RunProjMgr(6, argv));
@@ -1257,7 +1262,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ExecuteGeneratorEmptyContextMultipleTypes) {
   argv[5] = (char*)csolution.c_str();
 
   const string& hostType = CrossPlatformUtils::GetHostType();
-  if (hostType == "linux" || hostType == "win") {
+  if (shouldHaveGeneratorForHostType(hostType)) {
     EXPECT_EQ(0, RunProjMgr(6, argv));
   } else {
     EXPECT_EQ(1, RunProjMgr(6, argv));
@@ -1312,7 +1317,7 @@ TEST_F(ProjMgrUnitTests, ExecuteGenerator) {
   EXPECT_TRUE(PopulateContexts());
   EXPECT_TRUE(m_worker.ParseContextSelection(m_context));
   const string& hostType = CrossPlatformUtils::GetHostType();
-  if (hostType == "linux" || hostType == "win" || hostType == "mac") {
+  if (shouldHaveGeneratorForHostType(hostType)) {
     EXPECT_TRUE(m_worker.ExecuteGenerator(m_codeGenerator));
   } else {
     EXPECT_FALSE(m_worker.ExecuteGenerator(m_codeGenerator));
@@ -1333,7 +1338,7 @@ TEST_F(ProjMgrUnitTests, ExecuteGeneratorWithKey) {
   string genFolder = testcmsispack_folder + "/ARM/RteTestGenerator/0.1.0/Generator";
   // we use environment variable to test on all pl since it is reliable
   CrossPlatformUtils::SetEnv("RTE_GENERATOR_WITH_KEY", genFolder);
-  if (hostType == "linux" || hostType == "win") {
+  if (shouldHaveGeneratorForHostType(hostType)) {
     EXPECT_TRUE(m_worker.ExecuteGenerator(m_codeGenerator));
   } else {
     EXPECT_FALSE(m_worker.ExecuteGenerator(m_codeGenerator));

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1667,6 +1667,7 @@ TEST_F(ProjMgrUnitTests, ListComponents_MultiplePackSelection) {
   };
   set<string> expected_Gen = {
     "ARM::Device:RteTest Generated Component:RteTest@1.1.0 (ARM::RteTestGenerator@0.1.0)",
+    "ARM::Device:RteTest Generated Component:RteTestSimple@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTestWithKey@1.1.0 (ARM::RteTestGenerator@0.1.0)"
   };
   vector<string> components;


### PR DESCRIPTION
Add support for `$G` variable on `<generator>` element in .pdsc format as implemented in https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/pull/151

Add support for `gendir` on the `output-dirs` property to allow customizing the `destination` property in the generator input file as described in https://github.com/Open-CMSIS-Pack/devtools/issues/433

Contributed by STMicroelectronics.