### PR TITLE
SVDConv: fix bitfield generator for unions (#499)

### DIFF
--- a/tools/svdconv/SVDGenerator/include/HeaderData.h
+++ b/tools/svdconv/SVDGenerator/include/HeaderData.h
@@ -11,15 +11,22 @@
 #include "SvdGenerator.h"
 #include "SvdOptions.h"
 #include "FileIo.h"
+#include "SvdField.h"
 
 #include <stdint.h>
 #include <string>
 #include <map>
 #include <list>
 
+struct ONESTRUCT {
+  uint32_t mask;
+  std::map<uint32_t, SvdField*> fields;
 
-using REGMAP = std::map<uint64_t,     std::list<SvdItem*> >;
-using FIELDMAP = std::map<uint32_t, std::list<SvdItem*> >;
+  ONESTRUCT() : mask(0) {}
+};
+
+using REGMAP = std::map<uint64_t, std::list<SvdItem*> >;
+using FIELDMAPLIST = std::list<ONESTRUCT>;
 
 #define MAX_REGS      32
 
@@ -104,7 +111,7 @@ protected:
 
   // HeaderData_Peripheral
   bool      CreatePeripherals                       (SvdDevice* device);
-  
+
   bool      CreatePeripheralsInstance               (SvdDevice* device);
   bool      CreatePeripheralInstance                (SvdPeripheral* peripheral);
 
@@ -152,10 +159,10 @@ protected:
   void            Init_OpenCloseStructUnion         ();
 
   // HeaderData_Fields
-  uint32_t        CreateField                       (const std::list<SvdItem*>& fieldList, uint32_t regSize, uint32_t offsCnt);
-  bool            CreateSortedFields                (const FIELDMAP& sortedFields, uint32_t regSize);
-  bool            AddFields                         (SvdItem* container, FIELDMAP& sortedFields);
-  bool            CreateFields                      (SvdRegister* reg);
+  uint32_t        CreateField                       (SvdField* field, uint32_t regSize, uint32_t offsCnt);
+  bool            CreateSortedFields                (const FIELDMAPLIST& sortedFields, uint32_t regSize, std::string structName);
+  bool            AddFields                         (SvdItem* container, FIELDMAPLIST& sortedFields);
+  bool            CreateFields                      (SvdRegister* reg, std::string structName);
 
   // HeaderData_PosMask
   bool            CreatePosMask                     (SvdDevice* device);

--- a/tools/svdconv/SVDGenerator/src/HeaderData_Register.cpp
+++ b/tools/svdconv/SVDGenerator/src/HeaderData_Register.cpp
@@ -63,7 +63,7 @@ bool HeaderData::CreateSortedRegisters(const REGMAP &regs)
   return true;
 }
 
-uint32_t HeaderData::CreateSvdItem(SvdItem *item, uint64_t address) 
+uint32_t HeaderData::CreateSvdItem(SvdItem *item, uint64_t address)
 {
   if(!item) {
     return true;
@@ -117,7 +117,7 @@ bool HeaderData::CheckAlignment(SvdItem* item)
   if(/* (pos == 0 && size > 4) \
     ||*/(pos == 1 && size > 3) \
     ||  (pos == 2 && size > 2) \
-    ||  (pos == 3 && size > 1) ) 
+    ||  (pos == 3 && size > 1) )
   {
         const auto& name = item->GetName();
         m_gen->Generate<C_ERROR >("Unaligned Registers are not supported: '%s' addr: 0x%08x pos: %d, size: %d", item->GetLineNumber(), name.c_str(), address, pos, size);
@@ -202,20 +202,16 @@ uint32_t HeaderData::CreateRegister(SvdRegister* reg)
 
     size *= num;
   }
-  
+
   if(generateFields) {
     m_gen->Generate<UNION|BEGIN >("");
   }
-  
+
   m_gen->Generate<MAKE|MK_REGISTER_STRUCT    >("%s", accessType, dataTypeStr.c_str(), size, regName.c_str());
   m_gen->Generate<MAKE|MK_DOXY_COMMENT_ADDR  >("%s", addr, !descr.empty()? descr.c_str() : name.c_str());
-  
+
   if(generateFields) {
-    m_gen->Generate<STRUCT|BEGIN             >("");
-
-    CreateFields(reg);
-
-    m_gen->Generate<STRUCT|END               >("%s", structName.c_str());
+    CreateFields(reg, structName);
     m_gen->Generate<UNION|END                >("%s", unionName.c_str());
   }
 
@@ -244,6 +240,6 @@ uint32_t HeaderData::CreateRegCluster(SvdCluster*  cluster)
   }
 
   m_gen->Generate<MAKE|MK_DOXY_COMMENT_ADDR  >("%s", addr, !descr.empty()? descr.c_str() : name.c_str());
-  
+
   return size;
 }


### PR DESCRIPTION
Bitfields are now generated in separate structs inside register union, if overlapping