### PR TITLE
[cbuildgen] regression with 1.6.0: gpdsc file ignored #860 (#539)

### DIFF
--- a/tools/buildmgr/cbuild/src/CbuildProject.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildProject.cpp
@@ -228,20 +228,18 @@ RtePackage* CbuildProject::ReadGpdscFile(const string& gpdsc)
     LogMsg("M204", PATH(gpdsc));
     return NULL;
   }
-  RteItemBuilder rteItemBuilder;
+  RteItemBuilder rteItemBuilder(nullptr, PackageState::PS_GENERATED);
   XMLTreeSlim tree(&rteItemBuilder);
   tree.Init();
   bool success = tree.AddFileName(gpdsc, true);
   RtePackage* gpdscPack = rteItemBuilder.GetPack();
-  if(!success || !gpdscPack) {
-      LogMsg("M203", PATH(gpdsc));
-      return nullptr;
-  }
-  if (gpdscPack->Validate()) {
-    gpdscPack->SetPackageState(PackageState::PS_GENERATED);
+
+  if (success && gpdscPack && gpdscPack->Validate()) {
     return gpdscPack;
+  } else if (gpdscPack)
+  if (!success || !gpdscPack) {
+    delete gpdscPack;
   }
   LogMsg("M203", PATH(gpdsc));
-  delete gpdscPack;
   return nullptr;
 } // end of CbuildProject.cpp

--- a/tools/projmgr/src/ProjMgrUtils.cpp
+++ b/tools/projmgr/src/ProjMgrUtils.cpp
@@ -155,17 +155,15 @@ RtePackage* ProjMgrUtils::ReadGpdscFile(const string& gpdsc) {
   fs::path path(gpdsc);
   error_code ec;
   if (fs::exists(path, ec)) {
-    RteItemBuilder rteItemBuilder;
+    RteItemBuilder rteItemBuilder(nullptr, PackageState::PS_GENERATED);
     XMLTreeSlim tree(&rteItemBuilder);
     tree.Init();
     bool success = tree.AddFileName(gpdsc, true);
     RtePackage* gpdscPack = rteItemBuilder.GetPack();
-    if (!success || !gpdscPack) {
-      return nullptr;
-    }
-    if (gpdscPack->Validate()) {
-      gpdscPack->SetPackageState(PackageState::PS_GENERATED);
+    if (success && gpdscPack && gpdscPack->Validate()) {
       return gpdscPack;
+    } else if (gpdscPack) {
+      delete gpdscPack;
     }
   }
   return nullptr;


### PR DESCRIPTION
* [cbuildgen] regression with 1.6.0: gpdsc file ignored #860

Fixed by setting PackageState::PS_GENERATED on RtePackage creation

* [cbuildgen] regression with 1.6.0: gpdsc file ignored #860

Fixed by setting PackageState::PS_GENERATED on RtePackage creation

* Update tools/buildmgr/cbuild/src/CbuildProject.cpp

Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>

* Update tools/buildmgr/cbuild/src/CbuildProject.cpp

Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>

---------

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>
Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>