### PR TITLE
PackChk reports INFO messages when generate STM32L5xx_DFP and STM32L0xx_DFP (#479)

### DIFF
--- a/tools/packchk/include/ValidateSemantic.h
+++ b/tools/packchk/include/ValidateSemantic.h
@@ -43,7 +43,7 @@ public:
   bool ExcludeSysHeaderDirectories(const std::string& systemHeader, const std::string& rteFolder);
   bool FindFileFromList(const std::string& systemHeader, const std::set<RteFile*>& targFiles);
   bool CheckDeviceDependencies(RteDeviceItem* device, RteProject* rteProject);
-
+  bool HasExternalGenerator(RteComponentAggregate* aggregate);
 
   const std::map<std::string, compiler_s>& GetCompilers() {
     return m_compilers;


### PR DESCRIPTION
added:
- iteration over possible TrustZone variants, if available
- skipping Test for system_ and startup_ if generator is involved

https://github.com/Arm-Debug/devtools-external/pull/479