### PR TITLE
RTE Model refactoring: (#494)

### DIFF
--- a/libs/rtemodel/include/RteComponent.h
+++ b/libs/rtemodel/include/RteComponent.h
@@ -51,7 +51,7 @@ public:
    * @brief get number of files described in this component
    * @return number of <file> elements
   */
-  int GetFileCount() const;
+  size_t GetFileCount() const;
   /**
    * @brief get <files> element
    * @return pointer to RteFileContainer representing container for RteFile items

--- a/libs/rtemodel/include/RteDevice.h
+++ b/libs/rtemodel/include/RteDevice.h
@@ -1371,14 +1371,14 @@ public:
    * @brief get number of RteDeviceItemAggregate children
    * @return number of RteDeviceItemAggregate children as integer
   */
-  int GetChildCount() const { return (int)m_children.size(); }
+  size_t GetChildCount() const { return m_children.size(); }
 
   /**
    * @brief get number of RteDeviceItemAggregate children of requested hierarchy type
    * @param type RteDeviceItem::TYPE
    * @return  number of RteDeviceItemAggregate children as integer
   */
-  int GetChildCount(RteDeviceItem::TYPE type) const;
+  size_t GetChildCount(RteDeviceItem::TYPE type) const;
   /**
    * @brief create short device item description
    * @return summary string

--- a/libs/rtemodel/include/RteInstance.h
+++ b/libs/rtemodel/include/RteInstance.h
@@ -1035,12 +1035,20 @@ public:
   */
   virtual std::string GetEffectiveDisplayName(const std::string& targetName) const;
 
+
+  /**
+   * @brief get resolved component for specified target
+   * @param targetName target name
+   * @return pointer to resolved RteComponent, nullptr if not resolved
+  */
+  RteComponent* GetComponent(const std::string& targetName) const override
+  { return GetResolvedComponent(targetName); }
   /**
    * @brief get resolved component for specified target
    * @param targetName target name to resolve component
    * @return pointer to RteComponent if resolved, nullptr otherwise
   */
-  virtual RteComponent* GetResolvedComponent(const std::string& targetName) const override;
+  RteComponent* GetResolvedComponent(const std::string& targetName) const override;
 
   /**
    * @brief set resolved component for specified target

--- a/libs/rtemodel/include/RteKernel.h
+++ b/libs/rtemodel/include/RteKernel.h
@@ -229,7 +229,7 @@ protected:
    * @brief get this pointer to use in const methods
    * @return this
   */
-  RteKernel* GetThis() const { return const_cast<RteKernel*>(this); }
+  RteKernel* GetThisKernel() const { return const_cast<RteKernel*>(this); }
 
 private:
   RteGlobalModel* m_globalModel;

--- a/libs/rtemodel/include/RtePackage.h
+++ b/libs/rtemodel/include/RtePackage.h
@@ -195,30 +195,30 @@ public:
    * @return number of <api> elements as integer
   */
 
-  int GetApiCount() const { return m_apis ? m_apis->GetChildCount() : 0; }
+  size_t GetApiCount() const { return m_apis ? m_apis->GetChildCount() : 0; }
   /**
    * @brief get number of conditions in the pack described under <conditions> element
    * @return number of <condition> elements as integer
   */
 
-  int GetConditionCount() const { return m_conditions ? m_conditions->GetChildCount() : 0; }
+  size_t GetConditionCount() const { return m_conditions ? m_conditions->GetChildCount() : 0; }
   /**
    * @brief get number of components in the pack described under <components> element
    * @return number of <component> elements as integer
   */
 
-  int GetComponentCount() const { return m_components ? m_components->GetChildCount() : 0; }
+  size_t GetComponentCount() const { return m_components ? m_components->GetChildCount() : 0; }
   /**
    * @brief get number of examples  in the pack described under <examples> element
    * @return number of <example> elements as integer
   */
-  int GetExampleCount() const { return m_examples ? m_examples->GetChildCount() : 0; }
+  size_t GetExampleCount() const { return m_examples ? m_examples->GetChildCount() : 0; }
 
   /**
    * @brief get number of boards in the pack described under <boards> element
    * @return number of <board> elements as integer
   */
-  int GetBoardCount() const { return m_boards ? m_boards->GetChildCount() : 0; }
+  size_t GetBoardCount() const { return m_boards ? m_boards->GetChildCount() : 0; }
 
   /**
    * @brief get <releases> element

--- a/libs/rtemodel/src/RteComponent.cpp
+++ b/libs/rtemodel/src/RteComponent.cpp
@@ -114,7 +114,7 @@ RteBundle* RteComponent::GetParentBundle() const
 }
 
 
-int RteComponent::GetFileCount() const
+size_t RteComponent::GetFileCount() const
 {
   return m_files ? m_files->GetChildCount() : 0;
 }

--- a/libs/rtemodel/src/RteDevice.cpp
+++ b/libs/rtemodel/src/RteDevice.cpp
@@ -1150,14 +1150,10 @@ void RteDeviceItemAggregate::AddDeviceItem(RteDeviceItem* item)
 }
 
 
-int RteDeviceItemAggregate::GetChildCount(RteDeviceItem::TYPE type) const
+size_t RteDeviceItemAggregate::GetChildCount(RteDeviceItem::TYPE type) const
 {
-  int cnt = 0;
-  auto childmap = GetChildren();
-  if (childmap.empty()) {
-    return (0);
-  }
-
+  size_t cnt = 0;
+  auto& childmap = GetChildren();
   for (auto it = childmap.begin(); it != childmap.end(); it++) {
     if (it->second && it->second->GetType() == type) {
       cnt++;

--- a/libs/rtemodel/src/RteModel.cpp
+++ b/libs/rtemodel/src/RteModel.cpp
@@ -352,7 +352,7 @@ RtePackage* RteModel::ConstructPack(XMLTreeElement* xmlTreeDoc)
     GetCallback()->PackProcessed(package->GetID(), true);
     return package;
   }
-  GetCallback()->PackProcessed(xmlTreeDoc->GetFileName(), false);
+  GetCallback()->PackProcessed(xmlTreeDoc->GetRootFileName(), false);
   const list<string>& errors = package->GetErrors();
   m_errors.insert(m_errors.end(), errors.begin(), errors.end());
   delete package;

--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -593,7 +593,7 @@ bool RtePackage::Construct(XMLTreeElement* xmlElement)
   // we are not interested in XML attributes for package
   m_lineNumber = xmlElement->GetLineNumber();
   m_tag = xmlElement->GetTag();
-  m_fileName = xmlElement->GetFileName();
+  m_fileName = xmlElement->GetRootFileName();
   AddAttribute("schemaVersion", xmlElement->GetAttribute("schemaVersion"), false);
   bool success = ProcessXmlChildren(xmlElement);
   m_ID = ConstructID();

--- a/libs/rtemodel/test/src/RteChk.cpp
+++ b/libs/rtemodel/test/src/RteChk.cpp
@@ -44,17 +44,17 @@ public:
   virtual VISIT_RESULT Visit(RteItem* rteItem)
   {
     if (rteItem->IsValid())
-      return SKIP_CHILDREN;
+      return VISIT_RESULT::SKIP_CHILDREN;
 
     const list<string>& errors = rteItem->GetErrors();
     if (errors.empty())
-      return CONTINUE_VISIT;
+      return VISIT_RESULT::CONTINUE_VISIT;
     list<string>::const_iterator it;
     for (it = errors.begin(); it != errors.end(); it++) {
       string sErr = (*it);
       cerr << sErr << endl;
     }
-    return CONTINUE_VISIT;
+    return VISIT_RESULT::CONTINUE_VISIT;
   }
 };
 

--- a/libs/xmltree/include/XMLTree.h
+++ b/libs/xmltree/include/XMLTree.h
@@ -138,20 +138,20 @@ public:
    * @param tag name of tag
   */
   XMLTreeElement(XMLTreeElement* parent, const std::string& tag);
-  virtual ~XMLTreeElement();
+  ~XMLTreeElement() override;
 
   /**
    * @brief getter for this instance
    * @return pointer to the instance of type XMLTreeElement
   */
-  virtual XMLTreeElement* GetThis() const override { return const_cast<XMLTreeElement*>(this); }
+  XMLTreeElement* GetThis() const override { return const_cast<XMLTreeElement*>(this); }
 
   /**
    * @brief create a new instance of type XMLTreeElement
    * @param tag name of tag
    * @return pointer to instance of type XMLTreeElement
   */
-  virtual XMLTreeElement* CreateItem(const std::string& tag) override { return new XMLTreeElement(GetThis(), tag); }
+  XMLTreeElement* CreateItem(const std::string& tag) override { return new XMLTreeElement(GetThis(), tag); }
 
   /**
    * @brief create a new XML child element of the instance
@@ -201,13 +201,13 @@ public:
    * @brief getter for XML file name stored in the instance
    * @return string containing XML file name
   */
-  virtual const std::string& GetFileName() const  override { return m_xmlFile; }
+  const std::string& GetRootFileName() const  override { return m_xmlFile; }
 
   /**
    * @brief check if instance is valid
    * @return true if instance is valid, otherwise false
   */
-  virtual bool IsValid() const  override { return m_bValid; }
+  bool IsValid() const  override { return m_bValid; }
 
   /**
    * @brief setter for instance validity

--- a/libs/xmltree/include/XmlTreeItem.h
+++ b/libs/xmltree/include/XmlTreeItem.h
@@ -20,7 +20,7 @@
 /**
  * @brief enumerators for visitor class
 */
-enum VISIT_RESULT {
+enum class VISIT_RESULT {
   CONTINUE_VISIT, // continue processing
   SKIP_CHILDREN,  // skip processing of the children
   CANCEL_VISIT    // abort any further processing
@@ -67,12 +67,19 @@ public:
    * @param parent pointer to parent element
    * @param tag name of tag
   */
-  XmlTreeItem(TITEM* parent, const std::string& tag) :XmlItem(tag), m_parent(parent) {}
+  XmlTreeItem(TITEM* parent, const std::string& tag) : XmlItem(tag), m_parent(parent) {}
+
+  /**
+   * @brief parametrized constructor to instantiate with given attributes
+   * @param parent pointer to parent element
+   * @param attributes collection as key to value pairs
+  */
+  XmlTreeItem(TITEM* parent, const std::map<std::string, std::string>& attributes) : XmlItem(attributes), m_parent(parent) {}
 
   /**
    * @brief destructor
   */
-  virtual ~XmlTreeItem() {
+  ~XmlTreeItem() override {
     m_parent = nullptr;
     XmlTreeItem::Clear();
   }
@@ -80,7 +87,7 @@ public:
   /**
    * @brief clear children and attributes of the instance
   */
-  virtual void Clear() override
+  void Clear() override
   {
     for (auto it = m_children.begin(); it != m_children.end(); it++) {
       delete *it;
@@ -183,6 +190,12 @@ public:
   const std::list<TITEM*>& GetEmptyList() const { static const std::list<TITEM*> sEmptyList; return sEmptyList; }
 
   /**
+  * @brief get number of children
+  * @return number of children
+  */
+  size_t GetChildCount() const { return m_children.size(); }
+
+  /**
    * @brief  getter for member m_children
    * @return list of pointer to instances of template type TITEM
   */
@@ -210,15 +223,13 @@ public:
    * @brief add a new child to the instance
    * @param child pointer to a new child of template type TITEM
    * @param prepend true to insert child at the front, false to append child at the list end
-   * @return pointer to the new child
+   * @return pointer to the new child to allow something like newChild = AddChild(CreateItem(tag))
   */
   virtual TITEM* AddChild(TITEM* child, bool prepend) {
-    // returns TITEM* to allow something like newChild = AddChild(CreateItem(tag))
-    if (child && child != GetThis() && child->GetParent() == GetThis()) {
-      if (prepend)
-        m_children.push_front(child);
-      else
-        m_children.push_back(child);
+    if (prepend) {
+      m_children.push_front(child);
+    } else {
+      m_children.push_back(child);
     }
     return child;
   }
@@ -229,7 +240,8 @@ public:
    * @return pointer to the new child
   */
   virtual TITEM* AddChild(TITEM* child) {
-    return AddChild(child, false);
+    m_children.push_back(child);
+    return child;
   }
 
   /**
@@ -258,6 +270,21 @@ public:
       }
     }
     return nullptr;
+  }
+
+  /**
+   * @brief get child's attribute value
+   * @param tag child's tag
+   * @param attribute child's attribute key
+   * @return child's attribute value string
+  */
+  const std::string& GetChildAttribute(const std::string& tag, const std::string& attribute) const
+  {
+    TITEM* child = GetFirstChild(tag);
+    if (child) {
+      return child->GetAttribute(attribute);
+    }
+    return EMPTY_STRING;
   }
 
   /**
@@ -313,15 +340,15 @@ public:
   }
 
   /**
-   * @brief recursively look for an instance of template type TITEM specified by tag and tag text
-   * @param tag name of tag
-   * @param text text of tag
+   * @brief recursively look for an instance of a child item specified by tag and text
+   * @param tag child tag to search for
+   * @param text child text to search for
    * @return pointer to the instance found, otherwise nullptr
   */
-  virtual TITEM* FindItem(const char* tag, const char* text) const
+  virtual TITEM* FindItem(const std::string& tag, const std::string& text) const
   {
-    if (!tag || GetTag() == tag) {
-      if (!text || GetText() == text)
+    if (!tag.empty() || GetTag() == tag) {
+      if (!text.empty() || GetText() == text)
         return GetThis();
     }
     for (auto it = m_children.begin(); it != m_children.end(); it++) {
@@ -336,11 +363,11 @@ public:
    * @brief getter for file name associated with this instance
    * @return file name string
   */
-  virtual const std::string& GetFileName() const
+  virtual const std::string& GetRootFileName() const
   {
     TITEM* root = GetRoot();
     if (root)
-      return root->GetFileName();
+      return root->GetRootFileName();
     return EMPTY_STRING;
   }
 
@@ -352,10 +379,10 @@ public:
   virtual bool AcceptVisitor(XmlItemVisitor<TITEM>* visitor) {
     if (visitor) {
       VISIT_RESULT res = visitor->Visit(GetThis());
-      if (res == CANCEL_VISIT) {
+      if (res == VISIT_RESULT::CANCEL_VISIT) {
         return false;
       }
-      if (res == CONTINUE_VISIT) {
+      if (res == VISIT_RESULT::CONTINUE_VISIT) {
         for (auto it = m_children.begin(); it != m_children.end(); it++) {
           if (!(*it)->AcceptVisitor(visitor))
             return false;
@@ -369,7 +396,7 @@ public:
   /**
    * @brief setter for text of a child given by tag
    * @param tag name of child instance
-   * @param text text to set
+   * @param text child text to set
   */
   virtual void SetChildText(const std::string& tag, const std::string& text) {
     GetOrCreateChild(tag)->SetText(text);

--- a/libs/xmltree/include/XmlTreeItemBuilder.h
+++ b/libs/xmltree/include/XmlTreeItemBuilder.h
@@ -33,7 +33,7 @@ public:
    * @brief clear the instance
    * @param bDeleteContent true to delete the member m_pRoot of template type T
   */
-  virtual void Clear(bool bDeleteContent = false) {
+  void Clear(bool bDeleteContent = false) override {
 
     if (bDeleteContent && m_pRoot != 0)
       delete m_pRoot;
@@ -58,7 +58,7 @@ public:
   /**
    * @brief add child specified by member m_pCurrent to parent
   */
-  virtual void AddItem()
+  void AddItem() override
   {
     if (m_pParent && m_pParent != m_pCurrent)
       m_pParent->AddChild(m_pCurrent);
@@ -69,7 +69,7 @@ public:
    * @param key attribute name
    * @param value attribute value to set in instance of template type T
   */
-  virtual void AddAttribute(const std::string& key, const std::string& value)
+  void AddAttribute(const std::string& key, const std::string& value) override
   {
     if (m_pCurrent)
       m_pCurrent->AddAttribute(key, value);
@@ -79,7 +79,7 @@ public:
    * @brief setter for tag text of member m_pCurrent of template type T
    * @param text string to set in instance of template type T
   */
-  virtual void SetText(const std::string& text)
+  void SetText(const std::string& text) override
   {
     if (m_pCurrent)
       m_pCurrent->SetText(text);
@@ -88,7 +88,7 @@ public:
   /**
    * @brief this function gets called before a new item is created
   */
-  virtual void PreCreateItem()
+  void PreCreateItem() override
   {
     if (m_pParent)
       m_stack.push_front(m_pParent);
@@ -101,7 +101,7 @@ public:
    * @param tag name of item
    * @return true if item is successfully created
   */
-  virtual bool CreateItem(const std::string& tag)
+  bool CreateItem(const std::string& tag) override
   {
     if (!HasRoot()) {
       m_pRoot = m_pCurrent = CreateRootItem(tag);
@@ -122,7 +122,7 @@ public:
    * @brief this function get called after an item has been created
    * @param success validity flag to set for item having been created
   */
-  virtual void PostCreateItem(bool success)
+  void PostCreateItem(bool success) override
   {
     m_pCurrent = m_pParent;
     auto it = m_stack.begin();
@@ -143,7 +143,7 @@ public:
    * @brief setter for line number of the current item in the instance
    * @param lineNumber line number to set
   */
-  void SetLineNumber(int lineNumber)
+  void SetLineNumber(int lineNumber) override
   {
     if (m_pCurrent)
       m_pCurrent->SetLineNumber(lineNumber);

--- a/tools/packchk/src/CheckComponents.cpp
+++ b/tools/packchk/src/CheckComponents.cpp
@@ -22,7 +22,7 @@ VISIT_RESULT ComponentsVisitor::Visit(RteItem* item)
 {
   m_checkComponent.CheckComp(item);
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**

--- a/tools/packchk/src/CheckConditions.cpp
+++ b/tools/packchk/src/CheckConditions.cpp
@@ -40,7 +40,7 @@ DefinedConditionsVisitor::~DefinedConditionsVisitor()
 VISIT_RESULT DefinedConditionsVisitor::Visit(RteItem* item)
 {
   if(!m_target) {
-    return CANCEL_VISIT;
+    return VISIT_RESULT::CANCEL_VISIT;
   }
 
   RteCondition* cond = dynamic_cast<RteCondition*>(item);
@@ -49,13 +49,13 @@ VISIT_RESULT DefinedConditionsVisitor::Visit(RteItem* item)
     if(result == RteItem::R_ERROR) {
       LogMsg("M390", NAME(cond->GetName()), MSG("Skipping condition for further checks."), cond->GetLineNumber());
       cond->Invalidate();
-      return CONTINUE_VISIT;
+      return VISIT_RESULT::CONTINUE_VISIT;
     }
 
     m_Conditions->AddDefinedCondition(cond);
   }
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**
@@ -87,11 +87,11 @@ VISIT_RESULT UsedConditionsVisitor::Visit(RteItem* item)
     if(!condId.empty()) {
       m_Conditions->AddUsedCondition(condId, item->GetLineNumber());
     }
-    return CONTINUE_VISIT;
+    return VISIT_RESULT::CONTINUE_VISIT;
   }
 
   if(!cond->IsValid()) {
-    return CONTINUE_VISIT;
+    return VISIT_RESULT::CONTINUE_VISIT;
   }
 
   if(cond != item) {                // item is not a condition, but something that can use a condition
@@ -101,7 +101,7 @@ VISIT_RESULT UsedConditionsVisitor::Visit(RteItem* item)
     m_Conditions->AddUsedCondition(condId, item->GetLineNumber());
   }
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**

--- a/tools/packchk/src/CheckFiles.cpp
+++ b/tools/packchk/src/CheckFiles.cpp
@@ -41,7 +41,7 @@ VISIT_RESULT CheckFilesVisitor::Visit(RteItem* item)
 {
   m_checkFiles.CheckFile(item);
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**
@@ -224,7 +224,7 @@ bool CheckFiles::CheckFile(RteItem* item)
 
   // check if fileName is a URL
   if(fileName.find(":", 2) != (size_t)-1 || fileName.find("www.") == 0) {
-    return CONTINUE_VISIT;
+    return true;
   }
 
   // Trim #directJump from htm(l) strings

--- a/tools/packchk/src/GatherCompilers.cpp
+++ b/tools/packchk/src/GatherCompilers.cpp
@@ -37,7 +37,7 @@ VISIT_RESULT GatherCompilersVisitor::Visit(RteItem* item)
     AddCompiler(cond);
   }
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**

--- a/tools/packchk/src/RteModelReader.cpp
+++ b/tools/packchk/src/RteModelReader.cpp
@@ -20,12 +20,12 @@ using namespace std;
 VISIT_RESULT RteModelReaderErrorVistior::Visit(RteItem* rteItem)
 {
   if(rteItem->IsValid()) {
-    return SKIP_CHILDREN;
+    return VISIT_RESULT::SKIP_CHILDREN;
   }
 
   const list<string>& errors = rteItem->GetErrors();
   if(errors.empty()) {
-    return CONTINUE_VISIT;
+    return VISIT_RESULT::CONTINUE_VISIT;
   }
 
   for(auto msg : errors) {
@@ -40,7 +40,7 @@ VISIT_RESULT RteModelReaderErrorVistior::Visit(RteItem* rteItem)
     }
   }
 
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }
 
 /**

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1372,7 +1372,7 @@ bool ProjMgrWorker::AddRequiredComponents(ContextItem& context) {
   if (!unresolvedComponents.empty()) {
     string msg = "unresolved components:";
     for (const auto& component : unresolvedComponents) {
-      msg += "\n" + ProjMgrUtils::GetComponentID(component->GetComponent());
+      msg += "\n" + ProjMgrUtils::GetComponentID(component);
     }
     ProjMgrLogger::Error(msg);
     return false;

--- a/tools/svdconv/SVDModel/src/SvdDevice.cpp
+++ b/tools/svdconv/SVDModel/src/SvdDevice.cpp
@@ -46,7 +46,7 @@ SvdDevice::~SvdDevice()
 bool SvdDevice::Construct(XMLTreeElement* xmlElement)
 {
   // we are not interested in XML attributes for package
-	m_fileName = xmlElement->GetFileName();
+	m_fileName = xmlElement->GetRootFileName();
   AddAttribute("schemaVersion", xmlElement->GetAttribute("schemaVersion"), false);
 
   return SvdItem::Construct(xmlElement);

--- a/tools/svdconv/SVDModel/src/SvdItem.cpp
+++ b/tools/svdconv/SVDModel/src/SvdItem.cpp
@@ -792,11 +792,11 @@ bool SvdItem::AcceptVisitor(SvdVisitor* visitor)
 {
   if(visitor) {
     const auto res = visitor->Visit(this);
-    if( res == CANCEL_VISIT) {
+    if( res == VISIT_RESULT::CANCEL_VISIT) {
       return false;
     }
 
-    if(res == CONTINUE_VISIT) {
+    if(res == VISIT_RESULT::CONTINUE_VISIT) {
       SvdDimension *dimItem = GetDimension();
       if(dimItem) {
         dimItem->AcceptVisitor(visitor);

--- a/tools/svdconv/SVDModel/src/SvdModel.cpp
+++ b/tools/svdconv/SVDModel/src/SvdModel.cpp
@@ -93,5 +93,5 @@ bool SvdModel::CheckItem()
 
 VISIT_RESULT SvdModelCalculate::Visit(SvdItem* item)
 {
-  return CONTINUE_VISIT;
+  return VISIT_RESULT::CONTINUE_VISIT;
 }


### PR DESCRIPTION
* RTE Model refactoring:

derive RteItem from XmlTreeItem<RteItem>

make VISIT result class enum

remove duplicated methods from RteItem

use size_t instead of int for collection sizes

add RteComponentInstance::GetComponent() override to simplify logic

simplify XmlTreeItem::AddChild()
