### PR TITLE
[projmgr] Format relative paths in `misc` options

### DIFF
--- a/libs/rtefsutils/include/RteFsUtils.h
+++ b/libs/rtefsutils/include/RteFsUtils.h
@@ -222,6 +222,16 @@ public:
    * @return string containing the parent path
   */
   static std::string ParentPath(const std::string& path);
+
+  /**
+   * @brief determine relative path in respect to base directory
+   * @param path path to be processed
+   * @param base base directory
+   * @param withHeadingDot true if returned value should contain heading dot '.'
+   * @return relative path in respect to base directory
+  */
+  static std::string RelativePath(const std::string& path, const std::string& base, bool withHeadingDot = false);
+
   /**
    * @brief determine absolute path of the current working directory
    * @param withTrailingSlash true if returned value should contain trailing slash '/'

--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -562,6 +562,17 @@ string RteFsUtils::ParentPath(const string& path) {
   return fs::path(path).parent_path().generic_string();
 }
 
+string RteFsUtils::RelativePath(const string& path, const string& base, bool withHeadingDot) {
+  error_code ec;
+  string relativePath = fs::relative(path, base, ec).generic_string();
+  if (withHeadingDot) {
+    if (!relativePath.empty() && relativePath.find("./") != 0) {
+      relativePath.insert(0, "./");
+    }
+  }
+  return relativePath;
+}
+
 string RteFsUtils::GetCurrentFolder(bool withTrailingSlash) {
   error_code ec;
   string f = fs::current_path(ec).generic_string();

--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -563,6 +563,9 @@ string RteFsUtils::ParentPath(const string& path) {
 }
 
 string RteFsUtils::RelativePath(const string& path, const string& base, bool withHeadingDot) {
+  if (path.empty() || base.empty()) {
+    return "";
+  }
   error_code ec;
   string relativePath = fs::relative(path, base, ec).generic_string();
   if (withHeadingDot) {

--- a/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
+++ b/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
@@ -905,6 +905,24 @@ TEST_F(RteFsUtilsTest, ParentPath) {
   EXPECT_EQ(filePath, dirnameSubdir);
 }
 
+TEST_F(RteFsUtilsTest, RelativePath) {
+  string relPath;
+  string absSubdir = RteFsUtils::AbsolutePath(dirnameSubdir).generic_string();
+  string absBase = RteFsUtils::AbsolutePath(dirnameBase).generic_string();
+
+  relPath = RteFsUtils::RelativePath(absSubdir, absBase);
+  EXPECT_EQ(relPath, "dir/subdir");
+
+  relPath = RteFsUtils::RelativePath(absSubdir, absBase, true);
+  EXPECT_EQ(relPath, "./dir/subdir");
+
+  relPath = RteFsUtils::RelativePath(absSubdir, "");
+  EXPECT_EQ(relPath, "");
+
+  relPath = RteFsUtils::RelativePath("", absBase);
+  EXPECT_EQ(relPath, "");
+}
+
 TEST_F(RteFsUtilsTest, CreateDirectories) {
   error_code ec;
   bool result;

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -562,9 +562,9 @@ protected:
   bool ProcessComponentFiles(ContextItem& context);
   bool ProcessGroups(ContextItem& context);
   bool ProcessSequencesRelatives(ContextItem& context);
-  bool ProcessSequencesRelatives(ContextItem& context, std::vector<std::string>& src, const std::string& ref = std::string());
+  bool ProcessSequencesRelatives(ContextItem& context, std::vector<std::string>& src, const std::string& ref = std::string(), bool withHeadingDot = false);
   bool ProcessSequencesRelatives(ContextItem& context, BuildType& build, const std::string& ref = std::string());
-  bool ProcessSequenceRelative(ContextItem& context, std::string& item, const std::string& ref = std::string());
+  bool ProcessSequenceRelative(ContextItem& context, std::string& item, const std::string& ref = std::string(), bool withHeadingDot = false);
   bool ProcessOutputFilenames(ContextItem& context);
   bool ProcessLinkerOptions(ContextItem& context);
   bool ProcessLinkerOptions(ContextItem& context, LinkerItem& linker, StringCollection& linkerScriptFile, StringCollection& linkerRegionsFile, const std::string& ref);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2069,7 +2069,7 @@ bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem& context) {
   return true;
 }
 
-bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, const string& ref) {
+bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, const string& ref, bool withHeadingDot) {
   size_t offset = 0;
   bool pathReplace = false;
   // expand variables (static access sequences)
@@ -2115,8 +2115,8 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
             }
           }
           const string& depContextOutDir = depContext.directories.cprj + "/" + depContext.directories.outdir;
-          const string& relOutDir = fs::relative(depContextOutDir, context.directories.cprj, ec).generic_string();
-          const string& relSrcDir = fs::relative(depContext.cproject->directory, context.directories.cprj, ec).generic_string();
+          const string& relOutDir = RteFsUtils::RelativePath(depContextOutDir, context.directories.cprj, withHeadingDot);
+          const string& relSrcDir = RteFsUtils::RelativePath(depContext.cproject->directory, context.directories.cprj, withHeadingDot);
           if (regex_match(sequence, regex("^OutDir\\(.*"))) {
             regEx = regex("\\$OutDir\\(.*\\)\\$");
             replacement = relOutDir;
@@ -2971,9 +2971,9 @@ std::string ProjMgrWorker::GetBoardInfoString(const std::string& vendor,
     name + (revision.empty() ? "" : ":" + revision);
 }
 
-bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem& context, vector<string>& src, const string& ref) {
+bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem& context, vector<string>& src, const string& ref, bool withHeadingDot) {
   for (auto& item : src) {
-    if (!ProcessSequenceRelative(context, item, ref)) {
+    if (!ProcessSequenceRelative(context, item, ref, withHeadingDot)) {
       return false;
     }
   }
@@ -2988,15 +2988,15 @@ bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem& context, BuildType& b
     return false;
   }
   for (auto& misc : build.misc) {
-    if (!ProcessSequencesRelatives(context, misc.as)     ||
-        !ProcessSequencesRelatives(context, misc.c)      ||
-        !ProcessSequencesRelatives(context, misc.cpp)    ||
-        !ProcessSequencesRelatives(context, misc.c_cpp)  ||
-        !ProcessSequencesRelatives(context, misc.lib)    ||
-        !ProcessSequencesRelatives(context, misc.library)||
-        !ProcessSequencesRelatives(context, misc.link)   ||
-        !ProcessSequencesRelatives(context, misc.link_c) ||
-        !ProcessSequencesRelatives(context, misc.link_cpp)) {
+    if (!ProcessSequencesRelatives(context, misc.as,       "", true) ||
+        !ProcessSequencesRelatives(context, misc.c,        "", true) ||
+        !ProcessSequencesRelatives(context, misc.cpp,      "", true) ||
+        !ProcessSequencesRelatives(context, misc.c_cpp,    "", true) ||
+        !ProcessSequencesRelatives(context, misc.lib,      "", true) ||
+        !ProcessSequencesRelatives(context, misc.library,  "", true) ||
+        !ProcessSequencesRelatives(context, misc.link,     "", true) ||
+        !ProcessSequencesRelatives(context, misc.link_c,   "", true) ||
+        !ProcessSequencesRelatives(context, misc.link_cpp, "", true)) {
       return false;
     }
   }

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM0.cprj
@@ -18,7 +18,7 @@
     <output intdir="tmp/test-access-sequences1/CM0/Release" name="test-access-sequences1" outdir="out/test-access-sequences1/CM0/Release" rtedir="../data/TestAccessSequences/RTE" type="exe"/>
     <cflags add="-O3 -C-CPP-RteTest_ARMCM0" compiler="AC6"/>
     <cxxflags add="-O3 -C-CPP-RteTest_ARMCM0" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
+    <ldflags add="--list=./out/test-access-sequences1/CM0/Release/test-access-sequences1.map" compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
     <defines>DEF1-PROJ1-out/test-access-sequences2/CM0/Debug/test-access-sequences2;DEF2-PROJ1-out/test-access-sequences2/CM3/Release/test-access-sequences2;DEF3-PROJ1-out/test-access-sequences2/CM0/Release/test-access-sequences2;DEF4-PROJ1-out/test-access-sequences2/CM0/Debug;DEF5-PROJ1-../data/TestAccessSequences;DEF-CM0-RteTest_ARMCM0-</defines>
     <includes>../data/TestAccessSequences/path/CM0/RteTest_ARMCM0</includes>
   </target>

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences1.Release+CM3.cprj
@@ -18,7 +18,7 @@
     <output intdir="tmp/test-access-sequences1/CM3/Release" name="test-access-sequences1" outdir="out/test-access-sequences1/CM3/Release" rtedir="../data/TestAccessSequences/RTE" type="exe"/>
     <cflags add="-O3 -C-CPP-RteTest_ARMCM3" compiler="AC6"/>
     <cxxflags add="-O3 -C-CPP-RteTest_ARMCM3" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h"/>
+    <ldflags add="--list=./out/test-access-sequences1/CM3/Release/test-access-sequences1.map" compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h"/>
     <defines>DEF1-PROJ1-out/test-access-sequences2/CM3/Debug/test-access-sequences2;DEF2-PROJ1-out/test-access-sequences2/CM3/Release/test-access-sequences2;DEF3-PROJ1-out/test-access-sequences2/CM0/Release/test-access-sequences2;DEF4-PROJ1-out/test-access-sequences2/CM3/Debug;DEF5-PROJ1-../data/TestAccessSequences;DEF-CM3-RteTest_ARMCM3</defines>
     <includes>../data/TestAccessSequences/path/CM3/RteTest_ARMCM3</includes>
   </target>

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM0.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM0.cprj
@@ -18,7 +18,7 @@
     <output intdir="tmp/test-access-sequences2/CM0/Release" name="test-access-sequences2" outdir="out/test-access-sequences2/CM0/Release" rtedir="../data/TestAccessSequences/RTE" type="exe"/>
     <cflags add="PROJ2-D(RteTest_ARMCM0)-B() -O3 -C-CPP-RteTest_ARMCM0" compiler="AC6"/>
     <cxxflags add="PROJ2-D(RteTest_ARMCM0)-B() -O3 -C-CPP-RteTest_ARMCM0" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
+    <ldflags add="--list=./out/test-access-sequences2/CM0/Release/test-access-sequences2.map" compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
     <defines>out/test-access-sequences1/CM0/Release/test-access-sequences1;DEF-CM0-RteTest_ARMCM0-</defines>
     <includes>out/test-access-sequences1/CM0/Release/test-access-sequences1;../data/TestAccessSequences/path/CM0/RteTest_ARMCM0</includes>
   </target>

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM3.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences2.Release+CM3.cprj
@@ -18,7 +18,7 @@
     <output intdir="tmp/test-access-sequences2/CM3/Release" name="test-access-sequences2" outdir="out/test-access-sequences2/CM3/Release" rtedir="../data/TestAccessSequences/RTE" type="exe"/>
     <cflags add="PROJ2-D(RteTest_ARMCM3)-B() -O3 -C-CPP-RteTest_ARMCM3" compiler="AC6"/>
     <cxxflags add="PROJ2-D(RteTest_ARMCM3)-B() -O3 -C-CPP-RteTest_ARMCM3" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h"/>
+    <ldflags add="--list=./out/test-access-sequences2/CM3/Release/test-access-sequences2.map" compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h"/>
     <defines>out/test-access-sequences1/CM3/Release/test-access-sequences1;DEF-CM3-RteTest_ARMCM3</defines>
     <includes>out/test-access-sequences1/CM3/Release/test-access-sequences1;../data/TestAccessSequences/path/CM3/RteTest_ARMCM3</includes>
   </target>

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences.csolution.yml
@@ -33,6 +33,8 @@ solution:
       misc:
         - C-CPP:
             - -O3
+          Link:
+            - --list=$OutDir()$/$Project$.map
   
   projects:
     - project: ./test-access-sequences1.cproject.yml


### PR DESCRIPTION
Relates to https://github.com/Open-CMSIS-Pack/devtools/issues/841#issuecomment-1538663259

For access sequences resulting in relative paths inside `misc` options, add the heading dot `./` to evidence it is a relative path and not other miscellaneous values so the build manager can process it correctly.