### PR TITLE
Use XDG_CACHE_HOME for macOS

### DIFF
--- a/libs/crossplatform/CMakeLists.txt
+++ b/libs/crossplatform/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(HEADER_FILES    include/CrossPlatform.h
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   add_definitions(-DDEFAULT_PACKROOTDEF=\"XDG_CACHE_HOME\")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  add_definitions(-DDEFAULT_PACKROOTDEF=\"HOME\")
+  add_definitions(-DDEFAULT_PACKROOTDEF=\"XDG_CACHE_HOME\")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   add_definitions(-DDEFAULT_PACKROOTDEF=\"LOCALAPPDATA\")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")

--- a/libs/crossplatform/src/Darwin/constants.h
+++ b/libs/crossplatform/src/Darwin/constants.h
@@ -9,7 +9,7 @@
 
 constexpr const char* LOCAL_APP_DATA = "XDG_CACHE_HOME";
 constexpr const char* USER_PROFILE   = "HOME";
-constexpr const char* PACK_ROOT_DIR  = "/arm/packs";
+constexpr const char* PACK_ROOT_DIR  = "/.cache/arm/packs";
 constexpr const char* CACHE_DIR      = "/.cache";
 constexpr const char* HOST_TYPE      = "mac";
 

--- a/libs/crossplatform/src/Darwin/constants.h
+++ b/libs/crossplatform/src/Darwin/constants.h
@@ -9,7 +9,7 @@
 
 constexpr const char* LOCAL_APP_DATA = "XDG_CACHE_HOME";
 constexpr const char* USER_PROFILE   = "HOME";
-constexpr const char* PACK_ROOT_DIR  = "/.cache/arm/packs";
+constexpr const char* PACK_ROOT_DIR  = "/arm/packs";
 constexpr const char* CACHE_DIR      = "/.cache";
 constexpr const char* HOST_TYPE      = "mac";
 


### PR DESCRIPTION
somehow things are screwed up on macOS. I am expecting to use $HOME/.cache/arm/packs if XDG_CACHE_HOME is not set.