### PR TITLE
exclude more file types

### DIFF
--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -15,6 +15,9 @@ on:
       - 'libs/rtefsutils/**'
       - 'tools/buildmgr/**'
       - '!**/*.md'
+      - '!**/*.png'
+      - '!**/*.pptx'
+      - '!**/*.svg'
   push:
     branches:
       - main
@@ -32,6 +35,10 @@ on:
       - 'libs/rtefsutils/**'
       - 'tools/buildmgr/**'
       - '!**/*.md'
+      - '!**/*.png'
+      - '!**/*.pptx'
+      - '!**/*.svg'
+
   release:
     types: [ published ]
 


### PR DESCRIPTION
png, pptx and svg are other documentation related file extension which should not trigger any build, test, coverage nor lint actions.