### PR TITLE
PackChk should check for spaces in the name element of the <file> tag (#451)

### DIFF
--- a/tools/packchk/include/CheckFiles.h
+++ b/tools/packchk/include/CheckFiles.h
@@ -32,6 +32,7 @@ public:
   bool CheckFile(RteItem* item);
   bool CheckFileExists(const std::string& fileName, int lineNo, bool associated = false);
   bool CheckCaseSense(const std::string& fileName, int lineNo);
+  bool CheckForSpaces(const std::string& fileName, int lineNo);
   bool FindGetExactFileSystemName(const std::string& path, const std::string& fileNameIn, std::string& fileNameOut);
   bool CheckFileHasVersion(RteItem* item);
   bool CheckFileExtension(RteItem* item);

--- a/tools/packchk/src/CheckFiles.cpp
+++ b/tools/packchk/src/CheckFiles.cpp
@@ -236,6 +236,7 @@ bool CheckFiles::CheckFile(RteItem* item)
   if(!fileName.empty()) {
     if(CheckFileExists(fileName, lineNo)) {
       CheckCaseSense(fileName, lineNo);
+      CheckForSpaces(fileName, lineNo);
     }
 
     if(tag == "environment" && envName == "DS5") {
@@ -261,6 +262,7 @@ bool CheckFiles::CheckFile(RteItem* item)
   if(!fileName2.empty()) {
     if(CheckFileExists(fileName2, lineNo)) {
       CheckCaseSense(fileName2, lineNo);   // File must exist for this check!
+      CheckForSpaces(fileName2, lineNo);
     }
   }
 
@@ -413,6 +415,27 @@ bool CheckFiles::CheckCaseSense(const string& fileName, int lineNo)
     LogMsg("M010");
   }
   return ok;
+}
+
+/**
+ * @brief check name for whitespace
+ * @param fileName filename as written in PDSC
+ * @param lineNo line number for error reporting
+ * @return true/false
+*/
+bool CheckFiles::CheckForSpaces(const string& fileName, int lineNo)
+{
+  if (fileName.empty()) {
+    return true;
+  }
+
+  string name = RteUtils::ExtractFileName(fileName);
+  if(name.find(' ') != string::npos) {
+    LogMsg("M314", PATH(name), lineNo);
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/tools/packchk/src/PackChk_Msgs.cpp
+++ b/tools/packchk/src/PackChk_Msgs.cpp
@@ -122,7 +122,7 @@ const MsgTable PackChk::msgTable = {
   { "M311", { MsgLevel::LEVEL_ERROR,    CRLF_B, "Redefinition of '%TAG%' : '%NAME%', see Line %LINE%" } },
   { "M312", { MsgLevel::LEVEL_WARNING3, CRLF_B, "No '%TAG%' found for device '%NAME%'" } },
   { "M313", { MsgLevel::LEVEL_WARNING,  CRLF_B, "" } },
-  { "M314", { MsgLevel::LEVEL_ERROR,    CRLF_B, "" } },
+  { "M314", { MsgLevel::LEVEL_WARNING,  CRLF_B, "Filename '%NAME%' contains whitespaces, this is not recommended" } },
   { "M315", { MsgLevel::LEVEL_ERROR,    CRLF_B, "Invalid URL / Paths to Drives are not allowed in Package URL: '%URL%'" } },
   { "M316", { MsgLevel::LEVEL_WARNING,  CRLF_B, "URL must end with slash '/': '%URL%'" } },
   { "M317", { MsgLevel::LEVEL_ERROR,    CRLF_B, "" } },

--- a/tools/packchk/test/unittests/src/TestCheckFiles.cpp
+++ b/tools/packchk/test/unittests/src/TestCheckFiles.cpp
@@ -189,3 +189,19 @@ TEST_F(TestCheckFiles, CheckCaseSense)
   RteFsUtils::RemoveDir(testDataFolder);
   checkFiles.SetPackagePath(packPath);
 }
+
+
+TEST_F(TestCheckFiles, CheckForSpaces)
+{
+  map<string, bool> testInputs = {
+    // FilePath, expectedResults
+    { RteUtils::EMPTY_STRING,        true},
+    { "TestFile.h",                  true},
+    { "Test File.h",                 false},
+  };
+
+  for (const auto& [fileName, result] : testInputs) {
+    EXPECT_EQ(result, checkFiles.CheckForSpaces(fileName, 1)) <<
+      "error: failed for input \"" << fileName << "\"" << endl;
+  }
+}


### PR DESCRIPTION
added Implementation + Test. case.
"M314", LEVEL_WARNING, "Filename '%NAME%' contains whitespaces, this is not recommended"