### PR TITLE
Restore VersionCmp::MatchMode::ANY_VERSION since it is used in pack Installer (#553)

### DIFF
--- a/libs/rteutils/include/VersionCmp.h
+++ b/libs/rteutils/include/VersionCmp.h
@@ -29,6 +29,7 @@ public:
     ENFORCED_VERSION, // strictly fixed version is required (pack and condition)
     FIXED_VERSION,    // fixed version is accepted
     LATEST_VERSION,   // use the latest version (default)
+    ANY_VERSION,      // any version satisfies
     EXCLUDED_VERSION, // exclude specified version
     HIGHER_OR_EQUAL   // higher or equal version
   };


### PR DESCRIPTION
Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>