### PR TITLE
[projmgr] Add `variables` handling

### DIFF
--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -104,6 +104,7 @@ struct BuildType {
   std::vector<std::string> delpaths;
   std::vector<MiscItem> misc;
   ProcessorItem processor;
+  std::vector<std::pair<std::string, std::string>> variables;
 };
 
 /**

--- a/tools/projmgr/include/ProjMgrUtils.h
+++ b/tools/projmgr/include/ProjMgrUtils.h
@@ -62,6 +62,13 @@ public:
   static constexpr const char* SUFFIX_PACK_VENDOR = "::";
   static constexpr const char* PREFIX_PACK_VERSION = "@";
 
+  static constexpr const char* AS_PROJECT = "Project";
+  static constexpr const char* AS_COMPILER = "Compiler";
+  static constexpr const char* AS_BUILD_TYPE = "BuildType";
+  static constexpr const char* AS_TARGET_TYPE = "TargetType";
+  static constexpr const char* AS_DNAME = "Dname";
+  static constexpr const char* AS_BNAME = "Bname";
+
   /**
    * @brief class constructor
   */

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -208,6 +208,7 @@ struct ContextItem {
   std::map<std::string, std::pair<std::string, std::string>> gpdscs;
   StrVecMap compatibleLayers;
   std::string linkerScript;
+  std::map<std::string, std::string> variables;
   bool precedences;
 };
 
@@ -481,6 +482,7 @@ protected:
   bool CollectLayersFromPacks(ContextItem& context, StrVecMap& clayers);
   bool DiscoverMatchingLayers(ContextItem& context);
   void GetAllCombinations(const StrVecMap& src, const StrVecMap::iterator it, std::vector<StrVec>& combinations, const StrVec& previous = StrVec());
+  std::string ExpandString(const std::string& src, const StrMap& variables);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -93,6 +93,7 @@ static constexpr const char* YAML_TRUSTZONE = "trustzone";
 static constexpr const char* YAML_TYPE = "type";
 static constexpr const char* YAML_UNDEFINES = "undefines";
 static constexpr const char* YAML_UNDEFINE = "undefine";
+static constexpr const char* YAML_VARIABLES = "variables";
 static constexpr const char* YAML_VERSION = "version";
 static constexpr const char* YAML_WARNINGS = "warnings";
 

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -55,17 +55,17 @@
       "pattern": "^(GCC|AC6|IAR)(@(\\d+\\.\\d+\\.\\d+((\\+|\\-)[\\w.+-]+)?))?$",
       "description": "Selection of the toolchain used in the project (GCC, AC6, IAR), optionally with version, for example AC6@6.16.0"
     },
-    "ConsumesType": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "number"
-      } 
+    "ConsumesProvidesType": {
+      "oneOf": [
+        {"type": "string" },
+        {"type": "object", "additionalProperties": {"type": "number"}}
+      ]      
     },
-    "ProvidesType": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "number"
-      } 
+    "VariablesType": {
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {"type": "object", "additionalProperties": {"type": "string"}}
     },
     "ArrayOfCompilerType": {
       "type": "array",
@@ -195,7 +195,8 @@
         "add-path":   { "$ref": "#/definitions/AddpathsType" },
         "del-paths":  { "$ref": "#/definitions/DelpathsType", "description": "DEPRECATED use: del-path" },
         "del-path":   { "$ref": "#/definitions/DelpathsType" },
-        "misc":       { "$ref": "#/definitions/MiscTypes" }
+        "misc":       { "$ref": "#/definitions/MiscTypes" },
+        "variables":  { "$ref": "#/definitions/VariablesType" }
       },
       "additionalProperties": false,
       "required" : [ "type"]
@@ -227,7 +228,8 @@
         "add-path":   { "$ref": "#/definitions/AddpathsType" },
         "del-paths":  { "$ref": "#/definitions/DelpathsType", "description": "DEPRECATED use: del-path" },
         "del-path":   { "$ref": "#/definitions/DelpathsType" },
-        "misc":       { "$ref": "#/definitions/MiscTypes" }
+        "misc":       { "$ref": "#/definitions/MiscTypes" },
+        "variables":  { "$ref": "#/definitions/VariablesType" }
       },
       "additionalProperties": false,
       "required" : [ "type"]
@@ -459,7 +461,8 @@
         "add-path":     { "$ref": "#/definitions/AddpathsType" },
         "del-paths":    { "$ref": "#/definitions/DelpathsType", "description": "DEPRECATED use: del-path" },
         "del-path":     { "$ref": "#/definitions/DelpathsType" },
-        "misc":         { "$ref": "#/definitions/MiscTypes" }
+        "misc":         { "$ref": "#/definitions/MiscTypes" },
+        "variables":    { "$ref": "#/definitions/VariablesType" }
       },
       "additionalProperties": false
     },
@@ -584,22 +587,12 @@
         "consumes": {
           "type": "array",
           "description": "Consumed interfaces",
-          "items": {
-            "oneOf": [
-              {"type": "string" },
-              {"$ref": "#/definitions/ConsumesType" }
-            ]
-          }
+          "items": { "$ref": "#/definitions/ConsumesProvidesType" }
         },
         "provides": {
           "type": "array",
           "description": "Provided interfaces",
-          "items": {
-            "oneOf": [
-              {"type": "string" },
-              {"$ref": "#/definitions/ProvidesType" }
-            ]
-          }
+          "items": { "$ref": "#/definitions/ConsumesProvidesType" }
         }
       },
       "additionalProperties": false

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -287,25 +287,6 @@ bool ProjMgr::PopulateContexts(void) {
     return false;
   }
 
-  // Parse clayers
-  for (const auto& cproject : m_parser.GetCprojects()) {
-    string const& cprojectFile = cproject.first;
-    for (const auto& clayer : cproject.second.clayers) {
-      if (clayer.layer.empty()) {
-        continue;
-      }
-      error_code ec;
-      string const& clayerFile = fs::canonical(fs::path(cprojectFile).parent_path().append(clayer.layer), ec).generic_string();
-      if (clayerFile.empty()) {
-        ProjMgrLogger::Error(clayer.layer, "clayer file was not found");
-        return false;
-      }
-      if (!m_parser.ParseClayer(clayerFile, m_checkSchema)) {
-        return false;
-      }
-    }
-  }
-
   // Set output directory
   m_worker.SetOutputDir(m_outputDir);
 

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -545,6 +545,7 @@ void ProjMgrYamlParser::ParseBuildType(const YAML::Node& parent, BuildType& buil
     // TODO: after deprecation remove 'del-paths' keyword parsing in benefit of 'del-path'
     ParseVector(parent, YAML_DELPATHS, buildType.delpaths);
   }
+  ParseVectorOfStringPairs(parent, YAML_VARIABLES, buildType.variables);
 }
 
 void ProjMgrYamlParser::ParseTargetType(const YAML::Node& parent, TargetType& targetType) {
@@ -586,6 +587,7 @@ const set<string> solutionKeys = {
   YAML_DELPATHS,
   YAML_DELPATH,
   YAML_MISC,
+  YAML_VARIABLES,
 };
 
 const set<string> projectsKeys = {
@@ -663,6 +665,7 @@ const set<string> targetTypeKeys = {
   YAML_DELPATHS,
   YAML_DELPATH,
   YAML_MISC,
+  YAML_VARIABLES,
 };
 
 const set<string> buildTypeKeys = {
@@ -681,6 +684,7 @@ const set<string> buildTypeKeys = {
   YAML_DELPATHS,
   YAML_DELPATH,
   YAML_MISC,
+  YAML_VARIABLES,
 };
 
 const set<string> outputDirsKeys = {

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType1.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType1.cprj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-12-12T11:01:37" tool="csolution 1.2.0+p74-g8f32208"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output intdir="tmp/variables/TargetType1/BuildType1" name="variables.BuildType1+TargetType1" outdir="out/variables/TargetType1/BuildType1" rtedir="../data/TestLayers/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+    <defines>App-Layer;Build1-Layer;Target1-Layer</defines>
+  </target>
+
+  <components>
+    <component Cclass="Dependency" Cgroup="Device" Cvendor="ARM" Cversion="1.1.1" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="sourceC" name="Components/DeviceDependency.c" version="1.1.1"/>
+    </component>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType2.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType2.cprj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-12-12T11:01:37" tool="csolution 1.2.0+p74-g8f32208"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output intdir="tmp/variables/TargetType2/BuildType1" name="variables.BuildType1+TargetType2" outdir="out/variables/TargetType2/BuildType1" rtedir="../data/TestLayers/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct"/>
+    <defines>App-Layer;Build1-Layer;Target2-Layer</defines>
+  </target>
+
+  <components>
+    <component Cclass="Dependency" Cgroup="Device" Cvendor="ARM" Cversion="1.1.1" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="sourceC" name="Components/DeviceDependency.c" version="1.1.1"/>
+    </component>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.2.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/system_ARMCM3.c" version="1.2.2"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType1.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType1.cprj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-12-12T11:01:37" tool="csolution 1.2.0+p74-g8f32208"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output intdir="tmp/variables/TargetType1/BuildType2" name="variables.BuildType2+TargetType1" outdir="out/variables/TargetType1/BuildType2" rtedir="../data/TestLayers/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+    <defines>App-Layer;Build2-Layer;Target1-Layer</defines>
+  </target>
+
+  <components>
+    <component Cclass="Dependency" Cgroup="Device" Cvendor="ARM" Cversion="1.1.1" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="sourceC" name="Components/DeviceDependency.c" version="1.1.1"/>
+    </component>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType2.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType2.cprj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="1.0.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2022-12-12T11:01:37" tool="csolution 1.2.0+p74-g8f32208"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output intdir="tmp/variables/TargetType2/BuildType2" name="variables.BuildType2+TargetType2" outdir="out/variables/TargetType2/BuildType2" rtedir="../data/TestLayers/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct"/>
+    <defines>App-Layer;Build2-Layer;Target2-Layer</defines>
+  </target>
+
+  <components>
+    <component Cclass="Dependency" Cgroup="Device" Cvendor="ARM" Cversion="1.1.1" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="sourceC" name="Components/DeviceDependency.c" version="1.1.1"/>
+    </component>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../data/TestLayers/variables/RTE">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.2.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/system_ARMCM3.c" version="1.2.2"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestLayers/variables-redefinition.cproject.yml
+++ b/tools/projmgr/test/data/TestLayers/variables-redefinition.cproject.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  components:
+    - component: Device:Startup
+    - component: CORE

--- a/tools/projmgr/test/data/TestLayers/variables-redefinition.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/variables-redefinition.csolution.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  build-types:
+    - type: BuildType
+      compiler: AC6
+      variables:
+        - VariableName: FirstValue
+
+  target-types:
+    - type: TargetType
+      device: RteTest_ARMCM0
+      variables:
+        - VariableName: SecondValue
+
+  projects:
+    - project: variables-redefinition.cproject.yml

--- a/tools/projmgr/test/data/TestLayers/variables.cproject.yml
+++ b/tools/projmgr/test/data/TestLayers/variables.cproject.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  layers:
+    - layer: $VarBuildLayer$
+    - layer: $VarTargetLayer$
+    - layer: $VarSolution$

--- a/tools/projmgr/test/data/TestLayers/variables.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/variables.csolution.yml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  target-types:
+    - type: TargetType1
+      device: RteTest_ARMCM0
+      variables:
+        - VarTargetLayer: ./variables/target1.clayer.yml
+    - type: TargetType2
+      device: RteTest_ARMCM3
+      variables:
+        - VarTargetLayer: ./variables/target2.clayer.yml
+
+  build-types:
+    - type: BuildType1
+      compiler: AC6
+      variables:
+        - VarBuildLayer: ./variables/build1.clayer.yml
+    - type: BuildType2
+      compiler: AC6
+      variables:
+        - VarBuildLayer: ./variables/build2.clayer.yml
+
+  variables:
+    - VarSolution: ./variables/app.clayer.yml
+
+  projects:
+    - project: variables.cproject.yml

--- a/tools/projmgr/test/data/TestLayers/variables/app.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/app.clayer.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+
+  components:
+    - component: Dependency:Device
+  
+  define:
+    - App-Layer

--- a/tools/projmgr/test/data/TestLayers/variables/build1.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/build1.clayer.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+
+  components:
+    - component: CORE
+  
+  define:
+    - Build1-Layer

--- a/tools/projmgr/test/data/TestLayers/variables/build2.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/build2.clayer.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+
+  components:
+    - component: CORE
+  
+  define:
+    - Build2-Layer

--- a/tools/projmgr/test/data/TestLayers/variables/target1.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/target1.clayer.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+
+  components:
+    - component: Device:Startup
+
+  define:
+    - Target1-Layer

--- a/tools/projmgr/test/data/TestLayers/variables/target2.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/target2.clayer.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/clayer.schema.json
+
+layer:
+
+  components:
+    - component: Device:Startup
+
+  define:
+    - Target2-Layer

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -801,6 +801,45 @@ TEST_F(ProjMgrUnitTests, ListLayersAllContexts) {
   EXPECT_EQ(1, RunProjMgr(5, argv));
 }
 
+TEST_F(ProjMgrUnitTests, LayerVariables) {
+  char* argv[6];
+
+  // convert -s solution.yml
+  const string& csolution = testinput_folder + "/TestLayers/variables.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"-s";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)testoutput_folder.c_str();
+  EXPECT_EQ(0, RunProjMgr(6, argv));
+
+  // Check generated CPRJs
+  CompareFile(testoutput_folder + "/variables.BuildType1+TargetType1.cprj",
+    testinput_folder + "/TestLayers/ref/variables/variables.BuildType1+TargetType1.cprj");
+  CompareFile(testoutput_folder + "/variables.BuildType1+TargetType2.cprj",
+    testinput_folder + "/TestLayers/ref/variables/variables.BuildType1+TargetType2.cprj");
+  CompareFile(testoutput_folder + "/variables.BuildType2+TargetType1.cprj",
+    testinput_folder + "/TestLayers/ref/variables/variables.BuildType2+TargetType1.cprj");
+  CompareFile(testoutput_folder + "/variables.BuildType2+TargetType2.cprj",
+    testinput_folder + "/TestLayers/ref/variables/variables.BuildType2+TargetType2.cprj");
+}
+
+TEST_F(ProjMgrUnitTests, LayerVariablesRedefinition) {
+  char* argv[6];
+  StdStreamRedirect streamRedirect;
+  // convert -s solution.yml
+  const string& csolution = testinput_folder + "/TestLayers/variables-redefinition.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"-s";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)testoutput_folder.c_str();
+  EXPECT_EQ(0, RunProjMgr(6, argv));
+  const string& expected = "warning csolution: variable 'VariableName' redefined from 'FirstValue' to 'SecondValue'\n";
+  const string& errStr = streamRedirect.GetErrorString();
+  EXPECT_STREQ(errStr.c_str(), expected.c_str());
+}
+
 TEST_F(ProjMgrUnitTests, AccessSequences) {
   char* argv[7];
 

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -955,3 +955,18 @@ TEST_F(ProjMgrWorkerUnitTests, CollectLayersFromPacks) {
   StrVecMap clayers;
   EXPECT_FALSE(CollectLayersFromPacks(context, clayers));
 }
+
+TEST_F(ProjMgrWorkerUnitTests, ExpandString) {
+  ContextItem context;
+  context.variables = {
+    {"Foo", "./foo"},
+    {"Bar", "./bar"},
+    {"Foo Bar", "./foo-bar"},
+  };
+
+  EXPECT_EQ(ExpandString("path1: $Foo$/bar", context.variables), "path1: ./foo/bar");
+  EXPECT_EQ(ExpandString("path2: $Bar$/foo", context.variables), "path2: ./bar/foo");
+  EXPECT_EQ(ExpandString("$Foo$ $Bar$", context.variables), "./foo ./bar");
+  EXPECT_EQ(ExpandString("$Foo Bar$", context.variables), "./foo-bar");
+  EXPECT_EQ(ExpandString("$Foo$ $Foo$ $Foo$", context.variables), "./foo ./foo ./foo");
+}


### PR DESCRIPTION
Address [#proposals-for-layers](https://github.com/Open-CMSIS-Pack/devtools/blob/main/tools/projmgr/docs/Manual/YML-Input-Format.md#proposals-for-layers)
Accept `variables` node at csolution, build-types and target-types levels
Expand `variables` in references to clayers
Internals: shift clayer parsing to allow timely variables parsing; uniform variables and static access sequences expansion
Add test cases