### PR TITLE
prjmgr] Base files for config files are created unconditionally (#496)

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -540,7 +540,7 @@ void RteProject::UpdateConfigFileBackups(RteFileInstance* fi, RteFile* f)
   string absPath = RteFsUtils::AbsolutePath(fi->GetAbsolutePath()).generic_string();
   string dir = RteUtils::ExtractFilePath(absPath, false);
   string name = RteUtils::ExtractFileName(absPath);
-  const string& baseVersion = fi->GetVersionString();
+  const string& baseVersion = fi->GetAttribute("version"); // explicitly check the file instance version
   const string& updateVersion = f->GetVersionString();
   string baseFile = RteUtils::AppendFileBaseVersion(absPath, baseVersion);
   if (!RteFsUtils::Exists(baseFile)) {


### PR DESCRIPTION
in case the file version matches the component version
fixed by explicitly asking for the file instance version
