### PR TITLE
Ignore empty CMSIS_COMPILER_ROOT

### DIFF
--- a/tools/projmgr/src/ProjMgrYamlEmitter.cpp
+++ b/tools/projmgr/src/ProjMgrYamlEmitter.cpp
@@ -428,7 +428,7 @@ const string ProjMgrYamlCbuild::FormatPath(const string& original, const string&
     string compilerRoot;
     ProjMgrUtils::GetCompilerRoot(compilerRoot);
     index = path.find(compilerRoot);
-    if (index != string::npos) {
+    if (!compilerRoot.empty() && index != string::npos) {
       path.replace(index, compilerRoot.length(), "${CMSIS_COMPILER_ROOT}");
     } else {
       path = fs::relative(path, directory, ec).generic_string();


### PR DESCRIPTION
When `CMSIS_COMPILER_ROOT` isn't given, `ProjMgrYamlCbuild::FormatPath()` incorrectly inserted `"${CMSIS_COMPILER_ROOT}"` in front of all paths in the `*.cbuild.yml` file (unless located below `${CMSIS_PACK_ROOT}` instead of creating relative paths.

Contributed by STMicroelectronics

Signed-off-by: Erik MÅLLBERG <erik.mallberg@st.com>