### PR TITLE
Ram (#510)

### DIFF
--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -1745,7 +1745,7 @@ std::string RteTarget::GenerateRegionsHeaderContent() const
   oss << "// =======================" << RteUtils::LF_STRING;
   for (size_t i = 0; i < memRW.size(); i++) {
     RteItem* mem = memRW[i];
-    string id = string("__ROM") + RteUtils::LongToString(i);
+    string id = string("__RAM") + RteUtils::LongToString(i);
     oss << GenerateMemoryRegionContent(mem, id, i >= nDeviceRW);
   }
   oss << "// </h>" << RteUtils::LF_STRING;

--- a/test/packs/ARM/RteTestBoard/0.1.0/ARM.RteTestBoard.pdsc
+++ b/test/packs/ARM/RteTestBoard/0.1.0/ARM.RteTestBoard.pdsc
@@ -27,13 +27,13 @@
       <algorithm name="Board/Flash/BoargAlgo1.FLM" start="0x00000000" size="0x00040000" default="1"/>
       <algorithm name="Board/Flash/BoargAlgo2.FLM" start="0x00000000" size="0x00020000" default="0"/>
       <memory name="BoardFLASH" access="rx" start="0x30000000" size="0x00040000" startup="1" default="1"/>
-      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" init   ="0" default="1"/>
+      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" uninit="1" default="1"/>
     </board>
     <board name="RteTest NoMCU board" vendor="Keil">
       <description>No device board</description>
       <mountedDevice Dvendor="NO_VENDOR:0" Dname="NO_MCU"/>
       <memory name="BoardFLASH" access="rx" start="0x30000000" size="0x00040000" startup="1" default="1"/>
-      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" init   ="0" default="1"/>
+      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" uninit="1" default="1"/>
     </board>
     <board name="RteTest CM4 board" vendor="Keil" revision="Rev.C">
       <description>uVision Simulator</description>
@@ -42,7 +42,7 @@
       <algorithm name="Board/Flash/BoargAlgo1.FLM" start="0x00000000" size="0x00040000" default="1"/>
       <algorithm name="Board/Flash/BoargAlgo2.FLM" start="0x00000000" size="0x00020000" default="0"/>
       <memory name="BoardFLASH" access="rx" start="0x30000000" size="0x00040000" startup="1" default="1"/>
-      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" init   ="0" default="1"/>
+      <memory name="BoardRAM" access="rwx" start="0x40000000" size="0x00020000" default="1"/>
     </board>
   </boards>
 

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -118,7 +118,7 @@
       </description>
       <debug svd="Device/ARM/SVD/ARMCM0.svd"/>  <!-- SVD files do not contain any peripheral -->
       <memory id="IROM1" start="0x00000000" size="0x00040000" startup="1" default="1"/>
-      <memory id="IRAM1" start="0x20000000" size="0x00020000" init   ="0" default="1"/>
+      <memory id="IRAM1" start="0x20000000" size="0x00020000" uninit="1" default="1"/>
 
       <device Dname="RteTest_ARMCM0">
         <processor Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" Dendian="Configurable" Dclock="10000000"/>
@@ -148,7 +148,7 @@
       </description>
       <debug svd="Device/ARM/SVD/ARMCM3.svd"/>  <!-- SVD files do not contain any peripheral -->
       <memory id="IROM1" start="0x00000000" size="0x00040000" startup="1" default="1"/>
-      <memory id="IRAM1" start="0x20000000" size="0x00020000" init   ="0" default="1"/>
+      <memory id="IRAM1" start="0x20000000" size="0x00020000" uninit="1" default="1"/>
 
       <device Dname="RteTest_ARMCM3">
         <processor Dcore="Cortex-M3" DcoreVersion="r2p1" Dfpu="NO_FPU" Dmpu="MPU" Dendian="Configurable" Dclock="10000000"/>
@@ -164,7 +164,7 @@
       </description>
       <debug svd="Device/ARM/SVD/ARMCM4.svd"/>  <!-- SVD files do not contain any peripheral -->
       <memory name="FLASH" access="rx" start="0x00000000" size="0x00040000" startup="1" default="1"/>
-      <memory name="SRAM"  access="rwx" start="0x20000000" size="0x00020000" init   ="0" default="1"/>
+      <memory name="SRAM"  access="rwx" start="0x20000000" size="0x00020000" uninit="1" default="1"/>
       <algorithm name="Device/ARM/Flash/CortexM4SubFamily.FLM" start="0x00000000" size="0x00040000" default="1"/>
 
       <device Dname="RteTest_ARMCM4">

--- a/test/projects/RteTestM4/regions_RteTest_ARMCM4_FP_ref.h
+++ b/test/projects/RteTestM4/regions_RteTest_ARMCM4_FP_ref.h
@@ -31,17 +31,17 @@
 //   <o> Base address <0x0-0xFFFFFFFF:8>
 //   <i> Defines base address of memory region.
 //   <i> Default: 0x20000000
-#define __ROM0_BASE 0x20000000
+#define __RAM0_BASE 0x20000000
 //   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
 //   <i> Defines size of memory region.
 //   <i> Default: 0x00020000
-#define __ROM0_SIZE 0x00020000
+#define __RAM0_SIZE 0x00020000
 //   <q>Default region
 //   <i> Enables memory region globally for the application.
-#define __ROM0_DEFAULT 1
+#define __RAM0_DEFAULT 1
 //   <q>No zero initialize
 //   <i> Excludes region from zero initialization.
-#define __ROM0_NOINIT 0
+#define __RAM0_NOINIT 1
 // </h>
 
 // </h>

--- a/test/projects/RteTestM4/regions_RteTest_CM4_board_ref.h
+++ b/test/projects/RteTestM4/regions_RteTest_CM4_board_ref.h
@@ -48,34 +48,34 @@
 //   <o> Base address <0x0-0xFFFFFFFF:8>
 //   <i> Defines base address of memory region.
 //   <i> Default: 0x20000000
-#define __ROM0_BASE 0x20000000
+#define __RAM0_BASE 0x20000000
 //   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
 //   <i> Defines size of memory region.
 //   <i> Default: 0x00020000
-#define __ROM0_SIZE 0x00020000
+#define __RAM0_SIZE 0x00020000
 //   <q>Default region
 //   <i> Enables memory region globally for the application.
-#define __ROM0_DEFAULT 1
+#define __RAM0_DEFAULT 1
 //   <q>No zero initialize
 //   <i> Excludes region from zero initialization.
-#define __ROM0_NOINIT 0
+#define __RAM0_NOINIT 1
 // </h>
 
 // <h> BoardRAM (board memory)
 //   <o> Base address <0x0-0xFFFFFFFF:8>
 //   <i> Defines base address of memory region.
 //   <i> Default: 0x40000000
-#define __ROM1_BASE 0x40000000
+#define __RAM1_BASE 0x40000000
 //   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
 //   <i> Defines size of memory region.
 //   <i> Default: 0x00020000
-#define __ROM1_SIZE 0x00020000
+#define __RAM1_SIZE 0x00020000
 //   <q>Default region
 //   <i> Enables memory region globally for the application.
-#define __ROM1_DEFAULT 1
+#define __RAM1_DEFAULT 1
 //   <q>No zero initialize
 //   <i> Excludes region from zero initialization.
-#define __ROM1_NOINIT 0
+#define __RAM1_NOINIT 0
 // </h>
 
 // </h>


### PR DESCRIPTION
* [csolution] Generate regions_*.h file from memory tags #739 (#500) (#789)
bugfix: use __RAM for rw memory
extend noInit testing

* Bugfix in calculating pack ID in RtePackageInstanceInfo (merge)

