### PR TITLE
[buildmgr] Fix projects using preincludes in IAR

### DIFF
--- a/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
@@ -190,7 +190,7 @@ set(CC_DEFINES ${DEFINES})
 cbuild_set_defines(CC CC_DEFINES)
 set(CC_OPTIONS_FLAGS)
 cbuild_set_options_flags(CC "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" CC_OPTIONS_FLAGS)
-set(_PI "-include ")
+set(_PI "--preinclude ")
 
 if(SECURE STREQUAL "Secure")
   set(CC_SECURE "--cmse")


### PR DESCRIPTION
Projects may fail with compiler error:
```Unexpected command line arguments: -include```
The correct compiler flag is `--preinclude`