### PR TITLE
cbuild.yml as generator input

### DIFF
--- a/libs/rtemodel/include/RteGenerator.h
+++ b/libs/rtemodel/include/RteGenerator.h
@@ -44,6 +44,12 @@ public:
   virtual ~RteGenerator() override;
 
   /**
+   * @brief get generator commands for all host types without expansion
+   * @return map with host type ("win", "linux", "mac", "other", or "all") as key and generator command as value
+  */
+  std::map<std::string, std::string> GetCommands() const;
+
+  /**
    * @brief get generator command without expansion
    * @param hostType host type to match, empty to match current host
    * @return generator command for specified host type
@@ -127,6 +133,20 @@ public:
  * @return vector of arguments consisting of switch and value in pairs
 */
   std::vector<std::pair<std::string, std::string> > GetExpandedArguments(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
+
+  /**
+   * @brief get the absolute path to the executable with expanded key sequences for specified target
+   * @param target pointer to RteTarget
+   * @return expanded executable
+  */
+  std::string GetExecutable(RteTarget* target) const;
+
+  /**
+   * @brief get the absolute paths to executables for all host types with the expanded key sequences for specified target
+   * @param target pointer to RteTarget
+   * @return map with host type ("win", "linux", "mac", "other" or "all") as key and path to executable as value
+  */
+  std::map<std::string, std::string> GetExecutables(RteTarget* target) const;
 
   /**
    * @brief get full command line with arguments and expanded key sequences for specified target

--- a/libs/rtemodel/include/RteGenerator.h
+++ b/libs/rtemodel/include/RteGenerator.h
@@ -121,12 +121,12 @@ public:
   const std::string& GetWorkingDir() const { return GetItemValue("workingDir"); }
 
  /**
- * @brief get all arguments as vector similar to argv for the given host type
+ * @brief get all arguments as vector for the given host type
  * @param target pointer to RteTarget
  * @param hostType host type, empty to match current host
- * @return vector of arguments including command line at 0 vector element
+ * @return vector of arguments consisting of switch and value in pairs
 */
-  std::vector<std::string> GetExpandedArgv(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
+  std::vector<std::pair<std::string, std::string> > GetExpandedArguments(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
 
   /**
    * @brief get full command line with arguments and expanded key sequences for specified target

--- a/libs/rtemodel/include/RteGenerator.h
+++ b/libs/rtemodel/include/RteGenerator.h
@@ -45,9 +45,18 @@ public:
 
   /**
    * @brief get generator command without expansion
-   * @return generator command
+   * @param hostType host type to match, empty to match current host
+   * @return generator command for specified host type
   */
-  const std::string GetCommand() const;
+  const std::string GetCommand(const std::string& hostType = EMPTY_STRING ) const;
+
+  /**
+  * @brief get expanded generator executable command
+  * @param target pointer to RteTarget
+  * @param hostType host type to match, empty to match current host
+  * @return generator command for specified host type
+ */
+  std::string GetExecutable(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
 
   /**
    * @brief get item containing command line arguments
@@ -105,18 +114,27 @@ public:
   */
   const std::string& GetGpdsc() const;
 
-  /**
-   * @brief get generator working directory
-   * @return working directory value
-  */
+ /**
+  * @brief get generator working directory
+  * @return working directory value
+ */
   const std::string& GetWorkingDir() const { return GetItemValue("workingDir"); }
+
+ /**
+ * @brief get all arguments as vector similar to argv for the given host type
+ * @param target pointer to RteTarget
+ * @param hostType host type, empty to match current host
+ * @return vector of arguments including command line at 0 vector element
+*/
+  std::vector<std::string> GetExpandedArgv(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
 
   /**
    * @brief get full command line with arguments and expanded key sequences for specified target
    * @param target pointer to RteTarget
+   * @param hostType host type, empty to match current host
    * @return expanded command line with arguments, properly quoted
   */
-  std::string GetExpandedCommandLine(RteTarget* target) const;
+  std::string GetExpandedCommandLine(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
 
   /**
    * @brief get absolute path to gpdsc file for specified target

--- a/libs/rtemodel/include/RteItem.h
+++ b/libs/rtemodel/include/RteItem.h
@@ -543,6 +543,14 @@ public:
   */
   virtual bool MatchesHost() const;
 
+  /**
+ * @brief check if item provides data matching supplied host type
+ * @param hostType host type to match, empty to match current host
+ * @return true if item data matches host platform
+*/
+  virtual bool MatchesHost(const std::string& hostType) const;
+
+
  /**
 * @brief checks if the item contains all attributes matching those in the supplied map
 * @param attributes map of key-value pairs to match against component attributes

--- a/libs/rtemodel/src/RteGenerator.cpp
+++ b/libs/rtemodel/src/RteGenerator.cpp
@@ -141,33 +141,26 @@ string RteGenerator::GetExecutable(RteTarget* target, const std::string& hostTyp
 }
 
 
-vector<string> RteGenerator::GetExpandedArgv(RteTarget* target, const string& hostType) const
+vector<pair<string, string> > RteGenerator::GetExpandedArguments(RteTarget* target, const string& hostType) const
 {
-  vector<string> argv;
-  string exe = RteUtils::AddQuotesIfSpace(GetExecutable(target, hostType));
-  argv.push_back(exe); // executable as arv[0]
-
+  vector<pair<string, string> > args;
   RteItem* argsItem = GetArgumentsItem("exe");
   if (argsItem) {
     for (auto arg : argsItem->GetChildren()) {
       if (arg->GetTag() != "argument" || !arg->MatchesHost(hostType))
         continue;
-      string value = arg->GetAttribute("switch") + RteUtils::AddQuotesIfSpace(ExpandString(arg->GetText()));
-      argv.push_back(value);
+      args.push_back({arg->GetAttribute("switch"), ExpandString(arg->GetText())});
     }
   }
-  return argv;
+  return args;
 }
 
 string RteGenerator::GetExpandedCommandLine(RteTarget* target, const string& hostType) const
 {
-  vector<string> argv = GetExpandedArgv(target, hostType);
-  string fullCmd;
-  for (size_t i = 0; i < argv.size(); i++) {
-    if (i > 0) {
-      fullCmd += ' ';
-    }
-    fullCmd += argv[i];
+  const vector<pair<string, string> > args = GetExpandedArguments(target, hostType);
+  string fullCmd = GetExecutable(target, hostType);
+  for (size_t i = 0; i < args.size(); i++) {
+    fullCmd += ' ' + RteUtils::AddQuotesIfSpace(args[i].first + args[i].second);
   }
   return fullCmd;
 }

--- a/libs/rtemodel/src/RteItem.cpp
+++ b/libs/rtemodel/src/RteItem.cpp
@@ -542,10 +542,14 @@ const string& RteItem::GetPackageFileName() const
 
 bool RteItem::MatchesHost() const
 {
+  return MatchesHost(CrossPlatformUtils::GetHostType());
+}
+
+bool RteItem::MatchesHost(const string& hostType) const
+{
   const string& host = GetAttribute("host");
-  if (host.empty() || host == "all" || host == CrossPlatformUtils::GetHostType())
-    return true;
-  return false;
+  return (host.empty() || host == "all" ||
+          host == (hostType.empty() ? CrossPlatformUtils::GetHostType() : hostType));
 }
 
 

--- a/libs/rteutils/include/RteUtils.h
+++ b/libs/rteutils/include/RteUtils.h
@@ -121,10 +121,17 @@ public:
   static std::string RemoveTrailingBackslash(const std::string& s);
   /**
    * @brief determine string between two quotes
-   * @param s string to be looked for
+   * @param s string to be processed for
    * @return string between two quotes
   */
   static std::string RemoveQuotes(const std::string& s);
+  /**
+   * @brief adds quotes to a string if it contains spaces and not yet quoted
+   * @param s string to be processed
+   * @return string between two quotes
+  */
+  static std::string AddQuotesIfSpace(const std::string& s);
+
   /**
    * @brief check if name (e.g. Dname) is CMSIS-conformed
    * @param s name to be checked

--- a/libs/rteutils/src/RteUtils.cpp
+++ b/libs/rteutils/src/RteUtils.cpp
@@ -431,6 +431,15 @@ string RteUtils::RemoveQuotes(const string& s)
   return s;
 }
 
+std::string RteUtils::AddQuotesIfSpace(const std::string& s)
+{
+  static const string& QUOTE = string("\"");
+  if (s.find(' ') != string::npos && s.find('\"') == string::npos){
+    return QUOTE + s + QUOTE;
+  }
+  return s;
+}
+
 bool RteUtils::HasHexPrefix(const string& s)
 {
   return s.length() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X');

--- a/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
@@ -53,6 +53,9 @@
         <argument>$S</argument>
         <!-- absolute path to the generator input file -->
         <argument>$G</argument>
+        <argument host="win" switch="/foo=">bar</argument>
+        <argument host="linux" switch="--foo=">bar</argument>
+        <argument host="mac" switch="--foo=">bar</argument>
       </exe>
       <!-- path is either absolute or relative to working directory -->
       <gpdsc name="$PRTE/Device/$D/RteTest.gpdsc"/>

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -216,6 +216,7 @@ struct ContextItem {
   std::vector<std::tuple<RteItem::ConditionResult, std::string, std::set<std::string>, std::set<std::string>>> validationResults;
   std::map<std::string, std::map<std::string, RteFileInstance*>> configFiles;
   std::map<std::string, std::vector<ComponentFileItem>> componentFiles;
+  std::map<std::string, std::vector<ComponentFileItem>> generatorInputFiles;
   std::vector<GroupNode> groups;
   std::map<std::string, std::string> filePaths;
   std::map<std::string, RteGenerator*> generators;

--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -25,21 +25,20 @@ public:
   ~ProjMgrYamlEmitter(void);
 
   /**
-   * @brief emit context info
-   * @param context
-   * @param destinationPath A folder where the generator should place the resulting generated files
-   * @return Returns the file path of the created generator input file if success
+   * @brief generate cbuild-idx.yml file
+   * @param parser reference
+   * @param contexts vector with pointers to contexts
+   * @param outputDir directory
+   * @return true if executed successfully
   */
-  static std::optional<std::string> EmitContextInfo(const ContextItem& context, const std::string& destinationPath);
+  static bool GenerateCbuildIndex(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, const std::string& outputDir);
 
   /**
    * @brief generate cbuild.yml file
-   * @param parser reference
-   * @param processedContexts vector with pointers to contexts
-   * @param output directory
+   * @param context pointer to the context
    * @return true if executed successfully
   */
-  bool GenerateCbuild(ProjMgrParser& parser, const std::vector<ContextItem*> processedContexts, const std::string& outputDir);
+  static bool GenerateCbuild(ContextItem* context);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -15,6 +15,8 @@
 */
 static constexpr const char* YAML_ADDPATHS = "add-paths";
 static constexpr const char* YAML_ADDPATH = "add-path";
+static constexpr const char* YAML_ARGUMENT = "argument";
+static constexpr const char* YAML_ARGUMENTS = "arguments";
 static constexpr const char* YAML_ATTR = "attr";
 static constexpr const char* YAML_BOARD = "board";
 static constexpr const char* YAML_BUILD = "build";
@@ -30,6 +32,7 @@ static constexpr const char* YAML_CPROJECTS = "cprojects";
 static constexpr const char* YAML_CPROJECT = "cproject";
 static constexpr const char* YAML_CSOLUTION = "csolution";
 static constexpr const char* YAML_CONSUMES = "consumes";
+static constexpr const char* YAML_COMMAND = "command";
 static constexpr const char* YAML_COMPILER = "compiler";
 static constexpr const char* YAML_COMPONENT = "component";
 static constexpr const char* YAML_COMPONENTS = "components";
@@ -58,8 +61,12 @@ static constexpr const char* YAML_FORDEVICE = "for-device";
 static constexpr const char* YAML_FORTYPE = "for-type";
 static constexpr const char* YAML_FPU = "fpu";
 static constexpr const char* YAML_GENERATOR = "generator";
+static constexpr const char* YAML_GENERATORS = "generators";
+static constexpr const char* YAML_GPDSC = "gpdsc";
 static constexpr const char* YAML_GROUP = "group";
 static constexpr const char* YAML_GROUPS = "groups";
+static constexpr const char* YAML_HOST = "host";
+static constexpr const char* YAML_ID = "id";
 static constexpr const char* YAML_INFO = "info";
 static constexpr const char* YAML_LAYER = "layer";
 static constexpr const char* YAML_LAYERS = "layers";
@@ -95,6 +102,7 @@ static constexpr const char* YAML_SELECTED_BY = "selected-by";
 static constexpr const char* YAML_SETUPS = "setups";
 static constexpr const char* YAML_SETUP = "setup";
 static constexpr const char* YAML_SET = "set";
+static constexpr const char* YAML_SWITCH = "switch";
 static constexpr const char* YAML_TARGETTYPES = "target-types";
 static constexpr const char* YAML_TRUSTZONE = "trustzone";
 static constexpr const char* YAML_TYPE = "type";
@@ -103,6 +111,7 @@ static constexpr const char* YAML_UNDEFINE = "undefine";
 static constexpr const char* YAML_VARIABLES = "variables";
 static constexpr const char* YAML_VERSION = "version";
 static constexpr const char* YAML_WARNINGS = "warnings";
+static constexpr const char* YAML_WORKING_DIR = "working-dir";
 
 /**
   * @brief projmgr parser yaml implementation class, directly coupled to underlying yaml-cpp external library

--- a/tools/projmgr/schemas/cbuild.schema.json
+++ b/tools/projmgr/schemas/cbuild.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/cbuild.schema.json",
+  "title": "CMSIS Project Manager cbuild",
+  "version": "1.4.0",
+  "properties": {
+    "build": {
+      "$ref": "./common.schema.json#/definitions/BuildDescType"
+    }
+  },
+  "required": [ "build" ]
+}

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -14,11 +14,18 @@
       "type": "string",
       "pattern": "^(((^[.][^.+\\s]*)|(^[+][^.+\\s]*))|((^[.][^.+\\s]*)[+][^.+\\s]*|(^[+][^.+\\s]*)[.][^.+\\s]*))$"
     },
+    "BuildContextWithProjectName": {
+      "type": "string",
+      "pattern": "^([^.+\\s]+|[^.+\\s]*\\.[^.+\\s]+(\\+[^.+\\s]+)?|[^.+\\s]*\\+[^.+\\s]+(\\.[^.+\\s]+)?)$"
+    },
     "ArrayOfBuildContext": {
       "type": "array",
       "uniqueItems": true,
       "minItems": 1,
       "items": { "$ref": "#/definitions/BuildContext" }
+    },
+    "ConditionIDType": {
+      "type": "string"
     },
     "ForType": {
       "oneOf": [
@@ -104,6 +111,11 @@
       "uniqueItems": true,
       "minItems": 1,
       "items": {"type": "object", "additionalProperties": {"type": "string"}}
+    },
+    "VersionType": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$",
+      "description": "A version consists of 3 mandatory and 2 optional sections: MAJOR.MINOR.PATCH[-Pre Release][+Build Metadata]"
     },
     "ArrayOfCompilerType": {
       "type": "array",
@@ -362,10 +374,21 @@
       "uniqueItems": true,
       "items": { "$ref": "#/definitions/FileType" }
     },
+    "FileCategoryType": {
+      "enum": [ "doc", "header", "headerAsm", "headerC", "headerCpp", "headerLd", "include", "includeAsm", "includeC", "includeCpp", "includeLd", "library", "object", "source", "sourceC", "sourceCpp", "sourceAsm", "linkerScript", "utility", "image", "preIncludeGlobal", "preIncludeLocal", "other" ],
+      "description": "File category types define the use of component files within the application. Typically, these files are added to the project and processed by the build tools."
+    },
+    "FileAttributeType": {
+      "enum": [ "config", "template" ],
+      "description": "The file attribute defines the special handling in the project when being used as configuration or template file."
+    },
     "FileType": {
       "type": "object",
       "properties": {
         "file":            { "type": "string", "description": "File name along with the path." },
+        "category":        { "$ref": "#/definitions/FileCategoryType" },
+        "attr":            { "$ref": "#/definitions/FileAttributeType" },
+        "version":         { "$ref": "#/definitions/VersionType" },
         "for-type":        { "$ref": "#/definitions/ForType", "description": "DEPRECATED use: for-context" },
         "for-context":     { "$ref": "#/definitions/ForContext" },
         "not-for-type":    { "$ref": "#/definitions/NotForType", "description": "DEPRECATED use: not-for-context" },
@@ -390,6 +413,67 @@
       ],
       "additionalProperties": false
     },
+    "GeneratorsType": {
+      "type": "object",
+      "patternProperties": {
+        "\\w": { "$ref": "#/definitions/GeneratorType" }
+      }
+    },
+    "GeneratorType": {
+      "description": "General generator info",
+      "type": "object",
+      "properties": {
+        "working-dir": {
+          "type": "string",
+          "description": "Path to the directory where the generator runs"
+        },
+        "gpdsc": {
+          "type": "string",
+          "description": "Path to GPDSC file to be created by the generator"
+        },
+        "command": { "$ref": "#/definitions/CommandType" }
+      },
+      "required": [ "working-dir", "gpdsc", "command" ]
+    },
+    "CommandType": {
+      "type": "object",
+      "properties": {
+        "win":   { "$ref": "#/definitions/HostSpecificCommand" },
+        "linux": { "$ref": "#/definitions/HostSpecificCommand" },
+        "mac":   { "$ref": "#/definitions/HostSpecificCommand" },
+        "other": { "$ref": "#/definitions/HostSpecificCommand" }
+      },
+      "required": [ "win", "linux", "mac", "other" ]
+    },
+    "HostSpecificCommand": {
+      "type": "object",
+      "description": "Command for one of the supported host types (Windows, Linux, Mac or other)",
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Path to the executable"
+        },
+        "arguments": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments passed when executing the command"
+        }
+      }
+    },
+    "ComponentGeneratorType": {
+      "description": "Component specific generator info. Any field in this object overrides the corresponding value from the general GeneratorType",
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "files": { "$ref": "#/definitions/FilesType" }
+      },
+      "required": [ "id" ]
+    },
+    "ComponentID": {
+      "type": "string",
+      "pattern": "(^[\\w \\/.+-]+$)|(^([\\w \\/.+-]+::)?([\\w \\/.+-]+)(&[\\w \\/.+-]+)?(:[\\w \\/.+-]+)(:[\\w \\/.+-]+)?(&[\\w \\/.+-]+)?(@(>=)?(\\d+\\.\\d+\\.\\d+((\\+|\\-)[\\w.\\/+-]+)?))?$)",
+      "description": "Name of the software component. It can be a free text or a component identifier in the format [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]"
+    },
     "ComponentsType": {
       "type": "array",
       "description": "List of software components to be added in a project or layer.",
@@ -400,11 +484,7 @@
     "ComponentType": {
       "type": "object",
       "properties": {
-        "component": {
-          "type": "string",
-          "pattern": "(^[\\w \\/.+-]+$)|(^([\\w \\/.+-]+::)?([\\w \\/.+-]+)(&[\\w \\/.+-]+)?(:[\\w \\/.+-]+)(:[\\w \\/.+-]+)?(&[\\w \\/.+-]+)?(@(>=)?(\\d+\\.\\d+\\.\\d+((\\+|\\-)[\\w.\\/+-]+)?))?$)",
-          "description": "Name of the software component. It can be a free text or a component identifier in the format [Cvendor::] Cclass [&Cbundle] :Cgroup [:Csub] [&Cvariant] [@[>=]Cversion]"
-        },
+        "component":    { "$ref": "#/definitions/ComponentID" },
         "for-type":        { "$ref": "#/definitions/ForType", "description": "DEPRECATED use: for-context" },
         "for-context":     { "$ref": "#/definitions/ForContext" },
         "not-for-type":    { "$ref": "#/definitions/NotForType", "description": "DEPRECATED use: not-for-context" },
@@ -557,6 +637,38 @@
       },
       "additionalProperties": false
     },
+    "BuildDescType": {
+      "description": "The lock info that describes the resolved state of contexts and also can be used as input for generators",
+      "type": "object",
+      "properties": {
+        "solution": {
+          "type": "string",
+          "description": "Relative path to the csolution file for this context"
+        },
+        "project": {
+          "type": "string",
+          "description": "Relative path to the cproject file for this context"
+        },
+        "context":           { "$ref": "#/definitions/BuildContextWithProjectName" },
+        "compiler":          { "$ref": "#/definitions/CompilerType" },
+        "device":            { "$ref": "#/definitions/DeviceType" },
+        "processor":         { "$ref": "#/definitions/ProcessorType" },
+        "packs":             { "$ref": "#/definitions/PacksType" },
+        "misc":              { "$ref": "#/definitions/MiscType" },
+        "define":            { "$ref": "#/definitions/DefinesType" },
+        "add-path":          { "$ref": "#/definitions/AddpathsType" },
+        "output-type":       { "$ref": "#/definitions/OutputType" },
+        "output-dirs":       { "$ref": "#/definitions/OutputDirectoriesType" },
+        "components":        { "$ref": "#/definitions/ResolvedComponentsType" },
+        "groups":            { "$ref": "#/definitions/GroupsType" },
+        "generators":        { "$ref": "#/definitions/GeneratorsType" },
+        "constructed-files": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/FileType" }
+        }
+      },
+      "additionalProperties": false
+    },
     "LayerDescType": {
       "type": "object",
       "description": "This section describes layer contents.",
@@ -597,14 +709,15 @@
       "uniqueItems": true,
       "items": { "$ref": "#/definitions/PackType" }
     },
+    "PackID": {
+      "type": "string",
+      "pattern": "^([\\w .-]+)((::[\\w .*-]+)(@(>=)?(\\d+\\.\\d+\\.\\d+((\\+|\\-)[\\w.+-]+)?))?)?$",
+      "description": "Name of a required Software Pack in the format Vendor [:: Pack [@[>=] version]]"
+    },
     "PackType": {
       "type": "object",
       "properties": {
-        "pack": {
-          "type": "string",
-          "pattern": "^([\\w .-]+)((::[\\w .*-]+)(@(>=)?(\\d+\\.\\d+\\.\\d+((\\+|\\-)[\\w.+-]+)?))?)?$",
-          "description": "Name of a required Software Pack in the format Vendor [:: Pack [@[>=] version]]"
-        },
+        "pack": { "$ref": "#/definitions/PackID" },
         "path": {
           "type": "string",
           "description": "Path to software pack"
@@ -618,6 +731,34 @@
         { "$ref": "#/definitions/TypeListMutualExclusion" },
         { "required": [ "pack" ] }
       ],
+      "additionalProperties": false
+    },
+    "ResolvedComponentsType": {
+      "type": "array",
+      "description": "List of software components in their resolved state.",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/ResolvedComponentType" }
+    },
+    "ResolvedComponentType": {
+      "type": "object",
+      "description": "Software component in its resolved state",
+      "properties": {
+        "component":   { "$ref": "#/definitions/ComponentID" },
+        "condition":   { "$ref": "#/definitions/ConditionIDType" },
+        "selected-by": { "$ref": "#/definitions/ComponentID" },
+        "rtedir":      { "type": "string" },
+        "optimize":    { "$ref": "#/definitions/OptimizeType" },
+        "debug":       { "$ref": "#/definitions/DebugType" },
+        "warnings":    { "$ref": "#/definitions/WarningsType" },
+        "define":      { "$ref": "#/definitions/DefinesType" },
+        "undefine":    { "$ref": "#/definitions/UndefinesType" },
+        "add-path":    { "$ref": "#/definitions/AddpathsType" },
+        "del-path":    { "$ref": "#/definitions/DelpathsType" },
+        "misc":        { "$ref": "#/definitions/MiscTypes" },
+        "files":       { "$ref": "#/definitions/FilesType" },
+        "generator":   { "$ref": "#/definitions/ComponentGeneratorType" },
+        "from-pack":   { "$ref": "#/definitions/PackID" }
+      },
       "additionalProperties": false
     },
     "SetupsType": {

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -292,8 +292,10 @@
         "not-for-context": { "$ref": "#/definitions/NotForContext" }
       },
       "additionalProperties": false,
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "required": [ "project" ]
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion"},
+        { "required": [ "project" ] }
+      ]
     },
     "ProcessorType": {
       "type": ["object", "null"],
@@ -344,10 +346,13 @@
         "groups":          { "$ref": "#/definitions/GroupsType" },
         "files":           { "$ref": "#/definitions/FilesType" }
       },
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "anyOf": [
-        {"required" : ["files"]},
-        {"required" : ["groups"]}
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "anyOf": [
+            {"required" : ["files"]},
+            {"required" : ["groups"]}
+          ]
+        }
       ],
       "additionalProperties": false
     },
@@ -379,8 +384,10 @@
         "del-path":        { "$ref": "#/definitions/DelpathsType" },
         "misc":            { "$ref": "#/definitions/MiscTypes" }
       },
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "required": [ "file" ],
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "required": [ "file" ] }
+      ],
       "additionalProperties": false
     },
     "ComponentsType": {
@@ -415,8 +422,10 @@
         "del-path":        { "$ref": "#/definitions/DelpathsType" },
         "misc":            { "$ref": "#/definitions/MiscTypes" }
       },
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "required": [ "component" ],
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "required": [ "component" ] }
+      ],
       "additionalProperties": false
     },
     "LayersType": {
@@ -452,10 +461,13 @@
         "del-path":        { "$ref": "#/definitions/DelpathsType" },
         "misc":            { "$ref": "#/definitions/MiscTypes" }
       },
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "anyOf": [
-        { "required": ["layer"] },
-        { "required": ["type"]  }
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "anyOf": [
+            { "required": ["layer"] },
+            { "required": ["type"]  }
+          ]
+        }
       ],
       "additionalProperties": false
     },
@@ -602,8 +614,10 @@
         "not-for-type":    { "$ref": "#/definitions/NotForType", "description": "DEPRECATED use: not-for-context" },
         "not-for-context": { "$ref": "#/definitions/NotForContext" }
       },
-      "$ref": "#/definitions/TypeListMutualExclusion",
-      "required": [ "pack" ],
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "required": [ "pack" ] }
+      ],
       "additionalProperties": false
     },
     "SetupsType": {

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -397,9 +397,17 @@ bool ProjMgr::RunConvert(void) {
       }
     }
   }
+
   // Generate cbuild files
+  for (auto& contextItem : processedContexts) {
+    if (!m_emitter.GenerateCbuild(contextItem)) {
+      return false;
+    }
+  }
+
+  // Generate cbuild index
   if (!processedContexts.empty()) {
-    if (!m_emitter.GenerateCbuild(m_parser, processedContexts, m_outputDir)) {
+    if (!m_emitter.GenerateCbuildIndex(m_parser, processedContexts, m_outputDir)) {
       return false;
     }
   }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2712,15 +2712,9 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
       generatorDestination += '/';
     }
 
-    const auto generatorInputFilePath = ProjMgrYamlEmitter::EmitContextInfo(context, generatorDestination);
-
-    if (!generatorInputFilePath) {
-      ProjMgrLogger::Error("Failed to create the generator input file for '" + generatorId + "'");
+    if (!ProjMgrYamlEmitter::GenerateCbuild(&context)) {
       return false;
     }
-
-    // Update RteTarget with current generatorInputFilePath that was created
-    context.rteActiveTarget->SetGeneratorInputFile(*generatorInputFilePath);
 
     // TODO: review RteGenerator::GetExpandedCommandLine and variables
     //const string generatorCommand = m_kernel->GetCmsisPackRoot() + "/" + generator->GetPackagePath() + generator->GetCommand();
@@ -2730,9 +2724,9 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
       return false;
     }
 
-
     error_code ec;
     const auto& workingDir = fs::current_path(ec);
+    RteFsUtils::CreateDirectories(generatorDestination);
     fs::current_path(generatorDestination, ec);
     ProjMgrUtils::Result result = ProjMgrUtils::ExecCommand(generatorCommand);
     fs::current_path(workingDir, ec);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1455,6 +1455,16 @@ bool ProjMgrWorker::ProcessComponentFiles(ContextItem& context) {
         }
       }
     }
+    // input files for component generator. This list of files is directly fetched from the PDSC.
+    if (rteComponent->GetGenerator()) {
+      for (const RteItem* rteFile : files) {
+        const auto& filename = rteFile->GetOriginalAbsolutePath();
+        const auto& category = rteFile->GetAttribute("category");
+        const auto& attr = rteFile->GetAttribute("attr");
+        const auto& version = rteFile->GetVersionString();
+        context.generatorInputFiles[componentId].push_back({ filename, attr, category, version });
+      }
+    }
   }
   // constructed local pre-include files
   const auto& preIncludeFiles = context.rteActiveTarget->GetPreIncludeFiles();

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -1,0 +1,70 @@
+build:
+  solution: ../data/TestGenerator/test-gpdsc.csolution.yml
+  project: ../data/TestGenerator/test-gpdsc.cproject.yml
+  context: test-gpdsc.Debug+CM0
+  compiler: AC6
+  device: RteTestGen_ARMCM0
+  processor:
+    trustzone: non-secure
+  packs:
+    - pack: ARM::RteTestGenerator@0.1.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
+    - pack: ARM::RteTest_DFP@0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
+  define:
+    - _RTE_
+  add-path:
+    - ../data/TestGenerator/RTE/_Debug_CM0
+  output-type: exe
+  output-dirs:
+    gendir: ../data/TestGenerator/generated
+    intdir: tmp/test-gpdsc/CM0/Debug
+    outdir: out/test-gpdsc/CM0/Debug
+    rtedir: ../data/TestGenerator/RTE
+  components:
+    - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
+      condition: RteDevice
+      from-pack: ARM::RteTestGenerator@0.1.0
+      selected-by: Device:RteTest Generated Component:RteTest
+      generator:
+        id: RteTestGeneratorIdentifier
+        files:
+          - file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
+            category: other
+            version: 1.0.0
+    - component: ARM::RteTest:CORE@0.1.1
+      condition: Cortex-M Device
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: RteTest:CORE
+  generators:
+    RteTestGeneratorIdentifier:
+      working-dir: ../data/TestGenerator/RTE/Device
+      gpdsc: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
+      command:
+        win:
+          file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.bat
+          arguments:
+            - RteTestGen_ARMCM0
+            - ../../Debug+CM0.cprj
+            - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
+            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - /foo=bar
+        linux:
+          file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+          arguments:
+            - RteTestGen_ARMCM0
+            - ../../Debug+CM0.cprj
+            - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
+            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - --foo=bar
+        mac:
+          file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+          arguments:
+            - RteTestGen_ARMCM0
+            - ../../Debug+CM0.cprj
+            - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
+            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - --foo=bar
+  constructed-files:
+    - file: ../data/TestGenerator/RTE/_Debug_CM0/RTE_Components.h
+      category: header

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.cbuild-idx.yml
@@ -1,0 +1,6 @@
+build-idx:
+  csolution: ../data/TestGenerator/test-gpdsc.csolution.yml
+  cprojects:
+    - cproject: ../data/TestGenerator/test-gpdsc.cproject.yml
+  cbuilds:
+    - cbuild: test-gpdsc.Debug+CM0.cbuild.yml

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
@@ -1,4 +1,6 @@
 build:
+  solution: ../data/TestSolution/test.csolution.yml
+  project: ../data/TestSolution/TestProject1/test1.cproject.yml
   context: test1.Debug+CM0
   compiler: AC6
   device: RteTest_ARMCM0

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
@@ -1,4 +1,6 @@
 build:
+  solution: ../data/TestSolution/test.csolution.yml
+  project: ../data/TestSolution/TestProject1/test1.cproject.yml
   context: test1.Release+CM0
   compiler: GCC
   device: RteTest_ARMCM0

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
@@ -1,4 +1,6 @@
 build:
+  solution: ../data/TestSolution/test.csolution.yml
+  project: ../data/TestSolution/TestProject2/test2.cproject.yml
   context: test2.Debug+CM0
   compiler: AC6
   device: RteTest_ARMCM0

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
@@ -1,4 +1,6 @@
 build:
+  solution: ../data/TestSolution/test.csolution.yml
+  project: ../data/TestSolution/TestProject2/test2.cproject.yml
   context: test2.Debug+CM3
   compiler: AC6
   device: RteTest_ARMCM3

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
@@ -1,4 +1,6 @@
 build:
+  solution: ../data/TestSolution/pre-include.csolution.yml
+  project: ../data/TestSolution/pre-include.cproject.yml
   context: pre-include+CM0
   compiler: AC6
   device: RteTest_ARMCM0

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -47,7 +47,7 @@ TEST_F(ProjMgrGeneratorUnitTests, GenDir) {
 
   EXPECT_EQ(0, ProjMgr::RunProjMgr(6, argv));
 
-  const string generatorInputFile = testinput_folder + "/TestSolution/TestProject3/outdir/TestProject3.Debug+TypeA.generate.yml";
+  const string generatorInputFile = testinput_folder + "/TestSolution/TestProject3/TestProject3.Debug+TypeA.cbuild.yml";
   const string generatedGPDSC = testinput_folder + "/TestSolution/TestProject3/gendir/RteTestGen_ARMCM0/RteTest.gpdsc";
 
   EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1258,6 +1258,12 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_Generator) {
   // Check generated CPRJs
   CompareFile(testoutput_folder + "/test-gpdsc.Debug+CM0.cprj",
     testinput_folder + "/TestGenerator/ref/test-gpdsc.Debug+CM0.cprj");
+
+  // Check generated cbuild YMLs
+  CompareFile(testoutput_folder + "/test-gpdsc.cbuild-idx.yml",
+    testinput_folder + "/TestGenerator/ref/test-gpdsc.cbuild-idx.yml");
+  CompareFile(testoutput_folder + "/test-gpdsc.Debug+CM0.cbuild.yml",
+    testinput_folder + "/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_TargetOptions)


### PR DESCRIPTION
Implements required things in the cbuild.yml according to [Generator (Proposal).md](https://github.com/Open-CMSIS-Pack/devtools/blob/main/tools/projmgr/docs/Manual/Generator%20(Proposal).md) and https://github.com/Open-CMSIS-Pack/devtools/issues/434#issuecomment-1337608400

Adds the following information when generating `*.cbuild.yml` files:
- csolution
- cproject
- input to component generators:
  * generator command
  * arguments
  * files
  * gpdsc file
  * working directory

In addition, this switches to use `*.cbuild.yml` as input to generators (`$G` set correspondingly)

Limitations/future work:
- In addition to device, board should probably be added to the build description schema and implementation
- GPDSC is not used to update `*.cbuild.yml`
- Working dir is inconsistent between `ProjMgrWorker::ExecuteGenerator()` and what is recorded in `*.cbuild.yml` (`gendir` should not be used for working dir, only destination)

Contributed by STMicroelectronics

Signed-off-by: Erik MÅLLBERG <erik.lundin@st.com>