### PR TITLE
[buildmgr] Rework toolchain registration (#474)

### DIFF
--- a/tools/buildmgr/cbuild/include/Cbuild.h
+++ b/tools/buildmgr/cbuild/include/Cbuild.h
@@ -7,9 +7,9 @@
 #ifndef CBUILD_H
 #define CBUILD_H
 
-#include <list>
 #include <map>
 #include <string>
+#include <vector>
 
 // CMSIS Layer commands
 #define L_EXTRACT 1
@@ -26,9 +26,9 @@ struct CbuildRteArgs
   const std::string &rtePath;
   const std::string &compilerRoot;
   const std::string &toolchain;
-  const std::string &ext;
   const std::string &update;
   const std::string &intDir;
+  const std::vector<std::string> &envVars;
   const bool checkPack;
   const bool updateRteFiles;
 };
@@ -41,7 +41,8 @@ struct CbuildLayerArgs
   const std::string &file;
   const std::string &rtePath;
   const std::string &compilerRoot;
-  const std::list<std::string> &layerFiles;
+  const std::vector<std::string> &layerFiles;
+  const std::vector<std::string> &envVars;
   const std::string& name;
   const std::string& description;
   const std::string& output;

--- a/tools/buildmgr/cbuild/include/CbuildModel.h
+++ b/tools/buildmgr/cbuild/include/CbuildModel.h
@@ -189,6 +189,24 @@ public:
   }
 
   /**
+   * @brief get path to toolchain registered root
+   * @return string containing fully qualified path to toolchain root
+  */
+  const std::string& GetToolchainRegisteredRoot() const
+  {
+    return m_toolchainRegisteredRoot;
+  }
+
+  /**
+   * @brief get toolchain registered version
+   * @return string containing toolchain registered version
+  */
+  const std::string& GetToolchainRegisteredVersion() const
+  {
+    return m_toolchainRegisteredVersion;
+  }
+
+  /**
    * @brief get path to toolchain config file
    * @return string containing fully qualified path to toolchain config
   */
@@ -491,6 +509,8 @@ protected:
   std::string            m_targetName;
   std::string            m_deviceName;
   std::string            m_toolchainConfigVersion;
+  std::string            m_toolchainRegisteredVersion;
+  std::string            m_toolchainRegisteredRoot;
 
   std::map<std::string, std::string>                m_configFiles;
   std::map<std::string, std::list<std::string>>     m_cSourceFiles;
@@ -562,8 +582,9 @@ protected:
   const std::vector<std::string>& GetParentTranslationControls(const RteItem* item, std::map<std::string, std::vector<std::string>>& transCtrlMap, const std::vector<std::string>& targetTransCtrls);
   bool GenerateAuditData();
   bool GenerateFixedCprj(const std::string& update);
-  bool EvaluateToolchainConfig(const std::string& name, const std::string& versionRange, const std::string& localPath, const std::string& compilerRoot, const std::string& ext);
-  bool GetCompatibleToolchain(const std::string& name, const std::string& versionRange, const std::string& dir, const std::string& ext);
+  bool EvaluateToolchainConfig(const std::string& name, const std::string& versionRange, const std::vector<std::string>& envVars, const std::string& compilerRoot);
+  bool GetCompatibleToolchain(const std::string& name, const std::string& versionRange, const std::string& dir, const std::vector<std::string>& envVars);
+  bool GetToolchainConfig(const std::set<fs::directory_entry>& files, const std::string& name, const std::string& version);
   std::vector<std::string> SplitArgs(const std::string& args, const std::string& delim=std::string(" -"), bool relativePath=true);
   static std::vector<std::string> MergeArgs(const std::vector<std::string>& add, const std::vector<std::string>& remove, const std::vector<std::string>& reference, bool front = false);
   static std::string GetExtendedRteGroupName(RteItem* ci, const std::string& rteFolder);

--- a/tools/buildmgr/cbuild/src/CbuildLayer.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildLayer.cpp
@@ -1118,8 +1118,8 @@ bool CbuildLayer::CompareSections (const XMLTreeElement* first, const XMLTreeEle
 
 bool CbuildLayer::ConstructModel (const XMLTreeElement* compilers, const CbuildLayerArgs& args) {
   const string& toolchain = compilers->GetFirstChild()->GetAttribute("name");
-  const string& ext = CMEXT, update = "", intdir = "";
-  if (!CbuildKernel::Get()->Construct({args.file, args.rtePath, args.compilerRoot, toolchain, ext, update, intdir, false, true})) {
+  const string& update = "", intdir = "";
+  if (!CbuildKernel::Get()->Construct({args.file, args.rtePath, args.compilerRoot, toolchain, update, intdir, args.envVars, false, true})) {
     return false;
   }
   m_layerFiles = CbuildKernel::Get()->GetModel()->GetLayerFiles();

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -419,7 +419,7 @@ bool CbuildModel::GetCompatibleToolchain(const string& name, const string& versi
   for (const auto& envVar : envVars) {
     smatch sm;
     try {
-      regex_match(envVar, sm, regex("(\\w+)_TOOLCHAIN_(\\d+)\\_(\\d+)\\_(\\d+)=(.*)"));
+      regex_match(envVar, sm, regex("(\\w+)_TOOLCHAIN_(\\d+)_(\\d+)_(\\d+)=(.*)"));
     } catch (exception&) {};
     if (sm.size() == 6) {
       toolchains[sm[1]][string(sm[2])+'.'+string(sm[3])+'.'+string(sm[4])] = sm[5];

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -418,7 +418,9 @@ bool CbuildModel::GetCompatibleToolchain(const string& name, const string& versi
   map<string, map<string, string>> toolchains;
   for (const auto& envVar : envVars) {
     smatch sm;
-    regex_match(envVar, sm, regex("(\\w+)_TOOLCHAIN_(\\d+)\\_(\\d+)\\_(\\d+)=(.*)"));
+    try {
+      regex_match(envVar, sm, regex("(\\w+)_TOOLCHAIN_(\\d+)\\_(\\d+)\\_(\\d+)=(.*)"));
+    } catch (exception&) {};
     if (sm.size() == 6) {
       toolchains[sm[1]][string(sm[2])+'.'+string(sm[3])+'.'+string(sm[4])] = sm[5];
     }
@@ -477,7 +479,9 @@ bool CbuildModel::GetToolchainConfig(const set<fs::directory_entry>& files, cons
   for (const auto& p : files) {
     smatch sm;
     const string& stem = p.path().stem().generic_string();
-    regex_match(stem, sm, regex("(\\w+)\\.(\\d+\\.\\d+\\.\\d+)"));
+    try {
+      regex_match(stem, sm, regex("(\\w+)\\.(\\d+\\.\\d+\\.\\d+)"));
+    } catch (exception&) {};
     if (sm.size() == 3) {
       const string& configName = sm[1];
       const string& configVersion = sm[2];

--- a/tools/buildmgr/cbuildgen/config/AC5.5.6.7.cmake
+++ b/tools/buildmgr/cbuildgen/config/AC5.5.6.7.cmake
@@ -1,27 +1,33 @@
 # This file maps the CMSIS project options to toolchain settings.
 #
-#   - Applies to toolchain: ARM Compiler 5.06 update 7 (build 960)
+#   - Applies to toolchain: ARM Compiler 5.06 update 7 (build 960) and greater
 
 ############### EDIT BELOW ###############
 # Set base directory of toolchain
 set(TOOLCHAIN_ROOT)
 set(TOOLCHAIN_VERSION "5.6.7")
-set(EXT)
 
 ############ DO NOT EDIT BELOW ###########
 
-set(TOOLCHAIN_STRING "AC5_TOOLCHAIN_${TOOLCHAIN_VERSION}")
-string(REPLACE "." "_" TOOLCHAIN_STRING ${TOOLCHAIN_STRING})
-if(DEFINED ENV{${TOOLCHAIN_STRING}})
-  cmake_path(SET ${TOOLCHAIN_STRING} "$ENV{${TOOLCHAIN_STRING}}")
-  message(STATUS "Using ${TOOLCHAIN_STRING}='${${TOOLCHAIN_STRING}}'")
-  set(TOOLCHAIN_ROOT "${${TOOLCHAIN_STRING}}")
+set(AS "armasm")
+set(CC "armcc")
+set(CXX "armcc")
+set(OC "fromelf")
+
+if(DEFINED REGISTERED_TOOLCHAIN_ROOT)
+  set(TOOLCHAIN_ROOT "${REGISTERED_TOOLCHAIN_ROOT}")
+endif()
+if(DEFINED REGISTERED_TOOLCHAIN_VERSION)
+  set(TOOLCHAIN_VERSION "${REGISTERED_TOOLCHAIN_VERSION}")
 endif()
 
-set(AS ${TOOLCHAIN_ROOT}/armasm${EXT})
-set(CC ${TOOLCHAIN_ROOT}/armcc${EXT})
-set(CXX ${TOOLCHAIN_ROOT}/armcc${EXT})
-set(OC ${TOOLCHAIN_ROOT}/fromelf${EXT})
+if(DEFINED TOOLCHAIN_ROOT AND NOT TOOLCHAIN_ROOT STREQUAL "")
+  set(EXT ".exe")
+  set(AS ${TOOLCHAIN_ROOT}/${AS}${EXT})
+  set(CC ${TOOLCHAIN_ROOT}/${CC}${EXT})
+  set(CXX ${TOOLCHAIN_ROOT}/${CXX}${EXT})
+  set(OC ${TOOLCHAIN_ROOT}/${OC}${EXT})
+endif()
 
 # Helpers
 
@@ -180,22 +186,8 @@ set (ELF2BIN --bin --output "${OUT_DIR}/${BIN_FILE}" "${OUT_DIR}/$<TARGET_PROPER
 # Set CMake variables for toolchain initialization
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(CMAKE_ASM_COMPILER "${AS}")
 set(CMAKE_C_COMPILER "${CC}")
 set(CMAKE_CXX_COMPILER "${CXX}")
 set(CMAKE_OBJCOPY "${OC}")
-set(CMAKE_ASM_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_FORCED TRUE)
-set(CMAKE_CXX_COMPILER_FORCED TRUE)
-
-# Set CMake variables for skipping compiler identification
-set(CMAKE_C_COMPILER_ID "ARMCC")
-set(CMAKE_C_COMPILER_ID_RUN TRUE)
-set(CMAKE_C_COMPILER_VERSION "${TOOLCHAIN_VERSION}")
-set(CMAKE_C_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-set(CMAKE_CXX_COMPILER_ID "${CMAKE_C_COMPILER_ID}")
-set(CMAKE_CXX_COMPILER_ID_RUN "${CMAKE_C_COMPILER_ID_RUN}")
-set(CMAKE_CXX_COMPILER_VERSION "${CMAKE_C_COMPILER_VERSION}")
-set(CMAKE_CXX_COMPILER_FORCED "${CMAKE_C_COMPILER_FORCED}")
-set(CMAKE_CXX_COMPILER_WORKS "${CMAKE_C_COMPILER_WORKS}")

--- a/tools/buildmgr/cbuildgen/config/AC6.6.18.0.cmake
+++ b/tools/buildmgr/cbuildgen/config/AC6.6.18.0.cmake
@@ -1,27 +1,33 @@
 # This file maps the CMSIS project options to toolchain settings.
 #
-#   - Applies to toolchain: ARM Compiler 6.18
+#   - Applies to toolchain: ARM Compiler 6.18 and greater
 
 ############### EDIT BELOW ###############
 # Set base directory of toolchain
 set(TOOLCHAIN_ROOT)
 set(TOOLCHAIN_VERSION "6.18.0")
-set(EXT)
 
 ############ DO NOT EDIT BELOW ###########
 
-set(TOOLCHAIN_STRING "AC6_TOOLCHAIN_${TOOLCHAIN_VERSION}")
-string(REPLACE "." "_" TOOLCHAIN_STRING ${TOOLCHAIN_STRING})
-if(DEFINED ENV{${TOOLCHAIN_STRING}})
-  cmake_path(SET ${TOOLCHAIN_STRING} "$ENV{${TOOLCHAIN_STRING}}")
-  message(STATUS "Using ${TOOLCHAIN_STRING}='${${TOOLCHAIN_STRING}}'")
-  set(TOOLCHAIN_ROOT "${${TOOLCHAIN_STRING}}")
+set(AS "armasm")
+set(CC "armclang")
+set(CXX "armclang")
+set(OC "fromelf")
+
+if(DEFINED REGISTERED_TOOLCHAIN_ROOT)
+  set(TOOLCHAIN_ROOT "${REGISTERED_TOOLCHAIN_ROOT}")
+endif()
+if(DEFINED REGISTERED_TOOLCHAIN_VERSION)
+  set(TOOLCHAIN_VERSION "${REGISTERED_TOOLCHAIN_VERSION}")
 endif()
 
-set(AS ${TOOLCHAIN_ROOT}/armasm${EXT})
-set(CC ${TOOLCHAIN_ROOT}/armclang${EXT})
-set(CXX ${TOOLCHAIN_ROOT}/armclang${EXT})
-set(OC ${TOOLCHAIN_ROOT}/fromelf${EXT})
+if(DEFINED TOOLCHAIN_ROOT AND NOT TOOLCHAIN_ROOT STREQUAL "")
+  set(EXT)
+  set(AS ${TOOLCHAIN_ROOT}/${AS}${EXT})
+  set(CC ${TOOLCHAIN_ROOT}/${CC}${EXT})
+  set(CXX ${TOOLCHAIN_ROOT}/${CXX}${EXT})
+  set(OC ${TOOLCHAIN_ROOT}/${OC}${EXT})
+endif()
 
 # Helpers
 
@@ -553,12 +559,9 @@ elseif(BRANCHPROT STREQUAL "BTI_SIGNRET")
   set(CC_BRANCHPROT "-mbranch-protection=bti+pac-ret")
 endif()
 
-set (CC_SYS_INC_PATHS_LIST
-  "${TOOLCHAIN_ROOT}/../include"
+set(CC_SYS_INC_PATHS_LIST
+  "\${TOOLCHAIN_ROOT}/../include"
 )
-foreach(ENTRY ${CC_SYS_INC_PATHS_LIST})
-  string(APPEND CC_SYS_INC_PATHS "${_ISYS}\"${ENTRY}\" ")
-endforeach()
 
 # C++ Compiler
 
@@ -571,13 +574,10 @@ set(CXX_FLAGS "${CC_FLAGS}")
 set(CXX_OPTIONS_FLAGS)
 cbuild_set_options_flags(CXX "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" CXX_OPTIONS_FLAGS)
 
-set (CXX_SYS_INC_PATHS_LIST
-  "${TOOLCHAIN_ROOT}/../include/libcxx"
+set(CXX_SYS_INC_PATHS_LIST
+  "\${TOOLCHAIN_ROOT}/../include/libcxx"
   "${CC_SYS_INC_PATHS_LIST}"
 )
-foreach(ENTRY ${CXX_SYS_INC_PATHS_LIST})
-  string(APPEND CXX_SYS_INC_PATHS "${_ISYS}\"${ENTRY}\" ")
-endforeach()
 
 # Linker
 
@@ -607,6 +607,7 @@ set (ELF2BIN --bin --output "${OUT_DIR}/${BIN_FILE}" "${OUT_DIR}/$<TARGET_PROPER
 # Set CMake variables for toolchain initialization
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(CMAKE_ASM_COMPILER "${CC}")
 set(CMAKE_AS_LEG_COMPILER "${AS}")
 set(CMAKE_AS_ARM_COMPILER "${CC}")
@@ -614,18 +615,4 @@ set(CMAKE_AS_GNU_COMPILER "${CC}")
 set(CMAKE_C_COMPILER "${CC}")
 set(CMAKE_CXX_COMPILER "${CXX}")
 set(CMAKE_OBJCOPY "${OC}")
-set(CMAKE_SYSTEM_PROCESSOR "cortex-m0") # N.A.
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMakeASM")
-
-# Set CMake variables for skipping compiler identification
-set(CMAKE_ASM_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_ID "ARMClang")
-set(CMAKE_C_COMPILER_ID_RUN TRUE)
-set(CMAKE_C_COMPILER_VERSION "${TOOLCHAIN_VERSION}")
-set(CMAKE_C_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-set(CMAKE_CXX_COMPILER_ID "${CMAKE_C_COMPILER_ID}")
-set(CMAKE_CXX_COMPILER_ID_RUN "${CMAKE_C_COMPILER_ID_RUN}")
-set(CMAKE_CXX_COMPILER_VERSION "${CMAKE_C_COMPILER_VERSION}")
-set(CMAKE_CXX_COMPILER_FORCED "${CMAKE_C_COMPILER_FORCED}")
-set(CMAKE_CXX_COMPILER_WORKS "${CMAKE_C_COMPILER_WORKS}")

--- a/tools/buildmgr/cbuildgen/config/CMSIS-Build-Utils.cmake
+++ b/tools/buildmgr/cbuildgen/config/CMSIS-Build-Utils.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 Arm Limited and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CMake Utility functions for CMSIS-Build
+
+# Get running toolchain root directory and version
+# Check whether the running toolchain matches the registered one and fits the required version range
+function(cbuild_get_running_toolchain root version lang)
+  set(CMAKE_COMPILER_VERSION ${CMAKE_${lang}_COMPILER_VERSION})
+  if(DEFINED TOOLCHAIN_VERSION)
+    if(NOT TOOLCHAIN_VERSION VERSION_EQUAL CMAKE_COMPILER_VERSION)
+      message(STATUS "Registered toolchain version ${TOOLCHAIN_VERSION} does not match running version ${CMAKE_COMPILER_VERSION}")
+    endif()
+  endif()
+  if(CMAKE_COMPILER_VERSION VERSION_LESS TOOLCHAIN_VERSION_MIN)
+    message(FATAL_ERROR "Running toolchain version ${CMAKE_COMPILER_VERSION} is less than minimum required ${TOOLCHAIN_VERSION_MIN}")
+  endif()
+  if(DEFINED TOOLCHAIN_VERSION_MAX)
+    if(CMAKE_COMPILER_VERSION VERSION_GREATER TOOLCHAIN_VERSION_MAX)
+      message(FATAL_ERROR "Running toolchain version ${CMAKE_COMPILER_VERSION} is greater than maximum required ${TOOLCHAIN_VERSION_MAX}")
+    endif()
+  endif()
+  set(CMAKE_COMPILER_ROOT ${CMAKE_${lang}_COMPILER})
+  cmake_path(GET CMAKE_COMPILER_ROOT PARENT_PATH CMAKE_COMPILER_ROOT)
+  set(${root} ${CMAKE_COMPILER_ROOT} PARENT_SCOPE)
+  set(${version} ${CMAKE_COMPILER_VERSION} PARENT_SCOPE)
+endfunction()
+
+# Get system includes
+# Replace TOOLCHAIN_ROOT and TOOLCHAIN_VERSION variables
+function(cbuild_get_system_includes input output)
+  foreach(ENTRY ${${input}})
+    string(REGEX REPLACE "\\\${TOOLCHAIN_ROOT}" ${TOOLCHAIN_ROOT} ENTRY ${ENTRY})
+    string(REGEX REPLACE "\\\${TOOLCHAIN_VERSION}" ${TOOLCHAIN_VERSION} ENTRY ${ENTRY})
+    cmake_path(NORMAL_PATH ENTRY OUTPUT_VARIABLE NORMAL_ENTRY)
+    string(APPEND ${output} "${_ISYS}\"${NORMAL_ENTRY}\" ")
+  endforeach()
+  set(${output} ${${output}} PARENT_SCOPE)
+endfunction()

--- a/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
@@ -1,29 +1,37 @@
 # This file maps the CMSIS project options to toolchain settings.
 #
-#   - Applies to toolchain: IAR ARM C/C++ Compiler V9.32.1
+#   - Applies to toolchain: IAR ARM C/C++ Compiler V9.32.1 and greater
 
 ############### EDIT BELOW ###############
 # Set base directory of toolchain
 set(TOOLCHAIN_ROOT)
 set(TOOLCHAIN_VERSION "9.32.1")
-set(EXT)
 
 ############ DO NOT EDIT BELOW ###########
 
-set(TOOLCHAIN_STRING "IAR_TOOLCHAIN_${TOOLCHAIN_VERSION}")
-string(REPLACE "." "_" TOOLCHAIN_STRING ${TOOLCHAIN_STRING})
-if(DEFINED ENV{${TOOLCHAIN_STRING}})
-  cmake_path(SET ${TOOLCHAIN_STRING} "$ENV{${TOOLCHAIN_STRING}}")
-  message(STATUS "Using ${TOOLCHAIN_STRING}='${${TOOLCHAIN_STRING}}'")
-  set(TOOLCHAIN_ROOT "${${TOOLCHAIN_STRING}}")
+set(AS "iasmarm")
+set(CC "iccarm")
+set(CXX "iccarm")
+set(LD "ilinkarm")
+set(AR "iarchive")
+set(OC "ielftool")
+
+if(DEFINED REGISTERED_TOOLCHAIN_ROOT)
+  set(TOOLCHAIN_ROOT "${REGISTERED_TOOLCHAIN_ROOT}")
+endif()
+if(DEFINED REGISTERED_TOOLCHAIN_VERSION)
+  set(TOOLCHAIN_VERSION "${REGISTERED_TOOLCHAIN_VERSION}")
 endif()
 
-set(AS ${TOOLCHAIN_ROOT}/iasmarm${EXT})
-set(CC ${TOOLCHAIN_ROOT}/iccarm${EXT})
-set(CXX ${TOOLCHAIN_ROOT}/iccarm${EXT})
-set(LD ${TOOLCHAIN_ROOT}/ilinkarm${EXT})
-set(AR ${TOOLCHAIN_ROOT}/iarchive${EXT})
-set(OC ${TOOLCHAIN_ROOT}/ielftool${EXT})
+if(DEFINED TOOLCHAIN_ROOT)
+  set(EXT)
+  set(AS ${TOOLCHAIN_ROOT}/${AS}${EXT})
+  set(CC ${TOOLCHAIN_ROOT}/${CC}${EXT})
+  set(CXX ${TOOLCHAIN_ROOT}/${CXX}${EXT})
+  set(LD ${TOOLCHAIN_ROOT}/${LD}${EXT})
+  set(AR ${TOOLCHAIN_ROOT}/${AR}${EXT})
+  set(OC ${TOOLCHAIN_ROOT}/${OC}${EXT})
+endif()
 
 # Core Options
 
@@ -233,18 +241,9 @@ set (ELF2BIN --silent --bin "${OUT_DIR}/$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>
 # Set CMake variables for toolchain initialization
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(CMAKE_ASM_COMPILER "${AS}")
 set(CMAKE_C_COMPILER "${CC}")
 set(CMAKE_CXX_COMPILER "${CXX}")
 set(CMAKE_OBJCOPY "${OC}")
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMakeASM")
-
-# Set CMake variables for skipping compiler identification
-set(CMAKE_ASM_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_FORCED TRUE)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-set(CMAKE_CXX_COMPILER_ID "${CMAKE_C_COMPILER_ID}")
-set(CMAKE_CXX_COMPILER_ID_RUN "${CMAKE_C_COMPILER_ID_RUN}")
-set(CMAKE_CXX_COMPILER_VERSION "${CMAKE_C_COMPILER_VERSION}")
-set(CMAKE_CXX_COMPILER_FORCED "${CMAKE_C_COMPILER_FORCED}")
-set(CMAKE_CXX_COMPILER_WORKS "${CMAKE_C_COMPILER_WORKS}")

--- a/tools/buildmgr/cbuildgen/include/BuildSystemGenerator.h
+++ b/tools/buildmgr/cbuildgen/include/BuildSystemGenerator.h
@@ -90,9 +90,10 @@ public:
    * @param model pointer to valid RTE Model containing build information
    * @param outdir string path to output directory
    * @param intdir string path to intermediate directory
+   * @param compilerRoot string path to compiler configuration directory
    * @return
   */
-  bool Collect(const std::string& inputFile, const CbuildModel *model, const std::string& outdir, const std::string& intdir);
+  bool Collect(const std::string& inputFile, const CbuildModel *model, const std::string& outdir, const std::string& intdir, const std::string& compilerRoot);
 
   /**
    * @brief generate log file with packages, components and config files information
@@ -121,6 +122,7 @@ protected:
   std::string m_projectName;
   std::string m_outdir;
   std::string m_intdir;
+  std::string m_compilerRoot;
   std::string m_targetCpu;
   std::string m_targetFpu;
   std::string m_targetDsp;
@@ -142,7 +144,10 @@ protected:
   std::string m_linkerCxxMscGlobal;
   std::string m_linkerScript;
   std::string m_toolchain;
+  std::string m_toolchainVersion;
   std::string m_toolchainConfig;
+  std::string m_toolchainRegisteredRoot;
+  std::string m_toolchainRegisteredVersion;
   std::string m_auditData;
   bool m_asTargetAsm = false;
 

--- a/tools/buildmgr/cbuildgen/include/CbuildGen.h
+++ b/tools/buildmgr/cbuildgen/include/CbuildGen.h
@@ -18,8 +18,9 @@ public:
    * @brief entry point for running cbuildgen
    * @param argc command line argument count
    * @param argv command line argument vector
+   * @param envp environment variables
   */
-  static int RunCbuildGen(int argc, char** argv);
+  static int RunCbuildGen(int argc, char** argv, char** envp);
 
 protected:
   /**

--- a/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
@@ -33,14 +33,18 @@ BuildSystemGenerator::~BuildSystemGenerator(void) {
   // Reserved
 }
 
-bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *model, const string& outdir, const string& intdir) {
+bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *model, const string& outdir, const string& intdir, const string& compilerRoot) {
   error_code ec;
   m_projectDir = StrConv(RteFsUtils::AbsolutePath(inputFile).remove_filename().generic_string());
   m_workingDir = fs::current_path(ec).generic_string() + SS;
+  m_compilerRoot = compilerRoot;
 
   // Find toolchain config
   m_toolchainConfig = StrNorm(model->GetToolchainConfig());
   m_toolchain = model->GetCompiler();
+  m_toolchainVersion = model->GetCompilerVersion();
+  m_toolchainRegisteredRoot = model->GetToolchainRegisteredRoot();
+  m_toolchainRegisteredVersion = model->GetToolchainRegisteredVersion();
 
   // Output and intermediate directories
   if (!outdir.empty()) {

--- a/tools/buildmgr/cbuildgen/src/Console.cpp
+++ b/tools/buildmgr/cbuildgen/src/Console.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-int main(int argc, char **argv)
+int main(int argc, char **argv, char** envp)
 {
-  return CbuildGen::RunCbuildGen(argc, argv);
+  return CbuildGen::RunCbuildGen(argc, argv, envp);
 }

--- a/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
@@ -67,7 +67,7 @@ void CBuildIntegTestEnv::SetUp() {
   ifstream file(ac6ToolchainFilePath);
   string line;
   while (getline(file, line)) {
-    if (string::npos != line.find("TOOLCHAIN_ROOT")) {
+    if (string::npos != line.find("set(TOOLCHAIN_ROOT")) {
       ac6_toolchain_path = RteUtils::RemoveQuotes(line);
       break;
     }

--- a/tools/buildmgr/test/testinput/Examples/AC6/Asm/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Asm/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-05T10:53:33
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -81,11 +81,16 @@ set(AS_FLAGS_C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/Asm/AsmA
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES ASM AS_ARM AS_GNU AS_LEG C)
+
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
 
 # Global Flags
 
@@ -93,6 +98,7 @@ set(CMAKE_ASM_FLAGS "${ASM_CPU} ${ASM_BYTE_ORDER} ${ASM_DEFINES} ${ASM_FLAGS}")
 set(CMAKE_AS_ARM_FLAGS "${AS_ARM_CPU} ${AS_ARM_BYTE_ORDER} ${AS_ARM_DEFINES} ${AS_ARM_FLAGS}")
 set(CMAKE_AS_GNU_FLAGS "${AS_GNU_CPU} ${AS_GNU_BYTE_ORDER} ${AS_GNU_DEFINES} ${AS_GNU_FLAGS}")
 set(CMAKE_AS_LEG_FLAGS "${AS_LEG_CPU} ${AS_LEG_BYTE_ORDER} ${AS_LEG_DEFINES} ${AS_LEG_FLAGS}")
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/BranchProtection/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/BranchProtection/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-10-19T13:28:55
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,18 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/cmsis-toolbox/1.2.0/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_BRANCHPROT} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Build_AC6/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Build_AC6/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-30T16:21:17
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,20 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.18.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Build_AC6PP/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Build_AC6PP/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T16:38:24
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -55,15 +55,22 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_FLAGS_GLOBAL} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Flags/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Flags/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-02T13:59:26
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -58,14 +58,20 @@ set(CC_FLAGS_C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/CMSIS/RTOS2/R
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Library/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Library/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T15:21:29
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -36,14 +36,20 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_FLAGS_GLOBAL} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${LD_SECURE} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Minimal/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Minimal/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-03-30T08:56:44
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -33,14 +33,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_DEFINES} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/NestedGroups/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/NestedGroups/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-03-30T08:56:53
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -43,14 +43,19 @@ set(CC_FLAGS_C:/sandbox/devtools/build/TestOutput/TestData/Examples/AC6/NestedGr
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_DEFINES} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/RelativePath/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/RelativePath/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-03-30T08:49:42
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -37,14 +37,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_DEFINES} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/TrustZone/CM33_ns/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/TrustZone/CM33_ns/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-05T13:43:43
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -52,14 +52,20 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/TrustZone/CM33_s/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/TrustZone/CM33_s/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T16:53:26
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -44,14 +44,20 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/AC6/Whitespace/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/AC6/Whitespace/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-03-30T08:55:31
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,20 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/AccessSequence/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/AccessSequence/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-04-07T11:33:13
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -131,15 +131,21 @@ set(CXX_FLAGS_C:/Temp/devtools/tools/buildmgr/test/testinput/Examples/GCC/Access
 
 # Toolchain config map
 
-include ("C:/Temp/devtools/build/testoutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Asm/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Asm/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-15T11:49:01
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -128,17 +128,22 @@ set(AS_FLAGS_C:/sandbox/devtools/build/TestOutput/TestData/Examples/GCC/Asm/GAS.
 
 # Toolchain config map
 
-include ("c:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES ASM AS_GNU AS_LEG C)
+
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
 
 # Global Flags
 
 set(CMAKE_ASM_FLAGS "${ASM_CPU} ${ASM_BYTE_ORDER} ${ASM_DEFINES} ${ASM_FLAGS}")
 set(CMAKE_AS_GNU_FLAGS "${AS_GNU_CPU} ${AS_GNU_BYTE_ORDER} ${AS_GNU_DEFINES} ${AS_GNU_FLAGS}")
 set(CMAKE_AS_LEG_FLAGS "${AS_LEG_CPU} ${AS_LEG_BYTE_ORDER} ${AS_LEG_DEFINES} ${AS_LEG_FLAGS}")
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/BranchProtection/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/BranchProtection/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-10-20T09:16:36
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,19 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/cmsis-toolbox/1.2.0/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_BRANCHPROT} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Build_GCC/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Build_GCC/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-29T18:33:18
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -54,15 +54,20 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES ASM C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
 set(CMAKE_ASM_FLAGS "${ASM_CPU} ${ASM_BYTE_ORDER} ${ASM_DEFINES} ${ASM_FLAGS} ${AS_FLAGS_GLOBAL}")
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Build_GPP/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Build_GPP/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-29T18:34:00
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -58,16 +58,22 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES ASM C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
 set(CMAKE_ASM_FLAGS "${ASM_CPU} ${ASM_BYTE_ORDER} ${ASM_DEFINES} ${ASM_FLAGS} ${AS_FLAGS_GLOBAL}")
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_FLAGS_GLOBAL} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/DupFilename/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-08-23T15:48:24
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -35,14 +35,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/build/tools/buildmgr/test/integrationtests/testoutput/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/FlagOrder/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/FlagOrder/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-28T09:21:53
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -41,14 +41,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Flags/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Flags/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-30T14:00:54
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -58,14 +58,19 @@ set(CC_FLAGS_C:/Users/Test/AppData/Local/Arm/Packs/ARM/CMSIS/5.8.0/CMSIS/RTOS2/R
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Library/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Library/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T15:49:07
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -36,14 +36,19 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "11.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_FLAGS_GLOBAL} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${LD_SECURE} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Library/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Library/CMakeLists.txt.ref
@@ -36,8 +36,8 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-set(TOOLCHAIN_VERSION_MIN "11.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "10.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/Library/project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Library/project.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="GCC" version="10.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/Library/project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Library/project.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="1.0.2"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T15:49:07
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -36,14 +36,19 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "11.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_FLAGS_GLOBAL} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${LD_SECURE} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/CMakeLists.txt.ref
@@ -36,8 +36,8 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-set(TOOLCHAIN_VERSION_MIN "11.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "10.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/project.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="GCC" version="10.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/LibraryCustom/project.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="1.0.2"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/Minimal/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Minimal/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-28T09:21:53
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -41,14 +41,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/NestedGroups/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/NestedGroups/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-28T11:42:05
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,19 @@ set(CC_FLAGS_C:/sandbox/devtools/build/TestOutput/TestData/Examples/GCC/NestedGr
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Pre Include/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Pre Include/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-30T15:29:13
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -65,14 +65,19 @@ set(PRE_INC_LOCAL_C:/Users/Test/AppData/Local/Arm/Packs/Keil/PreIncludeTestPack/
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/RelativePath/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/RelativePath/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-06-30T14:11:24
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -45,14 +45,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project1/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project1/CMakeLists.txt.ref
@@ -107,7 +107,7 @@ set(CXX_FLAGS_C:/Sandbox/devtools-external/build/testoutput/GCC/TranslationContr
 # Toolchain config map
 
 set(TOOLCHAIN_VERSION_MIN "9.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project1/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project1/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-03-25T13:39:00
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -106,15 +106,21 @@ set(CXX_FLAGS_C:/Sandbox/devtools-external/build/testoutput/GCC/TranslationContr
 
 # Toolchain config map
 
-include ("C:/Sandbox/devtools-external/build/testoutput/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project2/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project2/CMakeLists.txt.ref
@@ -128,7 +128,7 @@ set(CXX_FLAGS_C:/Sandbox/devtools-external/build/testoutput/GCC/TranslationContr
 # Toolchain config map
 
 set(TOOLCHAIN_VERSION_MIN "9.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project2/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project2/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-03-24T09:23:57
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -127,15 +127,21 @@ set(CXX_FLAGS_C:/Sandbox/devtools-external/build/testoutput/GCC/TranslationContr
 
 # Toolchain config map
 
-include ("C:/Sandbox/devtools-external/build/testoutput/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2022-11-04T20:38:46
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -66,16 +66,22 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/Sandbox/devtools-external/build/testoutput/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "11.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES AS_GNU C CXX)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION CXX)
+
 # Global Flags
 
 set(CMAKE_AS_GNU_FLAGS "${AS_GNU_CPU} ${AS_GNU_BYTE_ORDER} ${AS_GNU_DEFINES} ${AS_GNU_FLAGS}")
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
+cbuild_get_system_includes(CXX_SYS_INC_PATHS_LIST CXX_SYS_INC_PATHS)
 set(CMAKE_CXX_FLAGS "${CXX_CPU} ${CXX_BYTE_ORDER} ${CXX_DEFINES} ${CXX_SECURE} ${CXX_FLAGS} ${CXX_SYS_INC_PATHS}")
 set(CMAKE_CXX_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_OPTIONS_FLAGS} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/CMakeLists.txt.ref
@@ -66,8 +66,8 @@ set(CXX_SRC_FILES
 
 # Toolchain config map
 
-set(TOOLCHAIN_VERSION_MIN "11.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "10.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/Project.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TranslationControl/Project3/Project.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="GCC" version="10.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_ns/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_ns/CMakeLists.txt.ref
@@ -53,7 +53,7 @@ set(LIB_FILES
 # Toolchain config map
 
 set(TOOLCHAIN_VERSION_MIN "9.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_ns/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_ns/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-07T17:15:13
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -52,14 +52,19 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/reference/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-06T11:36:35
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -45,14 +45,19 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "11.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/CMakeLists.txt.ref
@@ -45,8 +45,8 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-set(TOOLCHAIN_VERSION_MIN "11.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "10.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/FVP_Simulation_Model.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/FVP_Simulation_Model.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="1.0.2"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Ddsp="DSP" Dendian="Little-endian" Dfpu="SP_FPU" Dmve="NO_MVE" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/FVP_Simulation_Model.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/FVP_Simulation_Model.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="GCC" version="10.2.1"/>
   </compilers>
 
   <target Ddsp="DSP" Dendian="Little-endian" Dfpu="SP_FPU" Dmve="NO_MVE" Dname="ARMCM33_DSP_FP_TZ" Dsecure="Secure" Dtz="TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-07-07T17:16:48
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -51,14 +51,19 @@ set(LIB_FILES
 
 # Toolchain config map
 
-include ("C:/reference/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "11.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_FLAGS_GLOBAL} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/CMakeLists.txt.ref
@@ -51,8 +51,8 @@ set(LIB_FILES
 
 # Toolchain config map
 
-set(TOOLCHAIN_VERSION_MIN "11.2.1")
-include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "10.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.10.2.1.cmake")
 include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project

--- a/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/Target_Name.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/Target_Name.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="GCC" version="10.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/Target_Name.cprj
+++ b/tools/buildmgr/test/testinput/Examples/GCC/Whitespace/Target_Name.cprj
@@ -13,7 +13,7 @@
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="1.0.2"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">

--- a/tools/buildmgr/test/testinput/Examples/Mixed/Build_AC6_GCC/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/Mixed/Build_AC6_GCC/CMakeLists.txt.ref
@@ -64,11 +64,14 @@ set(CC_SRC_FILES
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/GCC.10.2.1.cmake")
+set(TOOLCHAIN_VERSION_MIN "9.2.1")
+include ("C:/sandbox/cbuild/etc/GCC.11.2.1.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES ASM C)
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
 
 # Global Flags
 

--- a/tools/buildmgr/test/testinput/Examples/Mixed/Pre Include/CMakeLists.txt.ref
+++ b/tools/buildmgr/test/testinput/Examples/Mixed/Pre Include/CMakeLists.txt.ref
@@ -1,6 +1,6 @@
 # CMSIS Build CMakeLists generated on 2021-03-30T08:56:32
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 # Target options
 
@@ -66,14 +66,20 @@ set(PRE_INC_LOCAL_C:/Users/Test/AppData/Local/Arm/Packs/Keil/PreIncludeTestPack/
 
 # Toolchain config map
 
-include ("C:/sandbox/devtools/build/TestOutput/cbuild/etc/AC6.6.16.0.cmake")
+set(TOOLCHAIN_VERSION_MIN "6.0.0")
+set(TOOLCHAIN_VERSION_MAX "6.99.99")
+include ("C:/sandbox/cbuild/etc/AC6.6.18.0.cmake")
+include ("C:/sandbox/cbuild/etc/CMSIS-Build-Utils.cmake")
 
 # Setup project
 
 project(${TARGET} LANGUAGES C)
 
+cbuild_get_running_toolchain(TOOLCHAIN_ROOT TOOLCHAIN_VERSION C)
+
 # Global Flags
 
+cbuild_get_system_includes(CC_SYS_INC_PATHS_LIST CC_SYS_INC_PATHS)
 set(CMAKE_C_FLAGS "${CC_CPU} ${CC_BYTE_ORDER} ${CC_DEFINES} ${CC_SECURE} ${CC_FLAGS} ${CC_SYS_INC_PATHS}")
 set(CMAKE_C_LINK_FLAGS "${LD_CPU} ${_LS}\"${LD_SCRIPT}\" ${LD_SECURE} ${LD_FLAGS_GLOBAL} ${LD_FLAGS}")
 

--- a/tools/buildmgr/test/unittests/src/BuildSystemGeneratorTests.cpp
+++ b/tools/buildmgr/test/unittests/src/BuildSystemGeneratorTests.cpp
@@ -47,19 +47,20 @@ void BuildSystemGeneratorTests::CheckBuildSystemGen_Collect(const TestParam& par
   string filename = inputDir + "/" + param.name;
   string toolchain, ext = CMEXT, novalue = "";
   string packlistDir, output, update;
-  bool ret_val, packMode = false;
+  vector<string> envVars;
+  bool ret_val, packMode = false, updateRte = false;
   error_code ec;
 
   fs::current_path(filename.c_str(), ec);
 
   filename = param.targetArg + ".cprj";
-  ret_val = CreateRte({filename, novalue, novalue, toolchain, ext, packlistDir, update, packMode});
+  ret_val = CreateRte({filename, novalue, novalue, toolchain, packlistDir, update, envVars, packMode, updateRte});
   ASSERT_EQ(ret_val, param.expect) << "CreateRte failed!";
 
   m_model = CbuildKernel::Get()->GetModel();
 
   /* Test */
-  ret_val = Collect(filename, m_model, output, "");
+  ret_val = Collect(filename, m_model, output, "", "");
 
   ASSERT_EQ(ret_val, param.expect) << "BuildSystemGenerator Collect failed!";
 }

--- a/tools/buildmgr/test/unittests/src/CbuildModelTests.cpp
+++ b/tools/buildmgr/test/unittests/src/CbuildModelTests.cpp
@@ -41,62 +41,97 @@ TEST_F(CbuildModelTests, GetAccessSequence) {
 
 
 TEST_F(CbuildModelTests, GetCompatibleToolchain_Select_Latest) {
-  string ext = ".cmake", name = "AC6", versionRange = "6.5.0:6.18.0", dir;
+  string name = "AC6", versionRange = "6.5.0:6.18.0", dir;
   string toolchainDir = testinput_folder + "/toolchain";
   string expectedToolchainVersion = "6.16.0";
   string expectedToolchainConfig = toolchainDir + "/AC6.6.16.0.cmake";
   RteFsUtils::NormalizePath(expectedToolchainConfig);
+  vector<string> envVars;
 
   // Select latest compatible toolchain
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.6.6.4.cmake", ""));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.6.16.0.cmake", ""));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/GCC.6.19.0.cmake", ""));
-  EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, ext));
+  EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
   EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);
   ASSERT_TRUE(RteFsUtils::RemoveDir(toolchainDir));
 }
 
 TEST_F(CbuildModelTests, GetCompatibleToolchain_Failed) {
-  string ext = ".cmake", name = "AC6", versionRange = "6.5.0:6.18.0", dir;
+  string name = "AC6", versionRange = "6.5.0:6.18.0", dir;
   string toolchainDir = testinput_folder + "/toolchain";
+  vector<string> envVars;
+
   // Toolchain not found
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir));
-  EXPECT_FALSE(GetCompatibleToolchain(name, versionRange, toolchainDir, ext));
+  EXPECT_FALSE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, RteUtils::EMPTY_STRING);
   EXPECT_EQ(m_toolchainConfig, RteUtils::EMPTY_STRING);
   ASSERT_TRUE(RteFsUtils::RemoveDir(toolchainDir));
 }
 
 TEST_F(CbuildModelTests, GetCompatibleToolchain_Invalid_Files) {
-  string ext = ".cmake", name = "AC6", versionRange = "6.5.0:6.18.0", dir;
+  string name = "AC6", versionRange = "6.5.0:6.18.0", dir;
   string toolchainDir = testinput_folder + "/toolchain";
+  vector<string> envVars;
+
   // No .cmake file found
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/test.info", ""));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.info", ""));
-  EXPECT_FALSE(GetCompatibleToolchain(name, versionRange, toolchainDir, ext));
+  EXPECT_FALSE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, RteUtils::EMPTY_STRING);
   EXPECT_EQ(m_toolchainConfig, RteUtils::EMPTY_STRING);
   ASSERT_TRUE(RteFsUtils::RemoveDir(toolchainDir));
 }
 
 TEST_F(CbuildModelTests, GetCompatibleToolchain_Select_Latest_recursively) {
-  string ext = ".cmake", name = "AC6", versionRange = "6.5.0:6.18.0", dir;
+  string name = "AC6", versionRange = "6.5.0:6.18.0", dir;
   string toolchainDir = testinput_folder + "/toolchain";
   string expectedToolchainVersion = "6.16.0";
   string expectedToolchainConfig = toolchainDir + "/Test/AC6.6.16.0.cmake";
   RteFsUtils::NormalizePath(expectedToolchainConfig);
+  vector<string> envVars;
 
   // Select latest compatible toolchain
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir+"/Test"));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
   ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
-  EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, ext));
+  EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
   EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);
+  ASSERT_TRUE(RteFsUtils::RemoveDir(toolchainDir));
+}
+
+TEST_F(CbuildModelTests, GetCompatibleToolchain_Registered) {
+  string name = "AC6", versionRange = "6.17.0:6.18.0", dir;
+  string toolchainDir = testinput_folder + "/toolchain";
+  string expectedToolchainVersion = "6.16.0";
+  string expectedToolchainConfig = toolchainDir + "/Test/AC6.6.16.0.cmake";
+  RteFsUtils::NormalizePath(expectedToolchainConfig);
+  string expectedToolchainRegisteredVersion = "6.17.0";
+  string expectedToolchainRegisteredRoot = toolchainDir;
+  RteFsUtils::NormalizePath(expectedToolchainRegisteredRoot);
+  vector<string> envVars = {
+    "AC6_TOOLCHAIN_6_16_0=" + toolchainDir,
+    "AC6_TOOLCHAIN_6_17_0=" + toolchainDir,
+    "AC6_TOOLCHAIN_6_17_1=" + toolchainDir + "/non-existent",
+    "AC6_TOOLCHAIN_6_19_0=" + toolchainDir,
+  };
+
+  // Select latest compatible toolchain
+  ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir + "/Test"));
+  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
+  EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
+  EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
+  EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);
+  EXPECT_EQ(m_toolchainRegisteredVersion, expectedToolchainRegisteredVersion);
+  EXPECT_EQ(m_toolchainRegisteredRoot, expectedToolchainRegisteredRoot);
   ASSERT_TRUE(RteFsUtils::RemoveDir(toolchainDir));
 }
 

--- a/tools/buildmgr/test/unittests/src/ModelTests.cpp
+++ b/tools/buildmgr/test/unittests/src/ModelTests.cpp
@@ -36,13 +36,14 @@ void ModelTests::TearDown() {
 void ModelTests::CheckCreateRte(const TestParam& param, const string& inputDir) {
   error_code ec;
   string filename = inputDir + "/" + param.name;
-  string toolchain = "", ext = CMEXT, novalue = "";
-  bool ret_val, packMode = false;
+  string toolchain = "", novalue = "";
+  bool ret_val, packMode = false, updateRte = false;
+  vector<string> envVars;
 
   fs::current_path(filename.c_str(), ec);
   filename = param.targetArg + ".cprj";
 
-  ret_val = CreateRte({filename, novalue, novalue, toolchain, ext, novalue, novalue, packMode});
+  ret_val = CreateRte({filename, novalue, novalue, toolchain, novalue, novalue, envVars, packMode, updateRte });
   EXPECT_EQ(ret_val, param.expect) << "CreateRte failed!";
 }
 
@@ -112,8 +113,9 @@ TEST_F(ModelTests, CreateRte_MissingDeviceName) {
 }
 
 TEST_F(ModelTests, CheckPackListLocalRepo) {
-  string const toolchain = "", ext = CMEXT, novalue = "";
+  string const toolchain = "", novalue = "";
   string const filename = testinput_folder + "/PacklistLocal.cprj";
   string const rtePath = string(CMAKE_SOURCE_DIR) + "/test/local";
-  EXPECT_TRUE(CreateRte({ filename, rtePath, novalue, toolchain, ext, novalue, novalue, true }));
+  vector<string> envVars;
+  EXPECT_TRUE(CreateRte({ filename, rtePath, novalue, toolchain, novalue, novalue, envVars, true, false }));
 }


### PR DESCRIPTION
Address `buildmgr` part of https://github.com/Open-CMSIS-Pack/devtools/issues/699
- handle environment variables for toolchain registration:
  - select the greatest registered toolchain and its greatest config file compatible with project requirements.
  - if no environment variable is found (no toolchain is registered), select the greatest config file compatible with project requirements and leave it to CMake to find the compiler. The CMake variable `TOOLCHAIN_ROOT` in config files is still accepted for backward compatibility.
- instructs CMake to check whether the running toolchain version matches the selected registered version and it is compatible with project requirements.
- increases minimum CMake version to 3.22 for alignment with policy [CMP0123](https://cmake.org/cmake/help/latest/policy/CMP0123.html) and ubuntu [22.04LTS](https://packages.ubuntu.com/search?keywords=cmake).