### PR TITLE
Add validation rule that detects a dependency satisfied by the component itself (#339)

### DIFF
--- a/libs/xmlreader/include/XML_Reader.h
+++ b/libs/xmlreader/include/XML_Reader.h
@@ -316,6 +316,11 @@ public:
     return text.length();
   }
 
+  /**
+   * @brief prints out XML stack, for error reporting on an improper XML closing tag
+  */
+  void PrintTagStack();
+
 private:
   /**
    * @brief opens source from m_SourceStack
@@ -391,11 +396,6 @@ private:
    * @return success true/false
   */
   bool PopTag(std::string& tag);
-
-  /**
-   * @brief prints out XML stack, for error reporting on an improper XML closing tag
-  */
-  void PrintTagStack();
 
   /**
    * @brief get string length of whole attribute(s) for current tag

--- a/libs/xmlreader/src/XML_Reader_Msgs.cpp
+++ b/libs/xmlreader/src/XML_Reader_Msgs.cpp
@@ -13,7 +13,7 @@ const MsgTable XML_Reader::msgTable = {
   { "M403", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Data:      [%TYPE%] '%DATA%'"                                                }  },
   { "M404", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Attribute name: '%NAME%'"                                                    }  },
   { "M405", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Attribute data: '%DATA%'"                                                    }  },
-  { "M406", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "XML Stack:\n%MSG%"                                                           }  },
+  { "M406", { MsgLevel::LEVEL_WARNING3, CRLF_B,   "XML Stack:\n%MSG%"                                                           }  },
   { "M407", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Recover from Error"                                                          }  },
   { "M408", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Recover from Error: giving up after 100 tries..."                            }  },
   { "M409", { MsgLevel::LEVEL_INFO ,    CRLF_B,   "Skipping unknown Tag: '%TAG%'"                                               }  },

--- a/libs/xmltreeslim/src/XmlTreeSlimInterface.cpp
+++ b/libs/xmltreeslim/src/XmlTreeSlimInterface.cpp
@@ -130,10 +130,11 @@ bool XMLTreeSlimInterface::Parse(const std::string& fileName, const std::string&
 
     if (recursion) {
       LogMsg("M421");
+      m_pXmlReader->PrintTagStack();
     }
   }
 
- m_pXmlReader->UnInit();
+  m_pXmlReader->UnInit();
 
   ErrLog::Get()->SetErrConsumer(prevConsumer);
   ErrLog::Get()->SetFileName("");

--- a/tools/packchk/include/ValidateSemantic.h
+++ b/tools/packchk/include/ValidateSemantic.h
@@ -29,6 +29,8 @@ public:
 
   bool Check();
   bool TestMcuDependencies(RtePackage* pKg);
+  bool TestDepsResult(const std::map<const RteItem*, RteDependencyResult>& results, RteComponent* component);
+  bool CheckSelfResolvedCondition(RteComponent* component, RteTarget* target);
   bool TestComponentDependencies();
   bool TestApis();
   bool CheckForUnsupportedChars(const std::string& name, const std::string& tag, int lineNo);

--- a/tools/packchk/src/PackChk_Msgs.cpp
+++ b/tools/packchk/src/PackChk_Msgs.cpp
@@ -198,7 +198,7 @@ const MsgTable PackChk::msgTable = {
   { "M384", { MsgLevel::LEVEL_ERROR,    CRLF_B, "Condition '%NAME%': Direct or indirect recursion detected. Skipping condition while searching for '%NAME2%'." } },
   { "M385", { MsgLevel::LEVEL_INFO,     CRLF_B, "Release date is empty." } },
   { "M386", { MsgLevel::LEVEL_WARNING,  CRLF_B, "Release date is in future: '%RELEASEDATE%' (today: %TODAYDATE%)" } },
-  { "M389", { MsgLevel::LEVEL_WARNING,  CRLF_B, "" } },
+  { "M389", { MsgLevel::LEVEL_WARNING,  CRLF_B, "The component '%NAME%' (Line %LINE%) has dependency '%EXPR%' : '%NAME2%' that is resolved by the component itself." } },
   { "M390", { MsgLevel::LEVEL_WARNING3, CRLF_B, "" } },
   { "M391", { MsgLevel::LEVEL_WARNING3, CRLF_B, "Redefined Item '%NAME%': %MSG%" } },
   { "M392", { MsgLevel::LEVEL_ERROR,    CRLF_B, "Redefined Device or Variant '%NAME%': %MSG%" } },

--- a/tools/packchk/test/data/CompResolvedByItself/ARM.CompResolvedByItself.pdsc
+++ b/tools/packchk/test/data/CompResolvedByItself/ARM.CompResolvedByItself.pdsc
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<package schemaVersion="1.4.9" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+  <vendor>ARM</vendor>
+  <url>http://www.keil.com/pack/</url>
+  <name>CompResolvedByItself</name>
+  <description>Add validation rule that detects a dependency rule satisfied by the component itself #510</description>
+
+  <releases>
+    <release version="1.0.0">
+      Added test
+    </release>
+  </releases>
+
+  <conditions>
+    <condition id="SW">                <!-- parent item -->
+     <require Cclass="C" Cgroup="G"/>  <!-- item -->
+    </condition>
+    <condition id="HW"> 
+      <require Dcore="Cortex-M*"/> 
+    </condition>
+
+    <condition id="cond1">
+     <require condition="HW"/>
+     <require condition="SW"/>
+    </condition>
+  </conditions>
+
+  <components>
+    <component Cclass="X" Cgroup="Y" condition="cond1"/>
+
+    <component Cclass="C" Cgroup="G" condition="cond1"/>
+    <component Cclass="C" Cgroup="G" Csub="S" condition="cond1"/>
+  </components>
+
+</package>

--- a/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
+++ b/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
@@ -239,7 +239,7 @@ TEST_F(PackChkIntegTests, AddRefPacks) {
   refPack4 += "/" + refName4 + ".pdsc";
   const string contentBegin = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"\
                               "<package schemaVersion=\"1.3\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema-instance\" xs:noNamespaceSchemaLocation=\"PACK.xsd\">\n"\
-                              "  <name>";    
+                              "  <name>";
   const string contentEnd =   "  </name>\n"\
                               "</package>\n";
 
@@ -274,7 +274,7 @@ TEST_F(PackChkIntegTests, AddRefPacks) {
 
   PackChk packChk;
   packChk.Check(10, argv, nullptr);
-  
+
   const RteGlobalModel& model = packChk.GetModel();
   const RtePackageMap& packs = model.GetPackages();
 
@@ -402,6 +402,34 @@ TEST_F(PackChkIntegTests, CheckFeatureSON) {
 
   if (!bFound) {
     FAIL() << "error: missing error M371";
+  }
+}
+
+// Validate self resolving component
+TEST_F(PackChkIntegTests, CheckCompResolvedByItself) {
+  const char* argv[2];
+
+  const string& pdscFile = PackChkIntegTestEnv::localtestdata_dir +
+    "/CompResolvedByItself/ARM.CompResolvedByItself.pdsc";
+  ASSERT_TRUE(RteFsUtils::Exists(pdscFile));
+
+  argv[0] = (char*)"";
+  argv[1] = (char*)pdscFile.c_str();
+
+  PackChk packChk;
+  EXPECT_EQ(0, packChk.Check(2, argv, nullptr));
+
+  auto errMsgs = ErrLog::Get()->GetLogMessages();
+  int foundCnt = 0;
+  for (const string& msg : errMsgs) {
+    size_t s;
+    if ((s = msg.find("M389")) != string::npos) {
+      foundCnt++;
+    }
+  }
+
+  if (foundCnt != 2) {
+    FAIL() << "error: missing message M389";
   }
 }
 


### PR DESCRIPTION
* Prepare for new check

* Preparation

* PackChk:

added:
- GitHub #510: Add validation rule that detects a dependency rule satisfied by the component itself

Message:
*** WARNING M389: ARM.GitHub#510.pdsc (Line 17) The component 'ARM::C.G(cond1)[]' (Line 17) has dependency 'SW' : 'require C:G' that is resolved by the component itself.

* added test case

* fixed issues

* Fixed: Test expected return value