### PR TITLE
[projmgr] Extend cbuild.yml output nodes (#370)

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -1182,7 +1182,7 @@ void RteProject::CollectSettings()
 
 string RteProject::GetRteComponentsH(const string & targetName, const string & prefix) const
 {
-  return GetRteHeader(string("/RTE_Components.h"), targetName, prefix);
+  return GetRteHeader(string("RTE_Components.h"), targetName, prefix);
 }
 
 string RteProject::GetRteHeader(const string& name, const string & targetName, const string & prefix) const

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -76,6 +76,32 @@ struct TargetItem {
 };
 
 /**
+ * @brief selected component item containing
+ *        pointer to component instance
+ *        pointer to input component item
+ *        generator identifier
+*/
+struct SelectedComponentItem {
+  RteComponentInstance* instance;
+  ComponentItem* item;
+  std::string generator;
+};
+
+/**
+ * @brief component file item containing
+ *        file name
+ *        file attribute
+ *        file category
+ *        file version
+*/
+struct ComponentFileItem {
+  std::string name;
+  std::string attr;
+  std::string category;
+  std::string version;
+};
+
+/**
  * @brief translation control item containing
  *        final context controls after processing,
  *        csolution controls,
@@ -155,10 +181,10 @@ struct ContextItem {
   ToolchainItem toolchain;
   std::map<std::string, std::string> targetAttributes;
   std::map<std::string, RtePackage*> packages;
-  std::map<std::string, std::pair<RteComponentInstance*, ComponentItem*>> components;
+  std::map<std::string, SelectedComponentItem> components;
   std::vector<std::tuple<RteItem::ConditionResult, std::string, std::set<std::string>, std::set<std::string>>> validationResults;
   std::map<std::string, std::map<std::string, RteFileInstance*>> configFiles;
-  std::map<std::string, std::vector<std::string>> componentFiles;
+  std::map<std::string, std::vector<ComponentFileItem>> componentFiles;
   std::vector<GroupNode> groups;
   std::map<std::string, std::string> filePaths;
   std::map<std::string, RteGenerator*> generators;
@@ -409,6 +435,7 @@ protected:
   std::string GetBoardInfoString(const std::string& vendor, const std::string& name, const std::string& revision) const;
   std::vector<PackageItem> GetFilteredPacks(const PackageItem& packItem, const std::string& rtePath) const;
   ToolchainItem GetToolchain(const std::string& compiler);
+  bool IsPreIncludeByTarget(const RteTarget* activeTarget, const std::string& preInclude);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -15,6 +15,7 @@
 */
 static constexpr const char* YAML_ADDPATHS = "add-paths";
 static constexpr const char* YAML_ADDPATH = "add-path";
+static constexpr const char* YAML_ATTR = "attr";
 static constexpr const char* YAML_BOARD = "board";
 static constexpr const char* YAML_BUILD = "build";
 static constexpr const char* YAML_BUILD_IDX = "build-idx";
@@ -33,6 +34,7 @@ static constexpr const char* YAML_COMPILER = "compiler";
 static constexpr const char* YAML_COMPONENT = "component";
 static constexpr const char* YAML_COMPONENTS = "components";
 static constexpr const char* YAML_CONDITION = "condition";
+static constexpr const char* YAML_CONSTRUCTEDFILES = "constructed-files";
 static constexpr const char* YAML_CONTEXT = "context";
 static constexpr const char* YAML_CONTEXTS = "contexts";
 static constexpr const char* YAML_DEBUG = "debug";
@@ -50,6 +52,7 @@ static constexpr const char* YAML_FROM_PACK = "from-pack";
 static constexpr const char* YAML_FORCOMPILER = "for-compiler";
 static constexpr const char* YAML_FORTYPE = "for-type";
 static constexpr const char* YAML_FPU = "fpu";
+static constexpr const char* YAML_GENERATOR = "generator";
 static constexpr const char* YAML_GROUP = "group";
 static constexpr const char* YAML_GROUPS = "groups";
 static constexpr const char* YAML_INTERFACES = "interfaces";
@@ -90,6 +93,7 @@ static constexpr const char* YAML_TRUSTZONE = "trustzone";
 static constexpr const char* YAML_TYPE = "type";
 static constexpr const char* YAML_UNDEFINES = "undefines";
 static constexpr const char* YAML_UNDEFINE = "undefine";
+static constexpr const char* YAML_VERSION = "version";
 static constexpr const char* YAML_WARNINGS = "warnings";
 
 /**

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -191,11 +191,11 @@ void ProjMgrGenerator::GenerateCprjComponents(XMLTreeElement* element, const Con
     XMLTreeElement* componentElement = element->CreateElement("component");
     if (componentElement) {
       for (const auto& name : COMPONENT_ATTRIBUTES) {
-        const string& value = component.first->GetAttribute(name);
+        const string& value = component.instance->GetAttribute(name);
         SetAttribute(componentElement, name, value);
       }
       if (context.configFiles.find(componentId) != context.configFiles.end()) {
-        const string& rteDir = component.first->GetAttribute("rtedir");
+        const string& rteDir = component.instance->GetAttribute("rtedir");
         if (!rteDir.empty()) {
           error_code ec;
           // Adjust component's rtePath relative to cprj
@@ -204,10 +204,10 @@ void ProjMgrGenerator::GenerateCprjComponents(XMLTreeElement* element, const Con
       }
 
       // Check whether non-locked option is not set or component version is required from user
-      if (!nonLocked || !RteUtils::GetSuffix(component.second->component, *ProjMgrUtils::PREFIX_CVERSION, true).empty()) {
+      if (!nonLocked || !RteUtils::GetSuffix(component.item->component, *ProjMgrUtils::PREFIX_CVERSION, true).empty()) {
 
         // Set Cversion attribute
-        SetAttribute(componentElement, versionAttribute, component.first->GetAttribute(versionAttribute));
+        SetAttribute(componentElement, versionAttribute, component.instance->GetAttribute(versionAttribute));
 
         // Config files
         for (const auto& configFileMap : context.configFiles) {
@@ -226,12 +226,12 @@ void ProjMgrGenerator::GenerateCprjComponents(XMLTreeElement* element, const Con
         }
       }
 
-      GenerateCprjOptions(componentElement, component.second->build);
-      GenerateCprjMisc(componentElement, component.second->build.misc);
-      GenerateCprjVector(componentElement, component.second->build.defines, "defines");
-      GenerateCprjVector(componentElement, component.second->build.undefines, "undefines");
-      GenerateCprjVector(componentElement, component.second->build.addpaths, "includes");
-      GenerateCprjVector(componentElement, component.second->build.delpaths, "excludes");
+      GenerateCprjOptions(componentElement, component.item->build);
+      GenerateCprjMisc(componentElement, component.item->build.misc);
+      GenerateCprjVector(componentElement, component.item->build.defines, "defines");
+      GenerateCprjVector(componentElement, component.item->build.undefines, "undefines");
+      GenerateCprjVector(componentElement, component.item->build.addpaths, "includes");
+      GenerateCprjVector(componentElement, component.item->build.delpaths, "excludes");
     }
 
   }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -364,9 +364,10 @@ bool ProjMgrWorker::InitializeTarget(ContextItem& context) {
     m_model->AddProject(0, rteProject);
     m_model->SetActiveProjectId(rteProject->GetProjectId());
     context.rteActiveProject = m_model->GetActiveProject();
-    context.rteActiveProject->AddTarget("CMSIS", map<string, string>(), true, true);
-    context.rteActiveProject->SetActiveTarget("CMSIS");
-    context.rteActiveProject->SetName(context.name);
+    const string& targetName = context.name.empty() ? "CMSIS" : context.name;
+    context.rteActiveProject->AddTarget(targetName, map<string, string>(), true, true);
+    context.rteActiveProject->SetActiveTarget(targetName);
+    context.rteActiveProject->SetName(targetName);
     context.rteActiveTarget = context.rteActiveProject->GetActiveTarget();
     context.rteFilteredModel = context.rteActiveTarget->GetFilteredModel();
   }
@@ -889,10 +890,11 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
   }
 
   // Get generators
-  for (const auto& [componentId, component] : context.components) {
-    RteGenerator* generator = component.first->GetParent()->GetComponent()->GetGenerator();
+  for (auto& [componentId, component] : context.components) {
+    RteGenerator* generator = component.instance->GetParent()->GetComponent()->GetGenerator();
     if (generator) {
       const string generatorId = generator->GetID();
+      component.generator = generatorId;
       context.generators.insert({ generatorId, generator });
       error_code ec;
       const string gpdsc = fs::weakly_canonical(generator->GetExpandedGpdsc(context.rteActiveTarget), ec).generic_string();
@@ -911,7 +913,7 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
 bool ProjMgrWorker::AddRequiredComponents(ContextItem& context) {
   list<RteItem*> selItems;
   for (auto& [_, component] : context.components) {
-    selItems.push_back(component.first);
+    selItems.push_back(component.instance);
   }
   set<RteComponentInstance*> unresolvedComponents;
   context.rteActiveProject->AddCprjComponents(selItems, context.rteActiveTarget, unresolvedComponents);
@@ -924,6 +926,11 @@ bool ProjMgrWorker::AddRequiredComponents(ContextItem& context) {
     return false;
   }
   context.rteActiveProject->CollectSettings();
+
+  // Generate RTE headers
+  if (!context.rteActiveTarget->GenerateRteHeaders()) {
+    return false;
+  }
   return true;
 }
 
@@ -968,15 +975,81 @@ bool ProjMgrWorker::ProcessComponentFiles(ContextItem& context) {
     ProjMgrLogger::Error("missing RTE target");
     return false;
   }
+  // files belonging to project groups, except config files
   const auto& groups = context.rteActiveTarget->GetProjectGroups();
   for (const auto& [_, group] : groups) {
     for (auto& [file, fileInfo] : group) {
-      const auto& component = context.rteActiveTarget->GetComponentInstanceForFile(file);
-      const string& filename = fileInfo.m_fi ? fileInfo.m_fi->GetAbsolutePath() : file;
-      context.componentFiles[ProjMgrUtils::GetComponentID(component)].push_back(filename);
+      const auto& ci = context.rteActiveTarget->GetComponentInstanceForFile(file);
+      const auto& component = ci->GetResolvedComponent(context.rteActiveTarget->GetName());
+      if (!fileInfo.m_fi) {
+        const auto& absPackPath = component->GetPackage()->GetAbsolutePackagePath();
+        error_code ec;
+        const auto& relFilename = fs::relative(file, absPackPath, ec).generic_string();
+        const auto& componentFile = context.rteActiveTarget->GetFile(relFilename, component);
+        const auto& attr = componentFile->GetAttribute("attr");
+        const auto& category = componentFile->GetAttribute("category");
+        const auto& version = attr == "config" ? componentFile->GetVersionString() : "";
+        context.componentFiles[ProjMgrUtils::GetComponentID(component)].push_back({ file, attr, category, version });
+      }
+    }
+  }
+  // iterate over components
+  for (const auto& [componentId, component] : context.components) {
+    const RteComponent* rteComponent = component.instance->GetParent()->GetComponent();
+    // pre-include files from packs
+    for (const auto& componentFile : rteComponent->GetFileContainer()->GetChildren()) {
+      const auto& category = componentFile->GetAttribute("category");
+      const auto& attr = componentFile->GetAttribute("attr");
+      if (((category == "preIncludeGlobal") || (category == "preIncludeLocal")) && attr.empty()) {
+        const auto& preInclude = rteComponent->GetPackage()->GetAbsolutePackagePath() + componentFile->GetAttribute("name");
+        if (IsPreIncludeByTarget(context.rteActiveTarget, preInclude)) {
+          context.componentFiles[componentId].push_back({ preInclude, "", category, "" });
+        }
+      }
+    }
+    // config files
+    for (const auto& configFileMap : context.configFiles) {
+      if (configFileMap.first == componentId) {
+        for (const auto& [_, configFile] : configFileMap.second) {
+          const auto& filename = configFile->GetAbsolutePath();
+          const auto& category = configFile->GetAttribute("category");
+          const auto& originalFile = configFile->GetFile(context.rteActiveTarget->GetName());
+          const auto& version = originalFile->GetVersionString();
+          context.componentFiles[componentId].push_back({ filename, "config", category, version });
+        }
+      }
+    }
+  }
+  // constructed local pre-include files
+  const auto& preIncludeFiles = context.rteActiveTarget->GetPreIncludeFiles();
+  for (const auto& [component, fileSet] : preIncludeFiles) {
+    if (component) {
+      const string& preIncludeLocal = component->ConstructComponentPreIncludeFileName();
+      for (const auto& file : fileSet) {
+        if (file == preIncludeLocal) {
+          const string& filename = context.rteActiveProject->GetProjectPath() +
+            context.rteActiveProject->GetRteHeader(file, context.rteActiveTarget->GetName(), "");
+          const string& componentID = ProjMgrUtils::GetComponentID(component);
+          context.componentFiles[componentID].push_back({ filename, "", "preIncludeLocal", ""});
+          break;
+        }
+      }
     }
   }
   return true;
+}
+
+bool ProjMgrWorker::IsPreIncludeByTarget(const RteTarget* activeTarget, const string& preInclude) {
+  const auto& preIncludeFiles = activeTarget->GetPreIncludeFiles();
+  for (const auto& [_, fileSet] : preIncludeFiles) {
+    for (auto file : fileSet) {
+      error_code ec;
+      if (fs::equivalent(file, preInclude, ec)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 bool ProjMgrWorker::ValidateContext(ContextItem& context) {
@@ -1628,10 +1701,10 @@ bool ProjMgrWorker::ProcessContext(ContextItem& context, bool loadGpdsc, bool re
       return false;
     }
   }
-  if (!ProcessComponentFiles(context)) {
+  if (!ProcessConfigFiles(context)) {
     return false;
   }
-  if (!ProcessConfigFiles(context)) {
+  if (!ProcessComponentFiles(context)) {
     return false;
   }
   if (resolveDependencies) {

--- a/tools/projmgr/test/data/TestSolution/pre-include.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/pre-include.cproject.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  compiler: AC6
+  components:
+    - component: Startup
+    - component: CORE
+    - component: RteTest:ComponentLevel
+    - component: RteTest:GlobalLevel

--- a/tools/projmgr/test/data/TestSolution/pre-include.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/pre-include.csolution.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: CM0
+      device: RteTest_ARMCM0
+
+  projects:
+    - project: ./pre-include.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
@@ -8,7 +8,7 @@ build:
     trustzone: non-secure
   packs:
     - pack: ARM::RteTest_DFP@0.2.0
-      path: $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
   optimize: none
   debug: on
   misc:
@@ -38,8 +38,14 @@ build:
     - ../data/TestSolution/path/solution/
     - ../data/TestSolution/path/CM0
     - ../data/TestSolution/path/Debug
-    - ../data/TestSolution/TestProject1/RTE/_CMSIS
-    - $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+    - ../data/TestSolution/TestProject1/RTE/_test1.Debug_CM0
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestSolution/TestProject1/generated
+    intdir: tmp/test1/CM0/Debug
+    outdir: out/test1/CM0/Debug
+    rtedir: ../data/TestSolution/TestProject1/RTE
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest
@@ -48,10 +54,16 @@ build:
       files:
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct
           category: linkerScript
+          attr: config
+          version: 1.0.0
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/startup_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 2.0.3
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/system_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 1.0.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -95,6 +107,7 @@ build:
         - ../data/TestSolution/TestProject1/path/sources/4/group
       files:
         - file: ../data/TestSolution/TestProject1/main.c
+          category: sourceC
           misc:
             ASM:
               - -ASM-file-AC6
@@ -123,3 +136,7 @@ build:
     - group: Debug Group
       files:
         - file: ../data/TestSolution/TestProject1/debug.c
+          category: sourceC
+  constructed-files:
+    - file: ../data/TestSolution/TestProject1/RTE/_test1.Debug_CM0/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
@@ -8,7 +8,7 @@ build:
     trustzone: non-secure
   packs:
     - pack: ARM::RteTest_DFP@0.2.0
-      path: $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
   optimize: size
   debug: off
   define:
@@ -21,8 +21,14 @@ build:
     - ../data/TestSolution/path/solution/
     - ../data/TestSolution/path/CM0
     - ../data/TestSolution/path/Release
-    - ../data/TestSolution/TestProject1/RTE/_CMSIS
-    - $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+    - ../data/TestSolution/TestProject1/RTE/_test1.Release_CM0
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestSolution/TestProject1/generated
+    intdir: tmp/test1/CM0/Release
+    outdir: out/test1/CM0/Release
+    rtedir: ../data/TestSolution/TestProject1/RTE
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest
@@ -31,10 +37,16 @@ build:
       files:
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/gcc_arm.ld
           category: linkerScript
+          attr: config
+          version: 2.0.0
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/startup_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 2.0.3
         - file: ../data/TestSolution/TestProject1/RTE/Device/RteTest_ARMCM0/system_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 1.0.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -76,6 +88,7 @@ build:
         - ../data/TestSolution/TestProject1/path/sources/4/group
       files:
         - file: ../data/TestSolution/TestProject1/main.c
+          category: sourceC
           misc:
             ASM:
               - -ASM-file-GCC
@@ -106,6 +119,7 @@ build:
     - group: Release Group
       files:
         - file: ../data/TestSolution/TestProject1/release.c
+          category: sourceC
           define:
             - DEF1-REL-FILE
           undefine:
@@ -114,3 +128,6 @@ build:
             - ../data/TestSolution/TestProject1/path/1/release/file
           del-path:
             - ../data/TestSolution/TestProject1/path/2/release/file
+  constructed-files:
+    - file: ../data/TestSolution/TestProject1/RTE/_test1.Release_CM0/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
@@ -8,7 +8,7 @@ build:
     trustzone: non-secure
   packs:
     - pack: ARM::RteTest_DFP@0.2.0
-      path: $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
   optimize: none
   debug: on
   misc:
@@ -45,8 +45,14 @@ build:
     - ../data/TestSolution/path/solution/
     - ../data/TestSolution/path/CM0
     - ../data/TestSolution/path/Debug
-    - ../data/TestSolution/TestProject2/RTE/_CMSIS
-    - $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+    - ../data/TestSolution/TestProject2/RTE/_test2.Debug_CM0
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestSolution/TestProject2/generated
+    intdir: tmp/test2/CM0/Debug
+    outdir: out/test2/CM0/Debug
+    rtedir: ../data/TestSolution/TestProject2/RTE
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest
@@ -55,10 +61,16 @@ build:
       files:
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct
           category: linkerScript
+          attr: config
+          version: 1.0.0
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM0/startup_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 2.0.3
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM0/system_ARMCM0.c
           category: sourceC
+          attr: config
+          version: 1.0.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -67,3 +79,7 @@ build:
     - group: Sources
       files:
         - file: ../data/TestSolution/TestProject2/main.c
+          category: sourceC
+  constructed-files:
+    - file: ../data/TestSolution/TestProject2/RTE/_test2.Debug_CM0/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
@@ -8,7 +8,7 @@ build:
     trustzone: non-secure
   packs:
     - pack: ARM::RteTest_DFP@0.2.0
-      path: $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
   optimize: none
   debug: on
   misc:
@@ -41,8 +41,14 @@ build:
     - ../data/TestSolution/path/solution/
     - ../data/TestSolution/path/CM3
     - ../data/TestSolution/path/Debug
-    - ../data/TestSolution/TestProject2/RTE/_CMSIS
-    - $CMSIS_PACK_ROOT$/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
+    - ../data/TestSolution/TestProject2/RTE/_test2.Debug_CM3
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestSolution/TestProject2/generated
+    intdir: tmp/test2/CM3/Debug
+    outdir: out/test2/CM3/Debug
+    rtedir: ../data/TestSolution/TestProject2/RTE
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
@@ -51,10 +57,16 @@ build:
       files:
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct
           category: linkerScript
+          attr: config
+          version: 1.2.0
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM3/startup_ARMCM3.c
           category: sourceC
+          attr: config
+          version: 2.0.3
         - file: ../data/TestSolution/TestProject2/RTE/Device/RteTest_ARMCM3/system_ARMCM3.c
           category: sourceC
+          attr: config
+          version: 1.2.2
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -63,3 +75,7 @@ build:
     - group: Sources
       files:
         - file: ../data/TestSolution/TestProject2/main.c
+          category: sourceC
+  constructed-files:
+    - file: ../data/TestSolution/TestProject2/RTE/_test2.Debug_CM3/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
@@ -1,0 +1,89 @@
+build:
+  context: pre-include+CM0
+  compiler: AC6
+  device: RteTest_ARMCM0
+  processor:
+    fpu: off
+    trustzone: non-secure
+  packs:
+    - pack: ARM::RteTest@0.1.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0
+    - pack: ARM::RteTest_DFP@0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
+  define:
+    - ARMCM0
+    - _RTE_
+  add-path:
+    - ../data/TestSolution/RTE/RteTest
+    - ../data/TestSolution/RTE/_pre-include_CM0
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/ComponentLevel/Include
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/GlobalLevel
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/Include
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestSolution/generated
+    intdir: tmp/pre-include/CM0
+    outdir: out/pre-include/CM0
+    rtedir: ../data/TestSolution/RTE
+  components:
+    - component: ARM::Device:Startup&RteTest Startup@2.0.3
+      condition: ARMCM0 RteTest
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: Startup
+      files:
+        - file: ../data/TestSolution/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct
+          category: linkerScript
+          attr: config
+          version: 1.0.0
+        - file: ../data/TestSolution/RTE/Device/RteTest_ARMCM0/startup_ARMCM0.c
+          category: sourceC
+          attr: config
+          version: 2.0.3
+        - file: ../data/TestSolution/RTE/Device/RteTest_ARMCM0/system_ARMCM0.c
+          category: sourceC
+          attr: config
+          version: 1.0.0
+    - component: ARM::RteTest:CORE@0.1.1
+      condition: Cortex-M Device
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: CORE
+    - component: ARM::RteTest:ComponentLevel@0.0.1
+      from-pack: ARM::RteTest@0.1.0
+      selected-by: RteTest:ComponentLevel
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/ComponentLevel/ComponentLevel.c
+          category: sourceC
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/ComponentLevel/ComponentLevel.h
+          category: preIncludeLocal
+        - file: ../data/TestSolution/RTE/RteTest/ComponentLevelConfig_0.h
+          category: preIncludeLocal
+          attr: config
+          version: 0.0.1
+        - file: ../data/TestSolution/RTE/RteTest/MyDir/RelativeComponentLevelConfig_0.h
+          category: header
+          attr: config
+          version: 0.0.1
+        - file: ../data/TestSolution/RTE/_pre-include_CM0/Pre_Include_RteTest_ComponentLevel.h
+          category: preIncludeLocal
+    - component: ARM::RteTest:GlobalLevel@0.0.2
+      from-pack: ARM::RteTest@0.1.0
+      selected-by: RteTest:GlobalLevel
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/GlobalLevel/GlobalLevel.c
+          category: sourceC
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/GlobalLevel/GlobalLevel.h
+          category: preIncludeGlobal
+        - file: ../data/TestSolution/RTE/RteTest/GlobalLevelConfig.h
+          category: preIncludeGlobal
+          attr: config
+          version: 0.0.2
+        - file: ../data/TestSolution/RTE/RteTest/Config/ConfigInclude.h
+          category: header
+          attr: config
+          version: 0.0.2
+  constructed-files:
+    - file: ../data/TestSolution/RTE/_pre-include_CM0/Pre_Include_Global.h
+      category: preIncludeGlobal
+    - file: ../data/TestSolution/RTE/_pre-include_CM0/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cprj
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cprj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-11-07T16:03:39" tool="csolution 0.9.2+p240-g013710d"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest" vendor="ARM" version="0.1.0:0.1.0"/>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output intdir="tmp/pre-include/CM0" name="pre-include+CM0" outdir="out/pre-include/CM0" rtedir="../data/TestSolution/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestSolution/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+  </target>
+
+  <components>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+    <component Cclass="RteTest" Cgroup="ComponentLevel" Cvendor="ARM" Cversion="0.0.1">
+      <file attr="config" category="preIncludeLocal" name="ComponentLevel/ComponentLevelConfig.h" version="0.0.1"/>
+      <file attr="config" category="header" name="ComponentLevel/Include/MyDir/RelativeComponentLevelConfig.h" version="0.0.1"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="GlobalLevel" Cvendor="ARM" Cversion="0.0.2">
+      <file attr="config" category="preIncludeGlobal" name="GlobalLevel/GlobalLevelConfig.h" version="0.0.2"/>
+      <file attr="config" category="header" name="Include/Config/ConfigInclude.h" version="0.0.2"/>
+    </component>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include.cbuild-idx.yml
@@ -1,0 +1,6 @@
+build-idx:
+  csolution: ../data/TestSolution/pre-include.csolution.yml
+  cprojects:
+    - cproject: ../data/TestSolution/pre-include.cproject.yml
+  cbuilds:
+    - cbuild: pre-include+CM0.cbuild.yml

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -2080,3 +2080,26 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_WriteCprjFail) {
   RteFsUtils::SetTreeReadOnly(outputFolder);
   EXPECT_EQ(1, RunProjMgr(10, argv));
 }
+
+TEST_F(ProjMgrUnitTests, RunProjMgr_PreInclude) {
+  char* argv[6];
+
+  // convert -s solution.yml
+  const string& csolution = testinput_folder + "/TestSolution/pre-include.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"-s";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)testoutput_folder.c_str();
+  EXPECT_EQ(0, RunProjMgr(6, argv));
+
+  // Check generated CPRJs
+  CompareFile(testoutput_folder + "/pre-include+CM0.cprj",
+    testinput_folder + "/TestSolution/ref/pre-include+CM0.cprj");
+
+  // Check generated cbuild YMLs
+  CompareFile(testoutput_folder + "/pre-include.cbuild-idx.yml",
+    testinput_folder + "/TestSolution/ref/pre-include.cbuild-idx.yml");
+  CompareFile(testoutput_folder + "/pre-include+CM0.cbuild.yml",
+    testinput_folder + "/TestSolution/ref/pre-include+CM0.cbuild.yml");
+}


### PR DESCRIPTION
* [projmgr] Extend cbuild.yml output nodes

- pre-includes
- constructed files
- file categories and attributes
- output dirs
- config files versions
- component generator IDs
