### PR TITLE
Fix IAR Compiler preinclude flag (#536)

### DIFF
--- a/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
@@ -289,7 +289,7 @@ set(CC_DEFINES ${DEFINES})
 cbuild_set_defines(CC CC_DEFINES)
 set(CC_OPTIONS_FLAGS)
 cbuild_set_options_flags(CC "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" CC_OPTIONS_FLAGS)
-set(_PI "-include ")
+set(_PI "--preinclude ")
 
 if((SECURE STREQUAL "Secure") AND 
         (TZ STREQUAL "NO_TZ") AND 


### PR DESCRIPTION
Addresses Open-CMSIS-Pack/devtools#858
Reverts partially Open-CMSIS-Pack/devtools#798
Reapplies fix from Open-CMSIS-Pack/devtools#737