### PR TITLE
RTE Model refactoring: preparation (#424)

### DIFF
--- a/libs/rtemodel/include/RteAttributes.h
+++ b/libs/rtemodel/include/RteAttributes.h
@@ -14,126 +14,21 @@
  */
 /******************************************************************************/
 
-#include <string>
+#include <XmlItem.h>
 #include <map>
 
-class RteAttributes
+class RteAttributes : public XmlItem
 {
 public:
   // default constructor
-  RteAttributes() {};
+  RteAttributes() noexcept : XmlItem() {};
 
   // parametrized constructor to instantiate with given attributes
   RteAttributes(const std::map<std::string, std::string>& attributes);
 
-  // destructor
-  virtual ~RteAttributes();
-
-  // copy constructor, uses default implementation
-  RteAttributes(const RteAttributes&) = default;
-
-  // assignment operator, uses default implementation
-  RteAttributes& operator=(const RteAttributes&) = default;
-
-  // move assignment operator, uses default implementation
-  RteAttributes& operator=(RteAttributes&&) noexcept = default;
-
-  /**
-   * @brief return XML tag name
-   * @return XML tag name
-  */
-  const std::string& GetTag() const { return m_tag; }
-  /**
-   * @brief set XML tag name
-   * @param tag XML tag name
-  */
-  void SetTag(const std::string& tag) { m_tag = tag; }
-  /**
-   * @brief determine XML attribute name if not empty, otherwise XML tag name
-   * @return attribute or tag name
-  */
-  virtual const std::string& GetName() const;
-
-  // attribute operations
+   // attribute operations
 public:
-  /**
-   * @brief add new XML attribute to XML tag
-   * @param name attribute name
-   * @param value attribute value
-   * @param insertEmpty true to insert, false to remove if attribute exists but is empty
-   * @return true if attribute is inserted/removed
-  */
-  bool AddAttribute(const std::string& name, const std::string& value, bool insertEmpty = true);
-  /**
-   * @brief add new attribute
-   * @param name attribute name
-   * @param value attribute value
-   * @return true if attribute is added
-  */
-  bool SetAttribute(const char* name, const char* value);
-  /**
-   * @brief add new attribute
-   * @param name attribute name
-   * @param value attribute value
-   * @param radix transformation radix
-   * @return true if attribute is added
-  */
-  bool SetAttribute(const char* name, long value, int radix = 10);
-  /**
-   * @brief remove attribute
-   * @param name attribute name
-   * @return true if attribute is removed
-  */
-  bool RemoveAttribute(const char* name);
-  /**
-   * @brief replace instance attributes with the given ones
-   * @param attributes given attributes
-   * @return true if attributes are set
-  */
-  bool SetAttributes(const std::map<std::string, std::string>& attributes);
-  /**
-   * @brief replace instance attributes with the given ones
-   * @param attributes given instance of RteAttributes
-   * @return true if attributes are set
-  */
-  bool SetAttributes(const RteAttributes& attributes);
-  /**
-   * @brief add missing attributes, optionally replace existing
-   * @param attributes map of name to value pairs to add
-   * @param replaceExisting true to replace existing attributes
-   * @return true if any attribute is set
-  */
-  bool AddAttributes(const std::map<std::string, std::string>& attributes, bool replaceExisting);
-  /**
-   * @brief clear all attributes of the instance
-   * @return true if any attribute is removed
-  */
-  bool ClearAttributes();
-  /**
-   * @brief determine number of attributes
-   * @return number of attributes
-  */
-  int GetCount() const { return (int)m_attributes.size(); }
-  /**
-   * @brief check if attribute list is empty
-   * @return true if attribute list is empty
-  */
-  bool IsEmpty() const { return m_attributes.empty(); }
-  /**
-   * @brief return list of attributes
-   * @return list of attributes
-  */
-  const std::map<std::string, std::string>& GetAttributes() const { return m_attributes; }
-  /**
-   * @brief concatenate instance attributes
-   * @return string containing all attributes
-  */
-  std::string GetAttributesString() const;
-  /**
-   * @brief concatenate attributes in a string conformed to XML syntax
-   * @return XML string containing attributes
-  */
-  std::string GetAttributesAsXmlString() const;
+
   /**
    * @brief determine prefix of attribute value
    * @param name attribute name
@@ -155,63 +50,8 @@ public:
    * @return suffix as integer of attribute value
   */
   int GetAttributeSuffixAsInt(const char* name, char delimiter = ':') const;
-  /**
-   * @brief convert attribute value to boolean value
-   * @param name attribute name
-   * @param defaultValue default value to be returned if attribute value is empty
-   * @return true if attribute value equal "1" or "true"
-  */
-  bool GetAttributeAsBool(const char* name, bool defaultValue = false) const;
-  /**
-   * @brief convert attribute value to integer value
-   * @param name attribute name
-   * @param defaultValue default value to be returned if attribute value is empty
-   * @return attribute value as integer
-  */
-  int GetAttributeAsInt(const char* name, int defaultValue = -1) const;
-  /**
-   * @brief convert attribute value to unsigned integer
-   * @param name attribute name
-   * @param defaultValue default value to be returned if attribute value is empty
-   * @return attribute value as unsigned integer
-  */
-  unsigned GetAttributeAsUnsigned(const char* name, unsigned defaultValue = 0) const;
-  /**
-   * @brief convert attribute value to unsigned long long
-   * @param name attribute name
-   * @param defaultValue default value to be returned if attribute value is empty
-   * @return attribute value as unsigned long long
-  */
-  unsigned long long GetAttributeAsULL(const char* name, unsigned long long defaultValue = 0L) const;
-  /**
-   * @brief return value of the attribute "generator"
-   * @return value of attribute "generator"
-  */
-  virtual const std::string& GetGeneratorName() const { return GetAttribute("generator"); }
-  /**
-   * @brief return attribute value of the attribute "generated" as boolean
-   * @return attribute value as boolean
-  */
-  virtual bool IsGenerated() const { return GetAttributeAsBool("generated"); }
-  /**
-   * @brief check if a component may be selected
-   * @return true if a component may be selected
-  */
-  virtual bool IsSelectable() const { return !IsGenerated() || GetAttributeAsBool("selectable") || HasAttribute("generator"); }
 
 public:
-  /**
-   * @brief determine attribute value
-   * @param name attribute name
-   * @return attribute value
-  */
-  virtual const std::string& GetAttribute(const std::string& name) const;
-  /**
-   * @brief check if attribute exists
-   * @param name attribute name
-   * @return true if attribute exists in the instance
-  */
-  virtual bool HasAttribute(const std::string& name) const;
   /**
    * @brief check if attribute has a certain value
    * @param pattern value to be checked, can contain wild cards
@@ -236,24 +76,7 @@ public:
    * @return true if attributes of the given instance exist in this instance
   */
   virtual bool Compare(const RteAttributes* other) const;
-  /**
-   * @brief check if all given attributes exist in the instance
-   * @param attributes given list of attributes
-   * @return true if all given attributes exist in the instance
-  */
-  virtual bool EqualAttributes(const std::map<std::string, std::string>& attributes) const;
-  /**
-   * @brief check if all attributes of the given instance exist in this instance
-   * @param other given instance of RteAttributes
-   * @return true if all attributes of the given instance exist in this instance
-  */
-  virtual bool EqualAttributes(const RteAttributes& other) const;
-  /**
-   * @brief check if all attributes of the given instance exist in this instance
-   * @param other pointer to given instance of RteAttributes
-   * @return true if all attributes of the given instance exist in this instance
-  */
-  virtual bool EqualAttributes(const RteAttributes* other) const;
+
   /**
    * @brief determine value of attribute related to version
    * @return value of attribute related to version
@@ -335,11 +158,6 @@ public:
   */
   static std::string GetPackageIDfromAttributes(const RteAttributes& attr, bool withVersion = true);
   /**
-   * @brief return value of attribute "url"
-   * @return value of attribute "url"
-  */
-  virtual const std::string& GetURL() const { return GetAttribute("url"); }
-  /**
    * @brief return value of component attribute "Cclass"
    * @return value of component attribute "Cclass"
   */
@@ -364,11 +182,7 @@ public:
    * @return value of component attribute "Cbundle"
   */
   virtual const std::string& GetCbundleName() const { return GetAttribute("Cbundle"); }
-  /**
-   * @brief check value of attribute "custom"
-   * @return true if value is "1" or "true"
-  */
-  virtual bool IsCustom() const { return GetAttributeAsBool("custom"); }
+
   /**
    * @brief return value of device attribute "Dfamily"
    * @return value of device attribute "Dfamily"
@@ -405,77 +219,6 @@ public:
   */
   virtual std::string GetFullDeviceName() const;
   /**
-   * @brief determine value of device attribute "remove" as boolean
-   * @return value of device attribute "remove" as boolean
-  */
-  virtual bool IsRemove() const { return GetAttributeAsBool("remove"); }
-  /**
-   * @brief determine value of device attribute "default" as boolean
-   * @return value of device attribute "default" as boolean
-  */
-  virtual bool IsDefault() const { return GetAttributeAsBool("default"); }
-  /**
-   * @brief return value of memory attribute "alias"
-   * @return value of memory attribute "alias"
-  */
-  virtual const std::string& GetAlias() const { return GetAttribute("alias"); }
-  /**
-   * @brief determine value of memory attribute "uninit" as boolean. Evaluates "init" if "uninit" does not exist
-   * @return value of memory attribute "uninit"
-  */
-  virtual bool IsNoInit() const
-  {
-    if (HasAttribute("uninit")) {
-      return GetAttributeAsBool("uninit");
-    }
-    return GetAttributeAsBool("init"); // backward compatibility
-  }
-  /**
-   * @brief check value of memory attribute "startup"
-   * @return true if value is "1" or "true"
-  */
-  virtual bool IsStartup() const { return GetAttributeAsBool("startup"); }
-  /**
-   * @brief return value of memory attribute "access"
-   * @return value of memory attribute "access"
-  */
-  virtual const std::string& GetAccess() const { return GetAttribute("access"); }
-  /**
-   * @brief check for memory read access
-   * @return true if read access specified
-  */
-  virtual bool IsReadAccess();
-  /**
-   * @brief check for memory write access
-   * @return true if write access specified
-  */
-  virtual bool IsWriteAccess();
-  /**
-   * @brief check for memory executable access
-   * @return true if executable access specified
-  */
-  virtual bool IsExecuteAccess();
-  /**
-   * @brief check for memory secure access
-   * @return true if secure access specified
-  */
-  virtual bool IsSecureAccess();
-  /**
-   * @brief check for memory non-secure access
-   * @return true if non-secure access specified
-  */
-  virtual bool IsNonSecureAccess();
-  /**
-   * @brief check for memory callable access
-   * @return true if callable access specified
-  */
-  virtual bool IsCallableAccess();
-  /**
-   * @brief check for memory peripheral area
-   * @return true if memory peripheral area specified
-  */
-  virtual bool IsPeripheralAccess();
-  /**
    * @brief determine value of attribute "condition"
    * @return condition ID
   */
@@ -490,11 +233,6 @@ public:
    * @return true if tag is API
   */
   virtual bool IsApi() const { return m_tag == "api"; }
-  /**
-   * @brief evaluate attribute "isDefaultVariant"
-   * @return true if value of attribute is "1" or "true"
-  */
-  virtual bool IsDefaultVariant() const { return GetAttributeAsBool("isDefaultVariant"); }
   /**
    * @brief return value of attribute "variant"
    * @return value of attribute "variant"
@@ -572,14 +310,6 @@ public:
   */
   virtual std::string ConstructComponentPreIncludeFileName() const;
   /**
-   * @brief clears list of attributes
-  */
-  virtual void Clear() { ClearAttributes(); }
-  /**
-   * @brief default does nothing
-  */
-  virtual void ProcessAttributes() {}; // called from SetAttributes(), AddAttributes() and ClearAttributes(), default does nothing
-  /**
    * @brief check if all given 'C' attributes exist in the instance
    * @param attributes given list of 'C' attributes
    * @return true if all given 'C' attributes exist in the instance
@@ -605,11 +335,7 @@ public:
   virtual bool MatchDevice(const std::map<std::string, std::string>& attributes) const;
 
 public:
-  static const std::string EMPTY_STRING;
-
-protected:
-  std::string m_tag; // an item can have a corresponding XML element with tag
-  std::map<std::string, std::string> m_attributes;
+  static const RteAttributes EMPTY_ATTRIBUTES;
 };
 
 typedef std::map<std::string, RteAttributes> RteAttributesMap;

--- a/libs/rtemodel/include/RteExample.h
+++ b/libs/rtemodel/include/RteExample.h
@@ -45,14 +45,32 @@ public:
   const std::set<std::string>& GetCategories() const { return m_categories; }
   /**
    * @brief get information about board for which the example is created
-   * @return board information as about RteAttributes
+   * @return board information as RteAttributes
   */
-  const RteAttributes& GetBoardInfo() const { return m_board; }
+  const RteAttributes& GetBoardInfo() const { return m_board ? *m_board : EMPTY_ATTRIBUTES;}
+
+  /**
+   * @brief get information about board for which the example is created
+   * @return board information as RteItem pointer
+  */
+  const RteItem* GetBoardInfoItem() const { return m_board; }
+
+  /**
+   * @brief get board name for which the example is created
+   * @return board name
+  */
+  const std::string& GetBoardName() const { return m_board ? m_board->GetAttribute("name") : EMPTY_STRING; }
+
+  /**
+     * @brief get board vendor name for which the example is created
+     * @return board vendor name
+    */
+  const std::string& GetBoardVendor() const { return m_board ? m_board->GetAttribute("vendor") : EMPTY_STRING; }
 
 public:
   /**
    * @brief check if example meta-data contain the specified keyword
-   * @param keyword keyword string to search for
+   * @param keyword string to search for in the collection of keywords
    * @return true if found
   */
   bool HasKeyword(const std::string& keyword) const;
@@ -132,10 +150,10 @@ protected:
   */
   virtual bool ProcessXmlElement(XMLTreeElement* xmlElement) override;
 
-  RteAttributes m_board; // development board the example refers to
+  RteItem* m_board; // development board the example refers to
   std::set<std::string> m_keywords; // example keywords
   std::set<std::string> m_categories; // example categories
-  std::list<RteAttributes*> m_componentAttributes; // component attributes of a component this example refers
+  std::list<RteItem*> m_componentAttributes; // component attributes of a component this example refers
   // Note: RteItem::m_children contain project files for different environments
 };
 /**

--- a/libs/rtemodel/include/RteInstance.h
+++ b/libs/rtemodel/include/RteInstance.h
@@ -122,18 +122,18 @@ public:
    * @brief get memory options
    * @return memory options as a reference to RteAttributes
   */
-  const RteAttributes& GetMemOpt() const { return m_memOpt; }
+  const RteItem& GetMemOpt() const { return m_memOpt; }
 
   /**
    * @brief get C/C++ compiler options
    * @return C/C++ compiler options as a reference to RteAttributes
   */
-  const RteAttributes& GetCOpt() const { return m_cOpt; }
+  const RteItem& GetCOpt() const { return m_cOpt; }
   /**
    * @brief get assembler options
    * @return assembler options as a reference to RteAttributes
   */
-  const RteAttributes& GetAsmOpt() const { return m_asmOpt; }
+  const RteItem& GetAsmOpt() const { return m_asmOpt; }
 
   /**
    * @brief get options of specified type (immutable)
@@ -181,9 +181,9 @@ private:
   bool m_bIncludeInLib;
   int m_instanceCount;
   VersionCmp::MatchMode m_VersionMatchMode;
-  RteAttributes m_memOpt;
-  RteAttributes m_cOpt;
-  RteAttributes m_asmOpt;
+  RteItem m_memOpt;
+  RteItem m_cOpt;
+  RteItem m_asmOpt;
 };
 
 typedef std::map<std::string, RteInstanceTargetInfo*> RteInstanceTargetInfoMap;
@@ -518,7 +518,7 @@ protected:
   virtual void CreateXmlTreeElementContent(XMLTreeElement* parentElement) const override;
 
 protected:
-  RteAttributes m_packageAttributes;
+  RteItem m_packageAttributes;
   RteInstanceTargetInfoMap m_targetInfos;
   bool m_bRemoved;
 };
@@ -1581,7 +1581,7 @@ protected:
   int m_instanceIndex; // zero-base instance index for multi-instance components, -1 otherwise
   std::string m_instanceName; // file name relative to project directory
   std::string m_fileName; // file name without path
-  RteAttributes m_componentAttributes;
+  RteItem m_componentAttributes;
 };
 
 #endif // RteInstance_H

--- a/libs/rtemodel/include/RteItem.h
+++ b/libs/rtemodel/include/RteItem.h
@@ -113,7 +113,7 @@ public:
    * @brief constructor
    * @param parent pointer to parent RteItem or nullptr if this item has no parent
   */
-  RteItem(RteItem* parent);
+  RteItem(RteItem* parent = nullptr);
 
   /**
    * @brief virtual destructor
@@ -121,30 +121,6 @@ public:
   virtual ~RteItem() override;
 
 public:
-
-  /**
-   * @brief get line number corresponding to position of the item's tag in associated file (is supported by XML parser)
-   * @return line number or 0 if not set
-  */
-  int GetLineNumber() const { return m_lineNumber; }
-
-  /**
-   * @brief set line number corresponding to position of the item's tag in associated file
-   * @param lineNumber 1-based integer
-  */
-  void SetLineNumber(int lineNumber) { m_lineNumber = lineNumber; }
-
-  /**
-   * @brief get item's text
-   * @return item's text string, empty if not set
-  */
-  const std::string& GetText() const { return m_text; }
-
-  /**
-   * @brief set item's text
-   * @param text string to set
-  */
-  void SetText(const std::string& text) { m_text = text; }
 
   /**
    * @brief get number of children
@@ -193,7 +169,7 @@ public:
    * @brief checks if this item is in valid state
    * @return true if item is valid
   */
-  bool IsValid() const { return m_bValid; }
+  bool IsValid() const override { return m_bValid; }
 
   /**
    * @brief get child item for specified ID
@@ -454,6 +430,74 @@ public:
   virtual std::string GetDownloadUrl(bool withVersion, const char* extension) const;
 
   /**
+ * @brief return value of memory attribute "alias"
+ * @return value of memory attribute "alias"
+*/
+  virtual const std::string& GetAlias() const { return GetAttribute("alias"); }
+  /**
+   * @brief determine value of memory attribute "uninit" as boolean. Evaluates "init" if "uninit" does not exist
+   * @return value of memory attribute "uninit"
+  */
+  virtual bool IsNoInit() const
+  {
+    if (HasAttribute("uninit")) {
+      return GetAttributeAsBool("uninit");
+    }
+    return GetAttributeAsBool("init"); // backward compatibility
+  }
+  /**
+   * @brief check value of memory attribute "startup"
+   * @return true if value is "1" or "true"
+  */
+  virtual bool IsStartup() const { return GetAttributeAsBool("startup"); }
+  /**
+   * @brief return value of memory attribute "access"
+   * @return value of memory attribute "access"
+  */
+  virtual const std::string& GetAccess() const { return GetAttribute("access"); }
+  /**
+   * @brief check for memory read access
+   * @return true if read access specified
+  */
+  virtual bool IsReadAccess();
+  /**
+   * @brief check for memory write access
+   * @return true if write access specified
+  */
+  virtual bool IsWriteAccess();
+  /**
+   * @brief check for memory executable access
+   * @return true if executable access specified
+  */
+  virtual bool IsExecuteAccess();
+  /**
+   * @brief check for memory secure access
+   * @return true if secure access specified
+  */
+  virtual bool IsSecureAccess();
+  /**
+   * @brief check for memory non-secure access
+   * @return true if non-secure access specified
+  */
+  virtual bool IsNonSecureAccess();
+  /**
+   * @brief check for memory callable access
+   * @return true if callable access specified
+  */
+  virtual bool IsCallableAccess();
+  /**
+   * @brief check for memory peripheral area
+   * @return true if memory peripheral area specified
+  */
+  virtual bool IsPeripheralAccess();
+  /**
+   * @brief determine value of attribute "condition"
+   * @return condition ID
+  */
+  virtual const std::string& GetConditionID() const { return GetAttribute("condition"); }
+
+
+  /**
    * @brief get RteCondition associated with the item
    * @return pointer RteCondition or nullptr if item has no condition
   */
@@ -477,6 +521,51 @@ public:
   * @return true if item's condition depends on selected board
   */
   virtual bool IsBoardDependent() const;
+
+  /**
+  * @brief return value of the attribute "generator"
+  * @return value of attribute "generator"
+  */
+  virtual const std::string& GetGeneratorName() const { return GetAttribute("generator"); }
+
+  /**
+ * @brief return attribute value of the attribute "generated" as boolean
+ * @return attribute value as boolean
+*/
+  virtual bool IsGenerated() const { return GetAttributeAsBool("generated"); }
+  /**
+   * @brief check if a component may be selected
+   * @return true if a component may be selected
+  */
+  virtual bool IsSelectable() const { return !IsGenerated() || GetAttributeAsBool("selectable") || HasAttribute("generator"); }
+  /**
+   * @brief check value of attribute "custom"
+   * @return true if value is "1" or "true"
+  */
+  virtual bool IsCustom() const { return GetAttributeAsBool("custom"); }
+
+  /**
+ * @brief determine value of device attribute "remove" as boolean
+ * @return value of device attribute "remove" as boolean
+*/
+  virtual bool IsRemove() const { return GetAttributeAsBool("remove"); }
+  /**
+   * @brief determine value of device attribute "default" as boolean
+   * @return value of device attribute "default" as boolean
+  */
+  virtual bool IsDefault() const { return GetAttributeAsBool("default"); }
+
+  /**
+ * @brief evaluate attribute "isDefaultVariant"
+ * @return true if value of attribute is "1" or "true"
+*/
+  virtual bool IsDefaultVariant() const { return GetAttributeAsBool("isDefaultVariant"); }
+
+  /**
+ * @brief return value of attribute "url"
+ * @return value of attribute "url"
+*/
+  virtual const std::string& GetURL() const { return GetAttribute("url"); }
 
   /**
    * @brief get errors found by Construct() or Validate()
@@ -590,9 +679,6 @@ protected:
 
   bool m_bValid; // validity flag
 
-  int m_lineNumber; // 1 - based line number in XML file
-
-  std::string m_text; // an item text, can be empty
   std::string m_ID; // an item ID, constructed in ConstructID() called by Construct()
 
   std::list<std::string> m_errors; // errors or warnings found by Construct() or Validate()

--- a/libs/rtemodel/src/RteDevice.cpp
+++ b/libs/rtemodel/src/RteDevice.cpp
@@ -68,7 +68,7 @@ void RteDeviceElement::GetEffectiveAttributes(RteAttributes& attributes) const
 {
   // fill in own attributes
   attributes.AddAttributes(m_attributes, false);
-  // get parent atributes
+  // get parent attributes
   RteDeviceElement* parent = GetDeviceElementParent();
   if (parent)
     parent->GetEffectiveAttributes(attributes);

--- a/libs/rtemodel/src/RteInstance.cpp
+++ b/libs/rtemodel/src/RteInstance.cpp
@@ -156,9 +156,9 @@ void RteInstanceTargetInfo::CopySettings(const RteInstanceTargetInfo& other)
   SetVersionMatchMode(other.GetVersionMatchMode());
   SetExcluded(other.IsExcluded());
   SetIncludeInLib(other.IsIncludeInLib());
-  m_memOpt = other.GetMemOpt();
-  m_cOpt = other.GetCOpt();
-  m_asmOpt = other.GetAsmOpt();
+  m_memOpt.SetAttributes(other.GetMemOpt());
+  m_cOpt.SetAttributes(other.GetCOpt());
+  m_asmOpt.SetAttributes(other.GetAsmOpt());
 }
 
 
@@ -488,7 +488,7 @@ string RteItemInstance::GetPackageID(bool withVersion) const
   if (IsPackageInfo())
     return RteAttributes::GetPackageID(withVersion);
 
-  return m_packageAttributes.GetPackageID(withVersion);
+  return RteAttributes::GetPackageIDfromAttributes(m_packageAttributes, withVersion);
 }
 
 const string& RteItemInstance::GetURL() const

--- a/libs/rtemodel/src/RteItem.cpp
+++ b/libs/rtemodel/src/RteItem.cpp
@@ -27,8 +27,7 @@ using namespace std;
 
 RteItem::RteItem(RteItem* parent) :
   m_parent(parent),
-  m_bValid(false),
-  m_lineNumber(0)
+  m_bValid(false)
 {
 }
 
@@ -359,6 +358,71 @@ string RteItem::GetDocFile() const
   }
   return EMPTY_STRING;
 }
+
+bool RteItem::IsReadAccess()
+{
+  if (HasAttribute("id")) {
+    return true;
+  }
+  const string& access = GetAccess();
+  return access.empty() || access.find('r') != string::npos;
+}
+
+bool RteItem::IsWriteAccess()
+{
+  const string& id = GetAttribute("id");
+  if (!id.empty()) {
+    return id.find("IRAM") == 0;
+  }
+  const string& access = GetAccess();
+  return access.find('w') != string::npos;
+}
+
+bool RteItem::IsExecuteAccess()
+{
+  const string& id = GetAttribute("id");
+  if (!id.empty()) {
+    return id.find("IROM") == 0;
+  }
+  const string& access = GetAccess();
+  return access.find('x') != string::npos;
+}
+
+bool RteItem::IsSecureAccess()
+{
+  if (HasAttribute("id")) {
+    return true;
+  }
+  const string& access = GetAccess();
+  return access.find('s') != string::npos && access.find('n') == string::npos;
+}
+bool RteItem::IsNonSecureAccess()
+{
+  if (HasAttribute("id")) {
+    return false;
+  }
+  const string& access = GetAccess();
+  return access.find('n') != string::npos && access.find('s') == string::npos;
+}
+
+bool RteItem::IsCallableAccess()
+{
+  if (HasAttribute("id")) {
+    return false;
+  }
+  const string& access = GetAccess();
+  return access.find('c') != string::npos;
+}
+
+bool RteItem::IsPeripheralAccess()
+{
+  if (HasAttribute("id")) {
+    return false;
+  }
+  const string& access = GetAccess();
+  return access.find('p') != string::npos;
+}
+
 
 string RteItem::GetOriginalAbsolutePath() const
 {

--- a/libs/rtemodel/test/CMakeLists.txt
+++ b/libs/rtemodel/test/CMakeLists.txt
@@ -1,5 +1,11 @@
 SET(TEST_SOURCE_FILES src/RteModelTest.cpp src/RteExampleTest.cpp
- src/RteModelTestConfig.h src/RteModelTestConfig.cpp)
+ src/RteModelTestConfig.h src/RteModelTestConfig.cpp src/RteChk.cpp src/RteChkTest.cpp )
+
+ SET(RTE_CHK_HEADER_FILES src/RteChk.h)
+ SET(RTE_CHK_SOURCE_FILES src/RteChk.cpp src/RteChkMain.cpp)
+ add_executable(RteChk ${RTE_CHK_SOURCE_FILES} ${RTE_CHK_HEADER_FILES})
+ target_link_libraries(RteChk PUBLIC
+  ErrLog RteModel RteFsUtils RteUtils XmlReader XmlTree XmlTreeSlim)
 
 add_definitions(-DGLOBAL_TEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../../test")
 

--- a/libs/rtemodel/test/src/RteChk.cpp
+++ b/libs/rtemodel/test/src/RteChk.cpp
@@ -1,0 +1,704 @@
+/*
+ * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+// RteChk.cpp : RTE Model tester
+//
+
+#include "RteChk.h"
+#include "XMLTreeSlim.h"
+#include "RteValueAdjuster.h"
+
+#include "RteModel.h"
+#include "RteFsUtils.h"
+
+#include "ErrLog.h"
+
+#include <time.h>
+#include <map>
+#include <algorithm>
+using namespace std;
+
+static clock_t clockInMsec() {
+  static clock_t CLOCK_PER_MSEC = CLOCKS_PER_SEC / 1000;
+  clock_t t = clock();
+  if (CLOCK_PER_MSEC <= 1)
+    return t;
+  return (t / CLOCK_PER_MSEC);
+}
+
+class RteXmlParser : public XMLTreeSlim
+{
+public:
+  RteXmlParser() :XMLTreeSlim(0, true) { m_XmlValueAdjuster = new RteValueAdjuster(); }
+  ~RteXmlParser() { delete m_XmlValueAdjuster; }
+
+};
+
+// Visitor design patter iteration through model
+class RteChkErrorVistior : public RteVisitor
+{
+public:
+  virtual VISIT_RESULT Visit(RteItem* rteItem)
+  {
+    if (rteItem->IsValid())
+      return SKIP_CHILDREN;
+
+    const list<string>& errors = rteItem->GetErrors();
+    if (errors.empty())
+      return CONTINUE_VISIT;
+    list<string>::const_iterator it;
+    for (it = errors.begin(); it != errors.end(); it++) {
+      string sErr = (*it);
+      cerr << sErr << endl;
+    }
+    return CONTINUE_VISIT;
+  }
+};
+
+
+RteChk::RteChk(std::ostream& os) :
+  m_flags(TIME|VALIDATE),
+  m_npdsc(0),
+  m_indent(0),
+  m_os(os)
+{
+  m_xmlTree = new RteXmlParser();
+  m_rteModel = new RteModel();
+  m_rteModel->SetUseDeviceTree(true);
+}
+
+RteChk::~RteChk()
+{
+  delete m_xmlTree;
+  delete m_rteModel;
+};
+
+void RteChk::SetFlag(unsigned flag, char op)
+{
+  if (op == '+') {
+    m_flags |= flag;
+  } else if (op == '-') {
+    m_flags &= ~flag;
+  }
+}
+
+bool RteChk::IsFlagSet(unsigned flag) const
+{
+  return (m_flags & flag) != 0;
+}
+
+unsigned RteChk::CharToFlagValue(char ch)
+{
+  switch (ch) {
+  case 'a':
+    return ALL;
+  case 'd':
+    return DUMP;
+  case 't':
+    return TIME;
+  case 'v':
+    return VALIDATE;
+  case 'c':
+    return COMPONENTS;
+  case 'D':
+    return DFP;
+  case 'B':
+    return BSP;
+  case 'p':
+    return PACKS;
+  default:
+    break;
+  };
+  return NONE;
+}
+
+int RteChk::ProcessArguments(int argc, char* argv[])
+{
+  for (int i = 1; i < argc; i++) {
+    char *ptr = argv[i];
+    if (*ptr == '-' || *ptr == '+') {
+      char op = *ptr;
+      ptr++;
+      SetFlag(CharToFlagValue(*ptr), op);
+      continue;
+    }
+    AddFileDir(argv[i]);
+
+    m_xmlTree->AddFileName(argv[i]);
+  }
+
+  if (m_files.empty() && m_dirs.empty()) {
+    m_os << "Usage: " << endl;
+    m_os << "RteChk [-t] [-d] FILE1.pdsc|DIR1 [DIR2 FILE2.pdsc ...]";
+    return -1;
+  }
+  return 0;
+}
+
+void RteChk::AddFileDir(const string& path) {
+  error_code ec;
+  if (!fs::exists(path, ec))
+    return;
+  if (fs::is_directory(path, ec)) {
+    m_dirs.insert(path);
+  } else {
+    m_files.insert(path);
+  }
+}
+
+unsigned long RteChk::CollectFiles() {
+
+  list<string> files;
+  for (const string& dir : m_dirs) {
+    RteFsUtils::GetPackageDescriptionFiles(files, dir, 3);
+  }
+  for (const string& file : m_files) {
+    files.push_back(file);
+  }
+
+  if (!files.empty()) {
+    m_xmlTree->SetFileNames(files, false);
+  }
+  return files.size();
+}
+
+
+int RteChk::RunCheckRte()
+{
+  m_os << "Collecting pdsc files ";
+  clock_t t0 = clockInMsec();
+  m_npdsc = CollectFiles();
+  clock_t t1 = clockInMsec();
+  if (IsFlagSet(TIME)) {
+    m_os << "(" << t1 - t0 << " ms) ";
+  }
+  m_os << m_npdsc << " files found" << endl;
+  if (!m_npdsc) {
+    m_os << "Nothing to process" << endl;
+    return 1;
+  }
+
+  m_xmlTree->Init();
+  m_os << "Parsing XML " ;
+  bool success = m_xmlTree->ParseAll();
+  clock_t t2 = clockInMsec();
+  if (IsFlagSet(TIME)) {
+    m_os << "(" << t2 - t1 << " ms) ";
+  }
+
+  if (success)
+    m_os << "passed";
+  else {
+    m_os << "failed";
+  }
+  m_os << std::endl;
+  if (!success || IsFlagSet(VALIDATE)) {
+    const list<string>& errors = m_xmlTree->GetErrorStrings();
+    for (auto it = errors.begin(); it != errors.end(); it++) {
+      m_os << *it << endl;
+    }
+  }
+
+  if (!success)
+    return 1;
+
+  m_os << endl<< "Constructing Model ";
+
+  success = m_rteModel->Construct(m_xmlTree);
+
+  clock_t t3 = clockInMsec();
+  if (IsFlagSet(TIME)) {
+    m_os << "(" << t3 - t2 << " ms. Read+Construct: " << t3 - t1 << " ms) ";
+  }
+
+  if (success)
+    m_os << "passed";
+  else
+    m_os << "failed";
+  m_os << endl;
+
+  m_os << endl << "Cleaning XML data";
+  m_xmlTree->Clear();
+  clock_t t4 = clockInMsec();
+  if (IsFlagSet(TIME)) {
+    m_os << " (" << t4 - t3 << " ms. Total: " << t4 - t1 << " ms)";
+  }
+  m_os << endl;
+
+  m_rteModel->ClearErrors();
+  if (IsFlagSet(VALIDATE)) {
+    m_os << endl << "Validating Model ";
+    success = m_rteModel->Validate();
+    clock_t t5 = clockInMsec();
+    if (IsFlagSet(TIME)) {
+      m_os << "(" << t5 - t3 << " ms. Total: " << t5 - t1 << " ms) ";
+    }
+  }
+
+  if (success)
+    m_os << "passed";
+  else
+    m_os << "failed";
+  m_os << std::endl;
+
+  if (!success) {
+    RteChkErrorVistior visitor;
+    m_rteModel->AcceptVisitor(&visitor); // an example of "Visitor" design pattern tree iteration
+  }
+  if (IsFlagSet(DUMP)) {
+    DumpModel(); // an example of classic iteration over model tree
+  }
+
+  // print summary information
+  m_os << endl << "Summary:" << endl;
+  m_os << "Packs: " << m_npdsc << endl;
+  ListPacks();
+  m_os << endl;
+  m_os << "Components: " << m_rteModel->GetComponentCount() << endl;
+  ListComponents();
+  m_os << endl;
+  m_os << "Devices: " << m_rteModel->GetDeviceCount() << endl;
+  m_os << "Boards: " << m_rteModel->GetBoards().size() << endl;
+
+  m_os << endl << "completed" << endl;
+  ErrLog::Get()->ClearLogMessages();
+  return success ? 0 : 1;
+}
+
+
+
+void RteChk::PrintText(const string& str)
+{
+  if (str.empty())
+    return;
+  for (int i = 0; i < m_indent; i++)
+    m_os << " ";
+  m_os << str << endl;
+}
+
+
+void RteChk::DumpDeviceElement(RteDeviceElement* e)
+{
+  if (!e)
+    return;
+  RteAttributes rteAttributes;
+  e->GetEffectiveAttributes(rteAttributes); // also inherited/overwritten
+  RteAttributes* pAttributes = &rteAttributes;
+  const string& tag = e->GetTag();
+  const string& name = e->GetName();
+
+  string elementString = "<" + tag + ">";
+  if (!e->HasAttribute("name") && tag != name) {
+    elementString += "(" + name + ")";
+  }
+  elementString += " " + pAttributes->GetAttributesAsXmlString();
+  PrintText(elementString);
+
+  const string& descr = e->GetDescription();
+  if (!descr.empty()) {
+    string sDescr = "Description: ";
+    sDescr += descr;
+    // remove newlines
+    sDescr.erase(std::remove(sDescr.begin(), sDescr.end(), '\r'), sDescr.end());
+    sDescr.erase(std::remove(sDescr.begin(), sDescr.end(), '\n'), sDescr.end());
+
+    PrintText(sDescr);
+  }
+}
+
+
+void RteChk::DumpEffectiveContent(RteDeviceProperty* d)
+{
+  RteDevicePropertyGroup* pg = dynamic_cast<RteDevicePropertyGroup*>(d);
+  if (!pg)
+    return;
+
+  const list<RteDeviceProperty*>& props = pg->GetEffectiveContent();
+  for (auto itp = props.begin(); itp != props.end(); itp++) {
+    RteDeviceProperty* p = *itp;
+    DumpDeviceElement(p);
+    DumpEffectiveContent(p);
+  }
+}
+
+
+void RteChk::DumpEffectiveProperties(RteDeviceItem* d, const string& processorName, bool endLeaf)
+{
+  PrintText("Properties");
+  m_indent++;
+  RteDevicePropertyMap props;
+  if (!endLeaf) {
+    d->GetProperties(props);
+  }
+  const RteDevicePropertyMap& propMap = endLeaf ? d->GetEffectiveProperties(processorName) : props;
+
+  for (auto it = propMap.begin(); it != propMap.end(); it++) {
+    const list<RteDeviceProperty*>& props = it->second;
+    for (auto itp = props.begin(); itp != props.end(); itp++) {
+      RteDeviceProperty* p = *itp;
+      DumpDeviceElement(p);
+      if (p->GetTag() != "sequence")
+        DumpEffectiveContent(p);
+    }
+  }
+  m_indent--;
+}
+
+
+void RteChk::DumpDeviceItem(RteDeviceItem* d, const string& dName, bool endLeaf)
+{
+  m_indent++;
+  DumpDeviceElement(d);
+  string processorName = RteUtils::GetSuffix(dName);
+  DumpEffectiveProperties(d, processorName, endLeaf);
+  m_indent--;
+}
+
+
+
+void RteChk::DumpDeviceAggregate(RteDeviceItemAggregate* da)
+{
+  if (!da)
+    return;
+
+  if (da->GetType() > RteDeviceItem::VENDOR_LIST) {
+    PrintText(da->GetName());
+  }
+  m_indent++;
+  if (da->GetType() > RteDeviceItem::VENDOR) {
+    // add device items;
+    const RteDeviceItemMap& deviceItems = da->GetAllDeviceItems();
+    for (auto itd = deviceItems.begin(); itd != deviceItems.end(); itd++) {
+      DumpDeviceItem(itd->second, da->GetName(), da->GetChildCount() == 0);
+    }
+  }
+
+  // add children
+  const auto children = da->GetChildren();
+  for (auto it = children.begin(); it != children.end(); it++) {
+    DumpDeviceAggregate(it->second);
+  }
+  m_indent--;
+}
+
+
+void RteChk::DumpConditions(RtePackage* pack)
+{
+  RteItem* conditions = pack->GetConditions();
+  if (!conditions)
+    return;
+  const list<RteItem*>& conditionList = conditions->GetChildren();
+  for (auto itcond = conditionList.begin(); itcond != conditionList.end(); itcond++) {
+    RteItem *pCond = *itcond;
+    if (pCond == NULL) {
+      continue;
+    }
+
+    m_os << " Condition " << pCond->GetName() << endl;
+    m_os << " Desc: " << pCond->GetDescription() << endl;
+    // condition expressions
+    const list<RteItem*>& exprlist = pCond->GetChildren();
+    for (auto itexpr = exprlist.begin(); itexpr != exprlist.end(); itexpr++) {
+      RteConditionExpression* expr = dynamic_cast<RteConditionExpression*>(*itexpr);
+      if (!expr)
+        continue;
+      m_os << " " << expr->GetName() << " " << expr->GetAttributesAsXmlString() << endl;
+    }
+  }
+}
+
+void RteChk::DumpComponents(RtePackage* pack)
+{
+  // components
+  RteItem* components = pack->GetComponents();
+  if (components) {
+    const list<RteItem*>& compList = components->GetChildren();
+    for (auto itc = compList.begin(); itc != compList.end(); itc++) {
+      RteComponent *pComp = dynamic_cast<RteComponent*>(*itc);
+      if (pComp == NULL) {
+        continue;
+      }
+      PrintComponent(pComp, true);
+    }
+  }
+}
+
+
+void RteChk::DumpExamples(RtePackage* pack)
+{
+  // Examples
+  RteItem* examples = pack->GetExamples();
+
+  if (examples) {
+    const list<RteItem*>& exampleList = examples->GetChildren();
+    for (auto itexmp = exampleList.begin(); itexmp != exampleList.end(); itexmp++) {
+      RteExample *pExmp = dynamic_cast<RteExample*>(*itexmp);
+      if (pExmp == NULL) {
+        continue;
+      }
+
+      m_os << " " << pExmp->GetTag() << " ";
+      {
+        auto attributes = pExmp->GetAttributes();
+        for (auto itattr = attributes.begin(); itattr != attributes.end(); itattr++) {
+          m_os << itattr->first << ":" << itattr->second << " " ;
+        }
+        m_os << endl;
+      }
+
+      m_os << " Desc: " << pExmp->GetDescription() << endl;
+
+      // board
+      RteAttributes board = pExmp->GetBoardInfo();
+      m_os << " Board: " << board.GetAttributesString() << endl;
+
+      auto children = pExmp->GetChildren();
+      for (auto itchild = children.begin(); itchild != children.end(); ++itchild) {
+        RteItem *pi = *itchild;
+        if (pi == NULL) {
+          continue;
+        }
+
+        m_os << " " << pi->GetTag() << ": ";
+        m_os << pi->GetAttributesAsXmlString() << endl;
+      }
+
+      m_os << " --- Categories --- " << endl;
+      auto listCat = pExmp->GetCategories();
+      for (auto itcat = listCat.begin(); itcat != listCat.end(); ++itcat) {
+        m_os << " " << *itcat << endl;
+      }
+
+      m_os << " --- Keywords --- " << endl;
+      auto listKw = pExmp->GetKeywords();
+      for (auto itkey = listKw.begin(); itkey != listKw.end(); ++itkey) {
+        m_os << " " << *itkey << endl;
+      }
+    }
+  }
+}
+
+void RteChk::DumpModel()
+{
+  if (m_rteModel->IsEmpty())
+    return;
+  const list<RteItem*>& packs = m_rteModel->GetChildren();
+  int i = 0;
+  for (auto it = packs.begin(); it != packs.end(); it++, i++) {
+    RtePackage* pack = dynamic_cast<RtePackage*>(*it);
+    if (pack == NULL) {
+      continue;
+    }
+    m_os << endl;
+
+    m_os << "Pack[" << i << "] : " << pack->GetVendorName()
+      << "." << pack->GetName()
+      << "." << pack->GetVersionString()
+      << " (";
+    switch (RteChk::GetPackageType(pack)) {
+    case PACK_GENERIC:
+      m_os << "generic";
+      break;
+    case PACK_DFP:
+      m_os << "DFP";
+      break;
+    case PACK_BSP:
+      m_os << "BSP";
+      break;
+    };
+    m_os << " )" << endl;
+    m_os << " Filename:" << RteUtils::ExtractFileName(pack->GetPackageFileName()) << endl;
+
+    m_os << "--- Conditions --- " << endl;
+    DumpConditions(pack);
+    m_os << "--- Components --- " << endl;
+    DumpComponents(pack);
+    m_os << "--- Examples --- " << endl;
+    DumpExamples  (pack);
+  }
+  // Devices
+  m_os << "--- Device Tree --- " << endl;
+  RteDeviceItemAggregate* da = m_rteModel->GetDeviceTree();
+  DumpDeviceAggregate(da);
+
+}
+
+void RteChk::ListPacks()
+{
+  RtePackageMap packs;
+  CollectPacks(packs, PACK_GENERIC);
+  m_os << "Generic: " << packs.size() << endl;
+  if (IsFlagSet(PACKS)) {
+    PrintPacks(packs);
+  }
+  packs.clear();
+  CollectPacks(packs, PACK_DFP);
+  m_os << "DFP: " << packs.size() << endl;
+  if (IsFlagSet(PACKS) && IsFlagSet(DFP)) {
+    PrintPacks(packs);
+  }
+  packs.clear();
+  CollectPacks(packs, PACK_BSP);
+  m_os << "BSP: " << packs.size() << endl;
+  if (IsFlagSet(PACKS) && IsFlagSet(BSP)) {
+    PrintPacks(packs);
+  }
+}
+
+
+void RteChk::CollectPacks(RtePackageMap& packs, PACK_TYPE packType)
+{
+  const list<RteItem*>& children = m_rteModel->GetChildren();
+  int i = 0;
+  for (auto it = children.begin(); it != children.end(); it++, i++) {
+    RtePackage* pack = dynamic_cast<RtePackage*>(*it);
+    if (pack == NULL) {
+      continue;
+    }
+    const string& id = pack->GetID();
+    if (packType == GetPackageType(pack)) {
+      packs[id] = pack;
+    }
+  }
+}
+
+void RteChk::PrintPacks(const RtePackageMap& packs)
+{
+  for (auto& it : packs) {
+    m_os << it.first << endl;
+  }
+  m_os << endl;
+
+}
+
+PACK_TYPE RteChk::GetPackageType(RtePackage* pack)
+{
+  const string& id = pack->GetID();
+  PACK_TYPE pType = PACK_GENERIC;
+  if (id.find("ARM.CMSIS") == string::npos) {
+    if (pack->GetDeviceFamiles()) {
+      pType = PACK_DFP;
+    } else if (pack->GetItem("boards") != nullptr) {
+      pType = PACK_BSP;
+    }
+  }
+  return pType;
+}
+
+void RteChk::ListComponents()
+{
+  RteComponentMap components;
+  CollectComponents(components, PACK_GENERIC);
+  m_os << "From generic packs: " << components.size() << endl;
+  if (IsFlagSet(COMPONENTS)) {
+    PrintComponents(components, false);
+  }
+  components.clear();
+  CollectComponents(components, PACK_DFP);
+  m_os << "From DFP: " << components.size() << endl;
+  if (IsFlagSet(COMPONENTS) && IsFlagSet(DFP)) {
+    PrintComponents(components, false);
+  }
+  components.clear();
+  CollectComponents(components, PACK_BSP);
+  m_os << "From BSP: " << components.size() << endl;
+  if (IsFlagSet(COMPONENTS) && IsFlagSet(BSP)) {
+    PrintComponents(components, false);
+  }
+}
+
+void RteChk::CollectComponents(RteComponentMap& components, PACK_TYPE packType)
+{
+  for (auto& it : m_rteModel->GetComponentList()) {
+    RteComponent* pComp = it.second;
+    const string& id = it.first;
+    RtePackage* pack = pComp->GetPackage();
+    if (GetPackageType(pack) == packType) {
+      components[id] = pComp;
+    }
+  }
+}
+
+
+void RteChk::PrintComponents(RteComponentMap& components, bool bFiles)
+{
+  for (auto& it : components) {
+    PrintComponent(it.second, bFiles);
+  }
+}
+
+void RteChk::PrintComponent(RteComponent* pComp, bool bFiles)
+{
+  m_os << pComp->GetFullDisplayName() << endl;
+  m_os << " " << pComp->GetTag() << " " ;
+  {
+    m_os << "Cbundle=" << pComp->GetCbundleName() << ", ";
+    m_os << "Cclass=" << pComp->GetCclassName() << ", ";
+    m_os << "Cgroup=" << pComp->GetCgroupName() << ", ";
+    m_os << "Csub=" << pComp->GetCsubName() << ", ";
+    m_os << "Cvariant=" << pComp->GetCvariantName() << ", ";
+    m_os << "Cvendor=" << pComp->GetVendorString() << ", ";
+    m_os << "Cversion=" << pComp->GetVersionString() << ", ";
+    m_os << "Capiversion=" << pComp->GetApiVersionString() << ", ";
+    m_os << "Condition=" << pComp->GetConditionID();
+    m_os << endl;
+  }
+  m_os << "     Desc: " << pComp->GetDescription() << endl;
+  RteFileContainer* fileContainer = pComp->GetFileContainer();
+
+  if (fileContainer && bFiles) {
+    // files
+    m_os << " --- Files --- " << endl;
+    const list<RteItem*>& files = fileContainer->GetChildren();
+    for (auto itf = files.begin(); itf != files.end(); itf++) {
+      RteFile *pFile = dynamic_cast<RteFile*>(*itf);
+      if (pFile == NULL) {
+        continue;
+      }
+
+      m_os << " " << pFile->GetTag() << " ";
+      m_os << pFile->GetName() << " - ";
+      m_os << pFile->GetCategoryString() << " Copy:" << (pFile->IsConfig() ? "yes" : "no");
+      m_os << " Condition=" << pFile->GetConditionID();
+      m_os << endl;
+    }
+  }
+  m_os << endl;
+}
+
+unsigned long RteChk::GetPackCount() const
+{
+  return m_npdsc;
+}
+int RteChk::GetComponentCount() const
+{
+  return m_rteModel ? m_rteModel->GetComponentCount() : -1;
+}
+int RteChk::GetDeviceCount() const
+{
+  return m_rteModel ? m_rteModel->GetDeviceCount() : -1;
+}
+int RteChk::GetBoardCount() const
+{
+  return m_rteModel ? (int)m_rteModel->GetBoards().size() : -1;
+}
+
+
+//------------------------------------------------------------------
+int RteChk::CheckRte(int argc, char* argv[])
+{
+  RteChk rteChk;
+
+  int res = rteChk.ProcessArguments(argc, argv);
+  if (res != 0)
+    return res;
+
+  cout << ">>>> Start RTE check" << endl;
+  res = rteChk.RunCheckRte();
+  cout << "<<<< End RTE check : " << res << endl << endl;
+
+  return res;
+}

--- a/libs/rtemodel/test/src/RteChk.h
+++ b/libs/rtemodel/test/src/RteChk.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// RteChk.h : RTE Model tester
+
+#include "RtePackage.h"
+#include "RteComponent.h"
+
+#include <string>
+#include <set>
+#include <iostream>
+
+class RteModel;
+class RteDeviceElement;
+class RteDeviceProperty;
+class RteDeviceItem;
+class RteDeviceItemAggregate;
+class XMLTree;
+
+enum PACK_TYPE { PACK_GENERIC, PACK_DFP, PACK_BSP };
+
+class RteChk
+{
+public:
+  RteChk(std::ostream& os = std::cout);
+  ~RteChk();
+
+  static int CheckRte(int argc, char* argv[]);
+
+  void SetFlag(unsigned flag, char op = '+');
+  unsigned GetFlags() const { return m_flags; }
+  bool IsFlagSet(unsigned flag) const;
+
+  int RunCheckRte();
+  void AddFileDir(const std::string& path);
+
+  int ProcessArguments(int argc, char* argv[]);
+
+  void DumpModel();
+
+  void PrintText(const std::string& str);
+
+  void DumpConditions(RtePackage* pack);
+  void DumpComponents(RtePackage* pack);
+  void DumpExamples  (RtePackage* pack);
+
+  void DumpDeviceAggregate(RteDeviceItemAggregate* da);
+  void DumpDeviceItem(RteDeviceItem* d, const std::string& dName, bool endLeaf);
+  void DumpDeviceElement(RteDeviceElement* e);
+  void DumpEffectiveContent(RteDeviceProperty* d);
+  void DumpEffectiveProperties(RteDeviceItem* d, const std::string& processorName, bool endLeaf);
+
+  void ListPacks();
+  void CollectPacks(RtePackageMap& packs, PACK_TYPE packType);
+  void PrintPacks(const RtePackageMap& packs);
+
+  void ListComponents();
+  void CollectComponents(RteComponentMap& components, PACK_TYPE packType);
+  void PrintComponents(RteComponentMap& components, bool bFiles);
+  void PrintComponent(RteComponent* pComp, bool bFiles);
+
+  unsigned long GetPackCount() const;
+  int GetComponentCount() const;
+  int GetDeviceCount() const;
+  int GetBoardCount() const;
+
+  const RteModel* GetRteModel() const { return m_rteModel; }
+
+  unsigned long CollectFiles();
+  static unsigned CharToFlagValue(char ch);
+  static PACK_TYPE GetPackageType(RtePackage* pack);
+
+  // flags
+  static const unsigned DUMP = 0x0001;
+  static const unsigned TIME = 0x0002;
+  static const unsigned VALIDATE = 0x0004;
+  static const unsigned COMPONENTS = 0x0008;
+  static const unsigned PACKS = 0x0010;
+  static const unsigned DFP = 0x0020;
+  static const unsigned BSP = 0x0040;
+  static const unsigned ALL = 0xFFFF;
+  static const unsigned NONE = 0x0000;
+
+private:
+  RteModel* m_rteModel;
+  XMLTree* m_xmlTree;
+  std::set<std::string> m_files;
+  std::set<std::string> m_dirs;
+
+  unsigned m_flags;
+  unsigned long m_npdsc;
+  int m_indent;
+  std::ostream& m_os;
+};

--- a/libs/rtemodel/test/src/RteChkMain.cpp
+++ b/libs/rtemodel/test/src/RteChkMain.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+
+// RteChkMain.cpp : RTE Model tester executable
+//
+
+#include "RteChk.h"
+
+//------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  return RteChk::CheckRte(argc, argv);
+}

--- a/libs/rtemodel/test/src/RteChkTest.cpp
+++ b/libs/rtemodel/test/src/RteChkTest.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "gtest/gtest.h"
+
+#include "RteModelTestConfig.h"
+
+#include "RteChk.h"
+
+#include "RteFsUtils.h"
+using namespace std;
+
+
+TEST(RteChkTest, Summary) {
+
+const string summary = "Collecting pdsc files 5 files found\n\
+Parsing XML passed\n\
+\n\
+Constructing Model passed\n\
+\n\
+Cleaning XML data\n\
+\n\
+Validating Model passed\n\
+\n\
+Summary:\n\
+Packs: 5\n\
+Generic: 1\n\
+DFP: 3\n\
+BSP: 1\n\
+\n\
+Components: 40\n\
+From generic packs: 24\n\
+From DFP: 16\n\
+From BSP: 0\n\
+\n\
+Devices: 10\n\
+Boards: 11\n\
+\n\
+completed\n";
+
+  list<string> files;
+  RteFsUtils::GetPackageDescriptionFiles(files, RteModelTestConfig::CMSIS_PACK_ROOT, 3);
+  ASSERT_TRUE(files.size() > 0);
+
+  stringstream ss;
+  RteChk rteChk(ss);
+  rteChk.SetFlag(RteChk::TIME, '-');
+  rteChk.AddFileDir(RteModelTestConfig::CMSIS_PACK_ROOT);
+  int res = rteChk.RunCheckRte();
+  ASSERT_EQ(res, 0);
+  ASSERT_EQ(rteChk.GetPackCount(), 5);
+  ASSERT_EQ(rteChk.GetComponentCount(), 40);
+  ASSERT_EQ(rteChk.GetDeviceCount(), 10);
+  ASSERT_EQ(rteChk.GetBoardCount(), 11);
+
+  string s = RteUtils::EnsureLf(ss.str());
+  ASSERT_EQ(s, summary);
+}
+// end of RteChkTest.cpp

--- a/libs/xmltree/include/XmlItem.h
+++ b/libs/xmltree/include/XmlItem.h
@@ -26,32 +26,58 @@ public:
   /**
    * @brief default constructor
   */
-  XmlItem() :m_lineNumber(0) {};
+  XmlItem() noexcept :m_lineNumber(0) {};
 
   /**
-   * @brief constructor
+   * @brief copy constructor, uses default implementation
+  */
+  XmlItem(const XmlItem&) = default;
+
+  /**
+   * @brief assignment operator, uses default implementation
+  */
+  XmlItem& operator=(const XmlItem&) = default;
+
+  /**
+   * @brief move assignment operator, uses default implementation
+  */
+  XmlItem& operator=(XmlItem&&) noexcept = default;
+
+  /**
+   * @brief parametrized constructor
    * @param tag XML tag
   */
   XmlItem(const std::string& tag) : m_tag(tag), m_lineNumber(0) {};
 
   /**
-   * @brief destructor
+   * @brief parametrized constructor to instantiate with given attributes
+   * @param attributes collection as key to value pairs
+  */
+  XmlItem(const std::map<std::string, std::string>& attributes) : m_attributes(attributes), m_lineNumber(0) {};
+
+  /**
+   * @brief virtual destructor
   */
   virtual ~XmlItem() {};
 
   /**
-   * @brief remove all attributes of the instance
+   * @brief clears the item, default removes all attributes of the instance
   */
   virtual void Clear();
 
   /**
-   * @brief called to construct a XML node with attributes and child elements. Default does nothing.
+   * @brief clear all attributes of the instance
   */
-  virtual void Construct() {};
+  virtual void ClearAttributes();
+
+  /**
+   * @brief called to construct the item with attributes and child elements. Default does nothing.
+  */
+  virtual void Construct() {/* default does nothing */};
 
   /**
    * @brief check if XML element is empty, i.e. if text and attributes list are empty
-   * @return
+   * @return true if empty
   */
   virtual bool IsEmpty() { return m_text.empty() && m_attributes.empty(); }
 
@@ -68,6 +94,13 @@ public:
   void SetTag(const std::string& tag) { m_tag = tag; }
 
   /**
+  * @brief return item's name
+  * @return item name, default returns "name" attribute if exists, otherwise item's tag
+ */
+  virtual const std::string& GetName() const;
+
+
+  /**
    * @brief getter for tag text
    * @return string containing tag text
   */
@@ -75,28 +108,69 @@ public:
 
   /**
    * @brief setter for tag text
-   * @param text text be set
+   * @param text string to set as item's text
   */
   void SetText(const std::string& text) { m_text = text; }
 
   /**
-   * @brief getter for list of attribute name mapped to attribute value
-   * @return list of attribute name mapped to attribute value
+   * @brief return collection of attributes as a key-value pairs
+   * @return map of name to value pairs
   */
   const std::map<std::string, std::string>& GetAttributes() const { return m_attributes; }
 
   /**
-   * @brief setter for list of attribute name mapped to its value
-   * @param attributes list of attribute name mapped to its value
-  */
-  void SetAttributes(const std::map<std::string, std::string>& attributes) { m_attributes = attributes; }
+  * @brief add missing attributes, optionally replace existing
+  * @param attributes map of name to value pairs to add
+  * @param replaceExisting true to replace existing attributes
+  * @return true if any attribute is set or changed
+ */
+  bool AddAttributes(const std::map<std::string, std::string>& attributes, bool replaceExisting);
 
   /**
-   * @brief add an attribute to the instance
+   * @brief add a single attribute to the item
    * @param name attribute name
    * @param value attribute value
+   * @param insertEmpty true to insert, false to remove if attribute exists but is empty
+   * @return true if attribute is inserted/removed/changed
   */
-  void AddAttribute(const std::string& name, const std::string& value);
+  bool AddAttribute(const std::string& name, const std::string& value, bool insertEmpty = true);
+
+  /**
+   * @brief add new attribute
+   * @param name attribute name
+   * @param value attribute value
+   * @return true if attribute is added
+  */
+  bool SetAttribute(const char* name, const char* value);
+  /**
+   * @brief add new attribute
+   * @param name attribute name
+   * @param value attribute value
+   * @param radix transformation radix
+   * @return true if attribute is added
+  */
+  bool SetAttribute(const char* name, long value, int radix = 10);
+
+  /**
+   * @brief set all attributes replacing existing ones
+   * @param attributes collection as key to value pairs
+   * @return true if any attribute collection has changed
+  */
+  bool SetAttributes(const std::map<std::string, std::string>& attributes);
+
+  /**
+   * @brief replace instance attributes with the given ones
+   * @param attributes given instance of XmlItem
+   * @return true if attributes are set
+  */
+  bool SetAttributes(const XmlItem &attributes);
+
+  /**
+   * @brief remove attribute
+   * @param name attribute name
+   * @return true if attribute is removed
+  */
+  bool RemoveAttribute(const char* name);
 
   /**
    * @brief remove the given attribute from the instance
@@ -139,7 +213,7 @@ public:
    * @param defaultValue value to be returned if attribute does not exist
    * @return true if attribute value is equal to "1" or "true", otherwise false
   */
-  bool      GetAttributeAsBool(const char* name, bool defaultValue = false) const;
+  bool GetAttributeAsBool(const char* name, bool defaultValue = false) const;
 
   /**
    * @brief getter for attribute value as integer
@@ -147,7 +221,7 @@ public:
    * @param defaultValue returned value in case attribute does not exist or its value is empty
    * @return attribute value as integer
   */
-  int       GetAttributeAsInt(const char* name, int defaultValue = -1) const;
+  int  GetAttributeAsInt(const char* name, int defaultValue = -1) const;
 
   /**
    * @brief getter for attribute value as unsigned long
@@ -155,7 +229,7 @@ public:
    * @param defaultValue value to be returned if attribute does not exist or its value is empty
    * @return attribute value as unsigned long
   */
-  unsigned  GetAttributeAsUnsigned(const char* name, unsigned defaultValue = 0) const;
+  unsigned GetAttributeAsUnsigned(const char* name, unsigned defaultValue = 0) const;
 
   /**
    * @brief getter for attribute value as unsigned long long
@@ -171,7 +245,7 @@ public:
    * @param defaultValue value to be returned if attribute does not exist
    * @return true if attribute value is equal to "1" or "true", otherwise false
   */
-  bool      GetAttributeAsBool(const std::string& name, bool defaultValue = false) const;
+  bool GetAttributeAsBool(const std::string& name, bool defaultValue = false) const;
 
   /**
    * @brief getter for attribute value as integer
@@ -179,7 +253,7 @@ public:
    * @param defaultValue returned value in case attribute does not exist or its value is empty
    * @return attribute value as integer
   */
-  int       GetAttributeAsInt(const std::string& name, int defaultValue = -1) const;
+  int  GetAttributeAsInt(const std::string& name, int defaultValue = -1) const;
 
   /**
    * @brief getter for attribute value as unsigned long
@@ -202,14 +276,14 @@ public:
    * @param defaultValue value to be returned if text is empty
    * @return tag text as boolean
   */
-  bool      GetTextAsBool(bool defaultValue = false) const;
+  bool  GetTextAsBool(bool defaultValue = false) const;
 
   /**
    * @brief getter for tag text as integer
    * @param defaultValue value to be returned if text is empty
    * @return tag text as integer
   */
-  int       GetTextAsInt(int defaultValue = -1) const;
+  int  GetTextAsInt(int defaultValue = -1) const;
 
   /**
    * @brief getter for tag text as unsigned long
@@ -270,7 +344,7 @@ public:
    * @param defaultValue value to be returned if given string is empty
    * @return true if given string is equal to "1" or "true"
   */
-  static bool      StringToBool(const std::string& value, bool defaultValue = false);
+  static bool StringToBool(const std::string& value, bool defaultValue = false);
 
   /**
    * @brief convert string to integer
@@ -278,7 +352,7 @@ public:
    * @param defaultValue value to be returned in case of empty string or conversion error
    * @return converted integer value
   */
-  static int       StringToInt(const std::string& value, int defaultValue = -1);
+  static int StringToInt(const std::string& value, int defaultValue = -1);
 
   /**
    * @brief convert string to unsigned integer
@@ -286,7 +360,7 @@ public:
    * @param defaultValue value to be returned in case of empty string or conversion error
    * @return converted unsigned integer value
   */
-  static unsigned  StringToUnsigned(const std::string& value, unsigned defaultValue = 0);
+  static unsigned StringToUnsigned(const std::string& value, unsigned defaultValue = 0);
 
   /**
    * @brief convert string to unsigned long long
@@ -326,6 +400,54 @@ public:
   */
   void SetLineNumber(int lineNumber) { m_lineNumber = lineNumber; }
 
+  /**
+  * @brief get number of attributes
+  * @return number of attributes as int
+ */
+  size_t GetAttributeCount() const { return m_attributes.size(); }
+  /**
+   * @brief check if attribute collection is empty
+   * @return true if attribute collection is empty
+  */
+  bool IsEmpty() const { return m_attributes.empty(); }
+
+  /**
+ * @brief check if all given attributes exist in the instance
+ * @param attributes given list of attributes
+ * @return true if all given attributes exist in the instance
+*/
+  virtual bool EqualAttributes(const std::map<std::string, std::string>& attributes) const;
+  /**
+   * @brief check if all attributes of the given instance exist in this instance
+   * @param other given instance of XmlItem
+   * @return true if all attributes of the given instance exist in this instance
+  */
+  virtual bool EqualAttributes(const XmlItem& other) const;
+  /**
+   * @brief check if all attributes of the given instance exist in this instance
+   * @param other pointer to given instance of XmlItem
+   * @return true if all attributes of the given instance exist in this instance
+  */
+  virtual bool EqualAttributes(const XmlItem* other) const;
+
+  /**
+  * @brief concatenate instance attributes
+  * @parem quote insert quotes around value strings
+  * @return string containing all attributes
+ */
+  std::string GetAttributesString(bool quote = false) const;
+  /**
+   * @brief concatenate attributes in a string conformed to XML syntax
+   * @return XML string containing attributes
+  */
+  std::string GetAttributesAsXmlString() const;
+
+protected:
+  /**
+   * @brief perform changes in internal data after calls to SetAttributes(), AddAttributes() and ClearAttributes()
+  */
+  virtual void ProcessAttributes() {/* default does nothing */};
+
 protected:
   std::string m_tag;  // item tag
   std::string m_text; // item text
@@ -335,7 +457,6 @@ protected:
 
 public:
   static const std::string EMPTY_STRING;
-
 };
 
 #endif // XmlItem_H

--- a/libs/xmltree/test/src/XmlTreeTest.cpp
+++ b/libs/xmltree/test/src/XmlTreeTest.cpp
@@ -24,6 +24,9 @@ TEST(XmlTreeTest, GetAttribute) {
   e.AddAttribute("yes", "true");
   e.AddAttribute("no", "false");
   e.AddAttribute("one", "1");
+  EXPECT_EQ(e.GetAttributesString(), "no=false one=1 string=strVal yes=true");
+  EXPECT_EQ(e.GetAttributesAsXmlString(), "no=\"false\" one=\"1\" string=\"strVal\" yes=\"true\"");
+
   e.AddAttribute("zero", "0");
   e.AddAttribute("empty", "");
   e.AddAttribute("zero", "0");

--- a/tools/buildmgr/cbuild/src/CbuildLayer.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildLayer.cpp
@@ -973,7 +973,7 @@ bool CbuildLayer::InitXml(const string &file, string* layerName) {
   } else {
     m_cprjTree = tree;
     m_cprj = elements;
-    m_cprj->root->SetAttributes({});
+    m_cprj->root->ClearAttributes();
   }
   return true;
 }


### PR DESCRIPTION
* RTE Model refactoring: preparation

Several methods moved from RteAttributes to RteItem
Member variables of RteAttributes type replaced by RteItem
RteAttributes is derived from XmlItem, redundant methods removed
RteChk executable is added to improve testing

