### PR TITLE
Fixes for GCC 8

### DIFF
--- a/libs/crossplatform/CMakeLists.txt
+++ b/libs/crossplatform/CMakeLists.txt
@@ -31,6 +31,12 @@ target_include_directories(CrossPlatform
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE ./src/${CMAKE_SYSTEM_NAME})
 
+# Explicitly link with stdc++fs for GCC 8
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  target_link_libraries(CrossPlatform PUBLIC stdc++fs)
+endif()
+
 if(UNIX)
   target_include_directories(CrossPlatform PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/win)
 elseif(WIN32)

--- a/libs/crossplatform/test/CMakeLists.txt
+++ b/libs/crossplatform/test/CMakeLists.txt
@@ -42,6 +42,12 @@ add_dependencies(CrossPlatformUnitTests TestProg)
 
 add_definitions(-DTEST_BIN_PATH="$<TARGET_FILE:CrossPlatformUnitTests>")
 
+# Explicitly link with stdc++fs for GCC 8
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  target_link_libraries(CrossPlatformUnitTests PUBLIC stdc++fs)
+endif()
+
 target_link_libraries(CrossPlatformUnitTests PUBLIC gtest gtest_main CrossPlatform RteFsUtils)
 
 add_test(NAME CrossPlatformUnitTests

--- a/libs/rtefsutils/CMakeLists.txt
+++ b/libs/rtefsutils/CMakeLists.txt
@@ -15,4 +15,10 @@ set_property(TARGET RteFsUtils PROPERTY
 
 target_include_directories(RteFsUtils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(RteFsUtils PUBLIC RteUtils CrossPlatform)
+# Explicitly link with stdc++fs for GCC 8
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  target_link_libraries(RteFsUtils PUBLIC RteUtils CrossPlatform stdc++fs)
+else()
+  target_link_libraries(RteFsUtils PUBLIC RteUtils CrossPlatform)
+endif()

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -13,6 +13,7 @@
 #include "XMLTreeSlim.h"
 
 #include <algorithm>
+#include <iomanip>
 #include <iterator>
 #include <fstream>
 


### PR DESCRIPTION
This fixes building for GCC 8. I found out that people still [build with Ubuntu 18](https://github.com/Open-CMSIS-Pack/devtools/issues/696) and [some changes](https://github.com/Open-CMSIS-Pack/devtools/pull/737/commits/e7b1121d2218247ea8fd2025cf24a51bfdb61669) in #737 didn't account for that.

- Restore explicit linking with `stdc++fs` (but only for GCC 8)
- Add missing header (didn't build on GCC 8.4.0 without this)

Contributed by STMicroelectronics
Signed-off-by: Erik MÅLLBERG <erik.lundin@st.com>

@edriouk Please review :)