### PR TITLE
Issue860 1 (#542)

### DIFF
--- a/libs/rtemodel/src/RteCprjProject.cpp
+++ b/libs/rtemodel/src/RteCprjProject.cpp
@@ -218,9 +218,9 @@ void RteCprjProject::ApplySelectedComponentsToCprjFile() {
       item = new RteItem(cprjComponents);
       item->SetTag("component");
       item->AddAttributes(ci->GetAttributes(), true);         // take over attributes
-      if (ci->GetVersionMatchMode(GetActiveTargetName()) != VersionCmp::MatchMode::FIXED_VERSION) {
-        item->RemoveAttribute("Cversion");                    // specify version only if fixed
-        item->RemoveAttribute("condition");                     // remove generally attribute "condition"
+      if (ci->GetVersionMatchMode(GetActiveTargetName()) > VersionCmp::MatchMode::FIXED_VERSION) {
+        item->RemoveAttribute("Cversion");                   // specify version only if fixed
+        item->RemoveAttribute("condition");                  // remove generally attribute "condition"
       }
       // TODO: add build flags to component
       ApplyComponentFilesToCprjFile(ci, item);                // add files to component

--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -349,7 +349,12 @@ RteComponentInstance* RteProject::AddCprjComponent(RteItem* item, RteTarget* tar
   if (version.empty()) {
     info->SetVersionMatchMode(VersionCmp::MatchMode::LATEST_VERSION);
   } else {
-    info->SetVersionMatchMode(VersionCmp::MatchMode::FIXED_VERSION);
+    VersionCmp::MatchMode mode = VersionCmp::MatchModeFromString(item->GetAttribute("versionMatchMode"));
+    if (mode == VersionCmp::MatchMode::ENFORCED_VERSION) {
+      info->SetVersionMatchMode(VersionCmp::MatchMode::ENFORCED_VERSION);
+    } else {
+      info->SetVersionMatchMode(VersionCmp::MatchMode::FIXED_VERSION);
+    }
   }
   if (item->GetAttribute("instances").empty())
     instanceCount = -1;
@@ -697,7 +702,7 @@ bool RteProject::Apply()
         if (ci && c->IsGenerated()) {
           const string& gpdsc = c->GetPackage()->GetPackageFileName();
           RteGpdscInfo* gpdscInfo = GetGpdscInfo(gpdsc);
-          if (!gpdscInfo || !gpdscInfo->IsUsedByTarget(targetName)) {
+          if (!gpdscInfo) {
             ci->SetRemoved(true); // gpdsc is removed => all files are removed
             continue;
           }
@@ -1052,7 +1057,7 @@ RteGpdscInfo* RteProject::AddGpdscInfo(const string& gpdscFile, RtePackage* gpds
 
 RteGpdscInfo* RteProject::AddGpdscInfo(RteComponent* c, RteTarget* target)
 {
-  if (!c || c->IsGenerated()) // it is already generated => gpdsc info is present
+  if (!c)
     return NULL;
 
   RteGenerator* gen = c->GetGenerator();

--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -1551,12 +1551,11 @@ RteComponent* RteTarget::ResolveComponent(RteComponentInstance* ci) const
 
   VersionCmp::MatchMode mode = ci->GetVersionMatchMode(GetName());
   RteComponent* c = NULL;
-  if (mode == VersionCmp::MatchMode::FIXED_VERSION) {
+  if (mode == VersionCmp::MatchMode::ENFORCED_VERSION) {
+    RteComponentList lst;
+    return GetFilteredModel()->FindComponents(*ci, lst);
+  } else if (mode == VersionCmp::MatchMode::FIXED_VERSION) {
     c = GetComponent(ci->GetComponentID(true));
-    if (!c && ci->HasAttribute("condition")) { //  enforced component is specified
-      RteComponentList lst;
-      c = GetFilteredModel()->FindComponents(*ci, lst);
-    }
   } else {
     c = GetLatestComponent(ci);
   }
@@ -1567,7 +1566,7 @@ RteComponent* RteTarget::ResolveComponent(RteComponentInstance* ci) const
     // try to find a component with a bundle
     RteComponentAggregate* a = m_classes->FindComponentAggregate(ci);
     if (a) {
-      if (mode == VersionCmp::MatchMode::FIXED_VERSION)
+      if (mode <= VersionCmp::MatchMode::FIXED_VERSION)
         c = a->GetComponent(ci->GetCvariantName(), ci->GetVersionString());
       else
         c = a->GetLatestComponent(ci->GetCvariantName());

--- a/libs/rteutils/include/VersionCmp.h
+++ b/libs/rteutils/include/VersionCmp.h
@@ -25,10 +25,10 @@ private:
 
 public:
 
-  enum class MatchMode {
-    ANY_VERSION,      // any installed version is accepted
+  enum MatchMode {
+    ENFORCED_VERSION, // strictly fixed version is required (pack and condition)
     FIXED_VERSION,    // fixed version is accepted
-    LATEST_VERSION,   // use the latest version
+    LATEST_VERSION,   // use the latest version (default)
     EXCLUDED_VERSION, // exclude specified version
     HIGHER_OR_EQUAL   // higher or equal version
   };

--- a/libs/rteutils/src/VersionCmp.cpp
+++ b/libs/rteutils/src/VersionCmp.cpp
@@ -193,12 +193,14 @@ VersionCmp::MatchMode VersionCmp::MatchModeFromString(const std::string& mode)
 {
   if (mode == "fixed")
     return MatchMode::FIXED_VERSION;
+  else if (mode == "enforced")
+    return MatchMode::ENFORCED_VERSION;
   else if (mode == "latest")
     return MatchMode::LATEST_VERSION;
   else if (mode == "excluded")
     return MatchMode::EXCLUDED_VERSION;
   // all other cases
-  return MatchMode::ANY_VERSION;
+  return MatchMode::LATEST_VERSION;
 }
 
 VersionCmp::MatchMode VersionCmp::MatchModeFromVersionString(const std::string& version)
@@ -230,8 +232,9 @@ std::string VersionCmp::MatchModeToString(VersionCmp::MatchMode mode)
   case MatchMode::HIGHER_OR_EQUAL:
     s = "latest";
     break;
-  case MatchMode::ANY_VERSION:
-    break; // no string
+  case MatchMode::ENFORCED_VERSION:
+    s = "enforced";
+    break;
   case MatchMode::EXCLUDED_VERSION:
     s = "excluded";
     break;

--- a/libs/rteutils/test/src/VersionCmpTests.cpp
+++ b/libs/rteutils/test/src/VersionCmpTests.cpp
@@ -11,12 +11,12 @@ using namespace std;
 
 TEST(VersionCmpTest, VersionMatchMode) {
 
-  EXPECT_EQ(VersionCmp::MatchModeFromString(""),         VersionCmp::MatchMode::ANY_VERSION);
+  EXPECT_EQ(VersionCmp::MatchModeFromString("enforced"), VersionCmp::MatchMode::ENFORCED_VERSION);
   EXPECT_EQ(VersionCmp::MatchModeFromString("fixed"),    VersionCmp::MatchMode::FIXED_VERSION);
   EXPECT_EQ(VersionCmp::MatchModeFromString("latest"),   VersionCmp::MatchMode::LATEST_VERSION);
   EXPECT_EQ(VersionCmp::MatchModeFromString("excluded"), VersionCmp::MatchMode::EXCLUDED_VERSION);
 
-  EXPECT_EQ(VersionCmp::MatchModeToString(VersionCmp::MatchMode::ANY_VERSION).empty(), true);
+  EXPECT_EQ(VersionCmp::MatchModeToString(VersionCmp::MatchMode::ENFORCED_VERSION), "enforced");
   EXPECT_EQ(VersionCmp::MatchModeToString(VersionCmp::MatchMode::FIXED_VERSION),"fixed");
   EXPECT_EQ(VersionCmp::MatchModeToString(VersionCmp::MatchMode::LATEST_VERSION), "latest");
   EXPECT_EQ(VersionCmp::MatchModeToString(VersionCmp::MatchMode::EXCLUDED_VERSION), "excluded");

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
@@ -6,3 +6,4 @@ echo %4
 
 mkdir %1
 copy "%3\Templates\RteTest.gpdsc.template" "%1\RteTest.gpdsc"
+copy "%3\Templates\RteTest_Generated_Component.c.template" "%1\RteTest_Generated_Component.c"

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -6,3 +6,4 @@ echo $4
 
 mkdir $1
 cp "$3/Templates/RteTest.gpdsc.template" "$1/RteTest.gpdsc"
+cp "$3/Templates/RteTest_Generated_Component.c.template" "$1/RteTest_Generated_Component.c"

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
@@ -26,9 +26,9 @@
   </conditions>
   <components>
     <component generator="RteTestGeneratorIdentifier" Cvendor="ARM" Cclass="Device" Cgroup="RteTest Generated Component" Csub="RteTest" Cversion="1.1.0" condition="RteTest">
-      <description>Configuration via STM32CubeMX</description>
+      <description>Configuration via STM32CubeMX, gpdsc component</description>
       <RTE_Components_h>
-        #define RTE_TEST_GENERATOR
+        #define RTE_TEST_GENERATOR_FROM_GPDSC_TEMPLATE
       </RTE_Components_h>
     </component>
   </components>

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Templates/RteTest_Generated_Component.c.template
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Templates/RteTest_Generated_Component.c.template
@@ -1,0 +1,2 @@
+#include RTE_Components.h
+// dummy RteTest_Generated_Component.c file from template

--- a/test/projects/RteTestM4/RteTestM4_Board.cprj
+++ b/test/projects/RteTestM4/RteTestM4_Board.cprj
@@ -59,7 +59,7 @@
       <file attr="config" category="header" name="Include/Config/ConfigInclude.h" path="Include" version="0.0.2"/>
     </component>
     <component Cclass="RteTest" Cgroup="LocalFile" Cvendor="ARM"/>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev2" Cversion="2.2.2" condition="BoardTest2"/>
+    <component Cclass="Board" Cgroup="Test" Csub="Rev2" Cversion="2.2.2" condition="BoardTest2" versionMatchMode="enforced"/>
   </components>
 
   <files>

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1243,6 +1243,12 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
     // Init matched component instance
     RteComponentInstance* matchedComponentInstance = new RteComponentInstance(matchedComponent);
     matchedComponentInstance->InitInstance(matchedComponent);
+    if (!item.condition.empty()) {
+      auto ti = matchedComponentInstance->EnsureTargetInfo(context.rteActiveTarget->GetName());
+      ti->SetVersionMatchMode(VersionCmp::MatchMode::ENFORCED_VERSION);
+      matchedComponentInstance->AddAttribute("versionMatchMode",
+        VersionCmp::MatchModeToString(VersionCmp::MatchMode::ENFORCED_VERSION));
+    }
 
     // Set layer's rtePath attribute
     if (!layer.empty() && context.csolution->directories.rte.empty()) {
@@ -1299,13 +1305,14 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
 
 RteComponent* ProjMgrWorker::ProcessComponent(ContextItem& context, ComponentItem& item, RteComponentMap& componentMap)
 {
-
   if (!item.condition.empty()) {
     RteComponentInstance ci(nullptr);
     ci.SetTag("component");
 
     ci.SetAttributes(ProjMgrUtils::ComponentAttributesFromId(item.component));
     ci.AddAttribute("condition", item.condition);
+    auto ti = ci.EnsureTargetInfo(context.rteActiveTarget->GetName());
+    ti->SetVersionMatchMode(VersionCmp::MatchMode::ENFORCED_VERSION);
     string packId = item.fromPack;
     RteUtils::ReplaceAll(packId,"::", ".");
     RteUtils::ReplaceAll(packId, "@", ".");

--- a/tools/projmgr/test/data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
+++ b/tools/projmgr/test/data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
@@ -26,10 +26,13 @@
   </conditions>
   <components>
     <component generator="RteTestGeneratorIdentifier" Cvendor="ARM" Cclass="Device" Cgroup="RteTest Generated Component" Csub="RteTest" Cversion="1.1.0" condition="RteTest">
-      <description>Configuration via STM32CubeMX</description>
+      <description>Configuration via STM32CubeMX test data</description>
       <RTE_Components_h>
-        #define RTE_TEST_GENERATOR
+        #define RTE_TEST_GENERATOR_FROM_GPDSC_PRE_CHECK
       </RTE_Components_h>
+      <files>
+        <file name="RteTest_Generated_Component.c" category="sourceC"/>
+      </files>
     </component>
   </components>
 </package>

--- a/tools/projmgr/test/data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest_Generated_Component.c
+++ b/tools/projmgr/test/data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest_Generated_Component.c
@@ -1,0 +1,2 @@
+#include RTE_Components.h
+// dummy RteTest_Generated_Component.c file

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -27,6 +27,9 @@ build:
       condition: RteDevice
       from-pack: ARM::RteTestGenerator@0.1.0
       selected-by: Device:RteTest Generated Component:RteTest
+      files:
+        - file: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest_Generated_Component.c
+          category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
     - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1294,6 +1294,13 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_Generator) {
   argv[5] = (char*)testoutput_folder.c_str();
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
+  string RTE_Components_h = testinput_folder + "/TestGenerator/RTE/_Debug_CM0/RTE_Components.h";
+
+  EXPECT_TRUE(RteFsUtils::Exists(RTE_Components_h));
+  string buf;
+  EXPECT_TRUE(RteFsUtils::ReadFile(RTE_Components_h, buf));
+  EXPECT_TRUE(buf.find("#define RTE_TEST_GENERATOR_FROM_GPDSC_PRE_CHECK") != string::npos);
+
   // Check generated CPRJs
  ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test-gpdsc.Debug+CM0.cprj",
     testinput_folder + "/TestGenerator/ref/test-gpdsc.Debug+CM0.cprj");


### PR DESCRIPTION
* [cbuildgen] regression with 1.6.0: gpdsc file ignored #860

set PackageState::PS_GENERATED on RtePackage creation
correction to fix "enforced component" misbehavior
tests added

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>