### PR TITLE
CMSIS-Toolbox 1.3 Documentation Updates

### DIFF
--- a/tools/buildmgr/docs/cbuild.md
+++ b/tools/buildmgr/docs/cbuild.md
@@ -21,16 +21,19 @@ Usage:
 Flags:
   -c, --clean              Remove intermediate and output directories
   -d, --debug              Enable debug messages
-  -g, --generator string   Select build CMake generator (default "Ninja")
+  -g, --generator string   Select build system generator (default "Ninja")
   -h, --help               Print usage
-  -i, --intdir path        Set directory for intermediate files
-  -j, --jobs number        Number of job slots for parallel execution (default: use all cores)
-  -l, --log file           Save output messages in a log file
-  -o, --outdir path        Set directory for output files
+  -i, --intdir string      Set directory for intermediate files
+  -j, --jobs int           Number of job slots for parallel execution
+  -l, --log string         Save output messages in a log file
+  -o, --outdir string      Set directory for output files
+  -p, --packs              Download missing software packs with cpackget
   -q, --quiet              Suppress output messages except build invocations
+  -r, --rebuild            Remove intermediate and output directories and rebuild
   -s, --schema             Check *.cprj file against CPRJ.xsd schema
   -t, --target string      Optional CMake target name
   -u, --update string      Generate *.cprj file for reproducing current build
+  -v, --verbose            Enable verbose messages from toolchain builds
   -V, --version            Print version
 ```
 

--- a/tools/cpackget/docs/cpackget.md
+++ b/tools/cpackget/docs/cpackget.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 - [cpackget: Pack Installer](#cpackget-pack-installer)
+  - [Table of Contents](#table-of-contents)
   - [Usage Overview](#usage-overview)
   - [Specify CMSIS-Pack root directory](#specify-cmsis-pack-root-directory)
   - [Initialize CMSIS-Pack root directory](#initialize-cmsis-pack-root-directory)
@@ -29,21 +30,74 @@ Usage:
   cpackget [command] [flags]
 
 Available Commands:
-  add             Add Open-CMSIS-Pack packages
-  checksum-create Generates a .checksum file containing the digests of a pack
-  checksum-verify Verifies the integrity of a pack using its .checksum file
-  help            Help about any command
-  init            Initializes a pack root folder
-  list            List installed packs
-  rm              Remove Open-CMSIS-Pack packages
-  update-index    Update the public index
+  add              Add Open-CMSIS-Pack packages
+  checksum-create  Generates a .checksum file containing the digests of a pack
+  checksum-verify  Verifies the integrity of a pack using its .checksum file  
+  help             Help about any command
+  rm               Remove Open-CMSIS-Pack packages
+  signature-create Digitally signs a pack with a X.509 certificate or PGP key
+  signature-verify Verifies a signed pack
+  update-index     Update the public index
 
 Flags:
-  -h, --help               help for cpackget
-  -R, --pack-root string   Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable (default <current setting>)
-  -q, --quiet              Run cpackget silently, printing only error messages
-  -v, --verbose            Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify "-q" for no messages
-  -V, --version            Prints the version number of cpackget and exit
+  -C, --concurrent-downloads uint   Number of concurrent batch downloads. Set to 0 to disable concurrency (default 5)
+  -h, --help                        help for cpackget
+  -R, --pack-root string            Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable (default "C:\\Users\\reikei01\\AppData\\Local\\Arm\\Packs")
+  -q, --quiet                       Run cpackget silently, printing only error messages
+  -T, --timeout uint                Set maximum duration (in seconds) of a download. Disabled by default
+  -v, --verbose                     Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify "-q" for no messages
+  -V, --version                     Prints the version number of cpackget and exit
+
+Use "cpackget [command] --help" for more information about a command.
+PS C:\Users\reikei01>
+PS C:\Users\reikei01> cbuild
+cbuild: Build Invocation 1.3.0 (C) 2022 Arm Ltd. and Contributors
+
+Usage:
+  cbuild <project.cprj> [flags]
+
+  -c, --clean              Remove intermediate and output directories
+  -d, --debug              Enable debug messages
+  -g, --generator string   Select build system generator (default "Ninja")
+  -h, --help               Print usage
+  -i, --intdir string      Set directory for intermediate files
+  -j, --jobs int           Number of job slots for parallel execution
+  -l, --log string         Save output messages in a log file
+  -o, --outdir string      Set directory for output files
+  -p, --packs              Download missing software packs with cpackget
+  -q, --quiet              Suppress output messages except build invocations
+  -r, --rebuild            Remove intermediate and output directories and rebuild
+  -s, --schema             Check *.cprj file against CPRJ.xsd schema
+  -t, --target string      Optional CMake target name
+  -u, --update string      Generate *.cprj file for reproducing current build
+  -v, --verbose            Enable verbose messages from toolchain builds
+  -V, --version            Print version
+PS C:\Users\reikei01> cpackget
+Please refer to the upstream repository for further information: https://github.com/Open-CMSIS-Pack/cpackget.
+
+Usage:
+  cpackget [command] [flags]
+
+Available Commands:
+  add              Add Open-CMSIS-Pack packages
+  checksum-create  Generates a .checksum file containing the digests of a pack
+  checksum-verify  Verifies the integrity of a pack using its .checksum file
+  help             Help about any command
+  init             Initializes a pack root folder
+  list             List installed packs
+  rm               Remove Open-CMSIS-Pack packages
+  signature-create Digitally signs a pack with a X.509 certificate or PGP key
+  signature-verify Verifies a signed pack
+  update-index     Update the public index
+
+Flags:
+  -C, --concurrent-downloads uint   Number of concurrent batch downloads. Set to 0 to disable concurrency (default 5)
+  -h, --help                        help for cpackget
+  -R, --pack-root string            Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable (default "C:\\Users\\reikei01\\AppData\\Local\\Arm\\Packs")
+  -q, --quiet                       Run cpackget silently, printing only error messages
+  -T, --timeout uint                Set maximum duration (in seconds) of a download. Disabled by default
+  -v, --verbose                     Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify "-q" for no messages
+  -V, --version                     Prints the version number of cpackget and exit
 
 Use "cpackget [command] --help" for more information about a command.
 ```

--- a/tools/cpackget/docs/cpackget.md
+++ b/tools/cpackget/docs/cpackget.md
@@ -32,55 +32,6 @@ Usage:
 Available Commands:
   add              Add Open-CMSIS-Pack packages
   checksum-create  Generates a .checksum file containing the digests of a pack
-  checksum-verify  Verifies the integrity of a pack using its .checksum file  
-  help             Help about any command
-  rm               Remove Open-CMSIS-Pack packages
-  signature-create Digitally signs a pack with a X.509 certificate or PGP key
-  signature-verify Verifies a signed pack
-  update-index     Update the public index
-
-Flags:
-  -C, --concurrent-downloads uint   Number of concurrent batch downloads. Set to 0 to disable concurrency (default 5)
-  -h, --help                        help for cpackget
-  -R, --pack-root string            Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable (default "C:\\Users\\reikei01\\AppData\\Local\\Arm\\Packs")
-  -q, --quiet                       Run cpackget silently, printing only error messages
-  -T, --timeout uint                Set maximum duration (in seconds) of a download. Disabled by default
-  -v, --verbose                     Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify "-q" for no messages
-  -V, --version                     Prints the version number of cpackget and exit
-
-Use "cpackget [command] --help" for more information about a command.
-PS C:\Users\reikei01>
-PS C:\Users\reikei01> cbuild
-cbuild: Build Invocation 1.3.0 (C) 2022 Arm Ltd. and Contributors
-
-Usage:
-  cbuild <project.cprj> [flags]
-
-  -c, --clean              Remove intermediate and output directories
-  -d, --debug              Enable debug messages
-  -g, --generator string   Select build system generator (default "Ninja")
-  -h, --help               Print usage
-  -i, --intdir string      Set directory for intermediate files
-  -j, --jobs int           Number of job slots for parallel execution
-  -l, --log string         Save output messages in a log file
-  -o, --outdir string      Set directory for output files
-  -p, --packs              Download missing software packs with cpackget
-  -q, --quiet              Suppress output messages except build invocations
-  -r, --rebuild            Remove intermediate and output directories and rebuild
-  -s, --schema             Check *.cprj file against CPRJ.xsd schema
-  -t, --target string      Optional CMake target name
-  -u, --update string      Generate *.cprj file for reproducing current build
-  -v, --verbose            Enable verbose messages from toolchain builds
-  -V, --version            Print version
-PS C:\Users\reikei01> cpackget
-Please refer to the upstream repository for further information: https://github.com/Open-CMSIS-Pack/cpackget.
-
-Usage:
-  cpackget [command] [flags]
-
-Available Commands:
-  add              Add Open-CMSIS-Pack packages
-  checksum-create  Generates a .checksum file containing the digests of a pack
   checksum-verify  Verifies the integrity of a pack using its .checksum file
   help             Help about any command
   init             Initializes a pack root folder

--- a/tools/projmgr/docs/Manual/Overview.md
+++ b/tools/projmgr/docs/Manual/Overview.md
@@ -109,7 +109,7 @@ The CMSIS-Pack repository must be present in the development environment.
 ### Invocation
 
 ```text
-CMSIS Project Manager 1.2.0 (C) 2022 Arm Ltd. and Contributors
+CMSIS Project Manager 1.3.0 (C) 2022 Arm Ltd. and Contributors
 
 Usage:
   csolution [-V] [--version] [-h] [--help]
@@ -133,10 +133,9 @@ Usage:
    -g, --generator arg   Code generator identifier
    -m, --missing         List only required packs that are missing in the pack repository
    -l, --load arg        Set policy for packs loading [latest|all|required]
+   -e, --export arg      Set suffix for exporting <context><suffix>.cprj retaining only specified versions
    -n, --no-check-schema Skip schema check
    -o, --output arg      Output directory
-
-Use 'csolution <command> -h' for more information about a command.
 ```
 
 ### Command Examples

--- a/tools/projmgr/docs/Manual/YML-Input-Format.md
+++ b/tools/projmgr/docs/Manual/YML-Input-Format.md
@@ -26,6 +26,7 @@ Project Manager.
     - [`output-dirs:`](#output-dirs)
     - [`rte-dirs:`](#rte-dirs)
     - [`output-type:`](#output-type)
+    - [Proposal: `output:`](#proposal-output)
     - [`linker:`](#linker)
     - [`for-compiler:`](#for-compiler)
   - [Translation Control](#translation-control)
@@ -413,6 +414,7 @@ The `project:` node is the start of a `*.cproject.yml` file and can contain the 
 &nbsp;&nbsp; [`add-path:`](#add-path)               |  Optional    | Additional include file paths.
 &nbsp;&nbsp; [`del-path:`](#del-path)               |  Optional    | Remove specific include file paths.
 &nbsp;&nbsp; [`misc:`](#misc)                       |  Optional    | Literal tool-specific controls.
+&nbsp;&nbsp; [`device:`](#device)                   |  Optional    | Device setting (specify processor core).
 &nbsp;&nbsp; [`processor:`](#processor)             |  Optional    | Processor specific settings.
 &nbsp;&nbsp; [`groups:`](#groups)                   | **Required** | List of source file groups along with source files.
 &nbsp;&nbsp; [`components:`](#components)           |  Optional    | List of software components used.
@@ -588,6 +590,29 @@ Value                                                 | Generated Output
 ```yml
 output-type: lib            # Generate a library
 ```
+
+### Proposal: `output:`
+
+This is a proposal to replace `output-type` with a more flexible solution.  It allows to generate both a elf/dwarf and bin file. Optionally the filename including path could be specified.
+
+```yml
+output:
+  - type: elf         # default
+    file: <path>\<file>.<ext>    # user define path with filename and extension (optional)
+    for-type:                    # (optional)
+
+  - type: hex
+    file: <path>\<file>.<ext>    # user define path with filename and extension
+
+  - type: bin
+    file: <path>\<file>.<ext>    # user define path with filename and extension
+    base-address:                # offset addresses
+
+  - type: lib                    # when lib is used, an elf and bin file would be not possible
+    file: <path>\<file>.<ext>    # user define path with filename and extension
+```
+
+If accepted, we would need to extend also the access sequences.
 
 ### `linker:`
 
@@ -971,6 +996,8 @@ A `device:` is derived from the `board:` setting, but an explicit `device:` sett
 
 If `device:` specifies a device with a multi-core processor, and no explicit `pname` for the processor core selection is specified, the default `pname` of the device is used.
 
+At the level of a `cproject.yml` file, only the `pname` can be specified as the device itself is selected at the level of a `csolution.yml` file.
+
 ## Processor Attributes
 
 ### `processor:`
@@ -979,7 +1006,6 @@ The `processor:` keyword defines attributes such as TrustZone and FPU register u
 
 `processor:`                   | Content
 :------------------------------|:------------------------------------
-&nbsp;&nbsp; `name:`           | Specifies the `pname` to select a processor core. Note: overwrites a `pname` selection at [`device:`](#device) level.
 &nbsp;&nbsp; `trustzone:`      | TrustZone mode: secure \| non-secure \| off.
 &nbsp;&nbsp; `fpu:`            | Control usage of FPU registers (S-Register for Helium/FPU) (default: on for devices with FPU registers).
 &nbsp;&nbsp; `endian:`         | Select endianness: little \| big (only available when devices are configurable).

--- a/tools/projmgr/docs/Manual/YML-Input-Format.md
+++ b/tools/projmgr/docs/Manual/YML-Input-Format.md
@@ -27,7 +27,7 @@ Project Manager.
     - [`rte-dirs:`](#rte-dirs)
     - [`output-type:`](#output-type)
     - [Proposal: `output:`](#proposal-output)
-    - [`linker:`](#linker)
+    - [Proposal `linker:`](#proposal-linker)
     - [`for-compiler:`](#for-compiler)
   - [Translation Control](#translation-control)
     - [`language-C:`](#language-c)
@@ -614,7 +614,13 @@ output:
 
 If accepted, we would need to extend also the access sequences.
 
-### `linker:`
+### Proposal `linker:`
+
+>**Note:** Linker Control needs review. 
+>
+> Currently the linker command files are provided using the `file:` notation under [`groups:`](#groups) or as part of software components. The extensions `.sct`, `.scf` and `.ld` are automatically recognized as linker script files. The benefit is that linker control files can be part of software components.
+
+
 
 The `linker:` list node controls the linker operation.
 


### PR DESCRIPTION
Added `device:` to cproject.yml as it allows to specify the processor core (pname).
Removed `processor:` name (as this is implemented via `device:` 
Added proposal `output:` to provide more flexiblity for output control 
Reflected CMSIS-Toolbox 1.3 command line parameters