### PR TITLE
[projmgr] Update access sequences

### DIFF
--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -569,7 +569,7 @@ string RteFsUtils::RelativePath(const string& path, const string& base, bool wit
   error_code ec;
   string relativePath = fs::relative(path, base, ec).generic_string();
   if (withHeadingDot) {
-    if (!relativePath.empty() && relativePath.find("./") != 0) {
+    if (!relativePath.empty() && relativePath.find("./") != 0 && relativePath.find("../") != 0) {
       relativePath.insert(0, "./");
     }
   }

--- a/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
+++ b/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
@@ -22,6 +22,7 @@ protected:
 const string dirnameBase = "RteFsUtilsTest";
 const string dirnameDir = dirnameBase + "/dir";
 const string dirnameSubdir = dirnameBase + "/dir/subdir";
+const string dirnameSubdir2 = dirnameBase + "/dir/subdir2";
 const string dirnameSubdirBackslash = RteUtils::SlashesToOsSlashes(dirnameBase + "\\dir\\subdir");
 const string dirnameSubdirMixed = RteUtils::SlashesToOsSlashes(dirnameBase + "/dir\\subdir");
 const string dirnameSubdirWithTrailing = dirnameBase + "/dir/subdir/";
@@ -908,6 +909,7 @@ TEST_F(RteFsUtilsTest, ParentPath) {
 TEST_F(RteFsUtilsTest, RelativePath) {
   string relPath;
   string absSubdir = RteFsUtils::AbsolutePath(dirnameSubdir).generic_string();
+  string absSubdir2 = RteFsUtils::AbsolutePath(dirnameSubdir2).generic_string();
   string absBase = RteFsUtils::AbsolutePath(dirnameBase).generic_string();
 
   relPath = RteFsUtils::RelativePath(absSubdir, absBase);
@@ -915,6 +917,9 @@ TEST_F(RteFsUtilsTest, RelativePath) {
 
   relPath = RteFsUtils::RelativePath(absSubdir, absBase, true);
   EXPECT_EQ(relPath, "./dir/subdir");
+
+  relPath = RteFsUtils::RelativePath(absSubdir, absSubdir2, true);
+  EXPECT_EQ(relPath, "../subdir");
 
   relPath = RteFsUtils::RelativePath(absSubdir, "");
   EXPECT_EQ(relPath, "");

--- a/tools/projmgr/include/ProjMgrUtils.h
+++ b/tools/projmgr/include/ProjMgrUtils.h
@@ -100,6 +100,7 @@ public:
   static constexpr const char* SUFFIX_PACK_VENDOR = "::";
   static constexpr const char* PREFIX_PACK_VERSION = "@";
 
+  static constexpr const char* AS_SOLUTION = "Solution";
   static constexpr const char* AS_PROJECT = "Project";
   static constexpr const char* AS_COMPILER = "Compiler";
   static constexpr const char* AS_BUILD_TYPE = "BuildType";
@@ -107,6 +108,15 @@ public:
   static constexpr const char* AS_DNAME = "Dname";
   static constexpr const char* AS_PNAME = "Pname";
   static constexpr const char* AS_BNAME = "Bname";
+
+  static constexpr const char* AS_SOLUTION_DIR = "SolutionDir";
+  static constexpr const char* AS_PROJECT_DIR = "ProjectDir";
+  static constexpr const char* AS_OUT_DIR = "OutDir";
+  static constexpr const char* AS_BIN = "bin";
+  static constexpr const char* AS_ELF = "elf";
+  static constexpr const char* AS_HEX = "hex";
+  static constexpr const char* AS_LIB = "lib";
+  static constexpr const char* AS_CMSE = "cmse-lib";
 
   /**
    * @brief class constructor

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -619,6 +619,8 @@ protected:
   void SetDefaultLinkerScript(ContextItem& context);
   void CheckAndGenerateRegionsHeader(ContextItem& context);
   bool GenerateRegionsHeader(ContextItem& context, std::string& generatedRegionsFile);
+  void UpdatePartialReferencedContext(ContextItem& context, std::string& contextName);
+  void ExpandAccessSequence(const ContextItem& context, const ContextItem& refContext, const std::string& sequence, std::string& item, bool withHeadingDot);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2196,7 +2196,7 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
       smatch asMatches;
       if (regex_match(sequence, asMatches, accessSequencesRegEx) && asMatches.size() == 3) {
         // get capture groups, see regex accessSequencesRegEx
-        const string sequence = asMatches[1];
+        const string sequenceName = asMatches[1];
         string contextName = asMatches[2];
         // access sequences with 'context' argument lead to path replacement
         pathReplace = true;
@@ -2213,10 +2213,10 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
             }
           }
           // expand access sequence
-          ExpandAccessSequence(context, refContext, sequence, item, withHeadingDot);
+          ExpandAccessSequence(context, refContext, sequenceName, item, withHeadingDot);
         } else {
           // full or partial context name cannot be resolved to a valid context
-          ProjMgrLogger::Error("context '" + contextName + "' referenced by access sequence '" + sequence + "' does not exist");
+          ProjMgrLogger::Error("context '" + contextName + "' referenced by access sequence '" + sequenceName + "' does not exist");
           return false;
         }
       } else {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -17,6 +17,18 @@
 
 using namespace std;
 
+static const regex accessSequencesRegEx = regex(string("^(") +
+  ProjMgrUtils::AS_SOLUTION_DIR + "|" +
+  ProjMgrUtils::AS_PROJECT_DIR  + "|" +
+  ProjMgrUtils::AS_OUT_DIR      + "|" +
+  ProjMgrUtils::AS_BIN          + "|" +
+  ProjMgrUtils::AS_ELF          + "|" +
+  ProjMgrUtils::AS_HEX          + "|" +
+  ProjMgrUtils::AS_LIB          + "|" +
+  ProjMgrUtils::AS_CMSE         + ")" +
+  "\\((.*)\\)$"
+);
+
 ProjMgrWorker::ProjMgrWorker(void) {
   m_loadPacksPolicy = LoadPacksPolicy::DEFAULT;
 }
@@ -129,6 +141,7 @@ bool ProjMgrWorker::AddContext(ProjMgrParser& parser, ContextDesc& descriptor, c
     context.directories.cprj = fs::weakly_canonical(RteFsUtils::AbsolutePath(context.directories.cprj), ec).generic_string();
 
     // context variables
+    context.variables[ProjMgrUtils::AS_SOLUTION] = context.csolution->name;
     context.variables[ProjMgrUtils::AS_PROJECT] = context.cproject->name;
     context.variables[ProjMgrUtils::AS_BUILD_TYPE] = context.type.build;
     context.variables[ProjMgrUtils::AS_TARGET_TYPE] = context.type.target;
@@ -2115,6 +2128,58 @@ bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem& context) {
   return true;
 }
 
+void ProjMgrWorker::UpdatePartialReferencedContext(ContextItem& context, string& contextName) {
+  if (contextName.find('+') == string::npos) {
+    if (!context.type.target.empty()) {
+      contextName.append('+' + context.type.target);
+    }
+  }
+  if (contextName.find('.') == string::npos) {
+    if (!context.type.build.empty()) {
+      const size_t targetDelim = contextName.find('+');
+      contextName.insert(targetDelim == string::npos ? contextName.length() : targetDelim, '.' + context.type.build);
+    }
+  }
+  if (contextName.empty() || (contextName.front() == '.') || (contextName.front() == '+')) {
+    contextName.insert(0, context.cproject->name);
+  }
+}
+
+void ProjMgrWorker::ExpandAccessSequence(const ContextItem & context, const ContextItem & refContext, const string & sequence, string & item, bool withHeadingDot) {
+  const string& refContextOutDir = refContext.directories.cprj + "/" + refContext.directories.outdir;
+  const string& relOutDir = RteFsUtils::RelativePath(refContextOutDir, context.directories.cprj, withHeadingDot);
+  string regExStr = "\\$";
+  string replacement;
+  if (sequence == ProjMgrUtils::AS_SOLUTION_DIR) {
+    regExStr += ProjMgrUtils::AS_SOLUTION_DIR;
+    replacement = RteFsUtils::RelativePath(refContext.csolution->directory, context.directories.cprj, withHeadingDot);
+  } else if (sequence == ProjMgrUtils::AS_PROJECT_DIR) {
+    regExStr += ProjMgrUtils::AS_PROJECT_DIR;
+    replacement = RteFsUtils::RelativePath(refContext.cproject->directory, context.directories.cprj, withHeadingDot);
+  } else if (sequence == ProjMgrUtils::AS_OUT_DIR) {
+    regExStr += ProjMgrUtils::AS_OUT_DIR;
+    replacement = relOutDir;
+  // TODO: the access sequences below must be refined after #895 (Rework `output` and `output-type` node)
+  } else if (sequence == ProjMgrUtils::AS_ELF) {
+    regExStr += ProjMgrUtils::AS_ELF;
+    replacement = relOutDir + "/" + (refContext.outputFiles.find("elf") != refContext.outputFiles.end() ? refContext.outputFiles.at("elf") : refContext.cproject->name);
+  } else if (sequence == ProjMgrUtils::AS_BIN) {
+    regExStr += ProjMgrUtils::AS_BIN;
+    replacement = relOutDir + "/" + refContext.cproject->name + ".bin";
+  } else if (sequence == ProjMgrUtils::AS_HEX) {
+    regExStr += ProjMgrUtils::AS_HEX;
+    replacement = relOutDir + "/" + refContext.cproject->name + ".hex";
+  } else if (sequence == ProjMgrUtils::AS_LIB) {
+    regExStr += ProjMgrUtils::AS_LIB;
+    replacement = relOutDir + "/" + refContext.cproject->name + ".lib";
+  } else if (sequence == ProjMgrUtils::AS_CMSE) {
+    regExStr += ProjMgrUtils::AS_CMSE;
+    replacement = relOutDir + "/" + refContext.cproject->name + "_CMSE_Lib.o";
+  }
+  regex regEx = regex(regExStr + "\\(.*\\)\\$");
+  item = regex_replace(item, regEx, replacement);
+}
+
 bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, const string& ref, bool withHeadingDot) {
   size_t offset = 0;
   bool pathReplace = false;
@@ -2128,66 +2193,37 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
       return false;
     }
     if (offset != string::npos) {
-      string replacement;
-      regex regEx;
-      if (regex_match(sequence, regex("(Output|OutDir|Source)\\(.*"))) {
-        // Output, OutDir and Source access sequences lead to path replacement
+      smatch asMatches;
+      if (regex_match(sequence, asMatches, accessSequencesRegEx) && asMatches.size() == 3) {
+        // get capture groups, see regex accessSequencesRegEx
+        const string sequence = asMatches[1];
+        string contextName = asMatches[2];
+        // access sequences with 'context' argument lead to path replacement
         pathReplace = true;
-        string contextName;
-        size_t offsetContext = 0;
-        if (!GetAccessSequence(offsetContext, sequence, contextName, '(', ')')) {
-          return false;
-        }
-        if (contextName.find('+') == string::npos) {
-          if (!context.type.target.empty()) {
-            contextName.append('+' + context.type.target);
-          }
-        }
-        if (contextName.find('.') == string::npos) {
-          if (!context.type.build.empty()) {
-            const size_t targetDelim = contextName.find('+');
-            contextName.insert(targetDelim == string::npos ? contextName.length() : targetDelim, '.' + context.type.build);
-          }
-        }
-        if (contextName.empty() || (contextName.front() == '.') || (contextName.front() == '+')) {
-           contextName.insert(0, context.cproject->name);
-        }
+        // update referenced context name when it's partially specified
+        UpdatePartialReferencedContext(context, contextName);
+        // find referenced context
         if (m_contexts.find(contextName) != m_contexts.end()) {
           error_code ec;
-          auto& depContext = m_contexts.at(contextName);
-          if (!depContext.precedences) {
-            if (!ProcessPrecedences(depContext)) {
+          auto& refContext = m_contexts.at(contextName);
+          // process referenced context precedences if needed
+          if (!refContext.precedences) {
+            if (!ProcessPrecedences(refContext)) {
               return false;
             }
           }
-          const string& depContextOutDir = depContext.directories.cprj + "/" + depContext.directories.outdir;
-          const string& relOutDir = RteFsUtils::RelativePath(depContextOutDir, context.directories.cprj, withHeadingDot);
-          const string& relSrcDir = RteFsUtils::RelativePath(depContext.cproject->directory, context.directories.cprj, withHeadingDot);
-          if (regex_match(sequence, regex("^OutDir\\(.*"))) {
-            regEx = regex("\\$OutDir\\(.*\\)\\$");
-            replacement = relOutDir;
-          }
-          else if (regex_match(sequence, regex("^Output\\(.*"))) {
-            regEx = regex("\\$Output\\(.*\\)\\$");
-            replacement = relOutDir + "/" + (depContext.outputFiles.find("elf") != depContext.outputFiles.end() ? depContext.outputFiles.at("elf") : depContext.cproject->name);
-          }
-          else if (regex_match(sequence, regex("^Source\\(.*"))) {
-            regEx = regex("\\$Source\\(.*\\)\\$");
-            replacement = relSrcDir;
-          }
-        }
-        else {
+          // expand access sequence
+          ExpandAccessSequence(context, refContext, sequence, item, withHeadingDot);
+        } else {
           // full or partial context name cannot be resolved to a valid context
           ProjMgrLogger::Error("context '" + contextName + "' referenced by access sequence '" + sequence + "' does not exist");
           return false;
         }
-      }
-      else {
+      } else {
         // access sequence is unknown
         ProjMgrLogger::Warn("unknown access sequence: '" + sequence + "'");
         continue;
       }
-      item = regex_replace(item, regEx, replacement);
     }
   }
   if (!pathReplace && !ref.empty()) {
@@ -2195,7 +2231,7 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
     error_code ec;
     if (!fs::equivalent(context.directories.cprj, ref, ec)) {
       const string& absPath = fs::weakly_canonical(fs::path(item).is_relative() ? ref + "/" + item : item, ec).generic_string();
-      item = fs::relative(absPath, context.directories.cprj, ec).generic_string();
+      item = RteFsUtils::RelativePath(absPath, context.directories.cprj, withHeadingDot);
     }
   }
   return true;
@@ -2259,16 +2295,18 @@ bool ProjMgrWorker::AddFile(const FileNode& src, vector<FileNode>& dst, ContextI
       }
     }
 
-    // Set file category
+    // Get file node
     FileNode srcNode = src;
-    if (srcNode.category.empty()) {
-      srcNode.category = ProjMgrUtils::GetCategory(srcNode.file);
-    }
 
     // Replace sequences and/or adjust file relative paths
     ProcessSequenceRelative(context, srcNode.file, root);
     ProcessSequencesRelatives(context, srcNode.build, root);
     UpdateMisc(srcNode.build.misc, context.toolchain.name);
+
+    // Set file category
+    if (srcNode.category.empty()) {
+      srcNode.category = ProjMgrUtils::GetCategory(srcNode.file);
+    }
 
     dst.push_back(srcNode);
 

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release.cprj
@@ -16,6 +16,7 @@
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Non-secure" Dvendor="ARM:82" Pname="cm0_core0">
     <output intdir="tmp/test-access-sequences3/Release" name="test-access-sequences3" outdir="out/test-access-sequences3/Release" rtedir="../data/TestAccessSequences/RTE" type="exe"/>
+    <asflags add="-DEF_SOLUTION=../data/TestAccessSequences/test-access-sequences2" compiler="AC6"/>
     <cflags add="-O3" compiler="AC6"/>
     <cxxflags add="-O3" compiler="AC6"/>
     <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0_Dual_cm0_core0/regions_RteTest_ARMCM0_Dual_cm0_core0.h"/>
@@ -29,6 +30,11 @@
   <files>
     <group name="CMSE">
       <file category="object" name="out/test-access-sequences3/Release/test-access-sequences3_CMSE_Lib.o"/>
+    </group>
+    <group name="Artifacts">
+      <file category="other" name="out/test-access-sequences3/Release/test-access-sequences3.bin"/>
+      <file category="other" name="out/test-access-sequences3/Release/test-access-sequences3.hex"/>
+      <file category="library" name="out/test-access-sequences3/Release/test-access-sequences3.lib"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences1.cproject.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences1.cproject.yml
@@ -2,14 +2,14 @@
 
 project:
   define:
-    - DEF1-PROJ1-$Output(test-access-sequences2.Debug)$
-    - DEF2-PROJ1-$Output(test-access-sequences2+CM3)$
-    - DEF3-PROJ1-$Output(test-access-sequences2.Release+CM0)$
+    - DEF1-PROJ1-$elf(test-access-sequences2.Debug)$
+    - DEF2-PROJ1-$elf(test-access-sequences2+CM3)$
+    - DEF3-PROJ1-$elf(test-access-sequences2.Release+CM0)$
     - DEF4-PROJ1-$OutDir(test-access-sequences2.Debug)$
-    - DEF5-PROJ1-$Source(test-access-sequences2.Debug)$
+    - DEF5-PROJ1-$ProjectDir(test-access-sequences2.Debug)$
   components:
     - component: CORE
   groups:
     - group: CMSE
       files: 
-        - file: $Output(test-access-sequences2)$_CMSE_Lib.o
+        - file: $cmse-lib(test-access-sequences2)$

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.cproject.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.cproject.yml
@@ -4,9 +4,9 @@ project:
   misc:
     - C-CPP: [PROJ2-D($Dname$)-B($Bname$)]
   define:
-    - $Output(test-access-sequences1)$
+    - $elf(test-access-sequences1)$
   add-path:
-    - $Output(test-access-sequences1)$
+    - $elf(test-access-sequences1)$
   components:
     - component: CORE
   groups:

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.csolution.yml
@@ -13,6 +13,8 @@ solution:
       misc:
         - C-CPP:
             - -O3
-  
+        - ASM:
+            - -DEF_SOLUTION=$SolutionDir()$/$Solution$
+
   projects:
     - project: ./test-access-sequences3.cproject.yml

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences3.cproject.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences3.cproject.yml
@@ -3,12 +3,18 @@
 project:
   device: RteTest_ARMCM0_Dual:cm0_core0
   define:
-    - DEF1-PROJ1-$Output(test-access-sequences3.Debug)$
-    - DEF2-PROJ1-$Output(test-access-sequences3.Release)$
+    - DEF1-PROJ1-$elf(test-access-sequences3.Debug)$
+    - DEF2-PROJ1-$elf(test-access-sequences3.Release)$
     - Device_$Dname$_Processor_$Pname$
   components:
     - component: CORE
   groups:
     - group: CMSE
       files: 
-        - file: $Output(test-access-sequences3)$_CMSE_Lib.o
+        - file: $cmse-lib(test-access-sequences3)$
+    - group: Artifacts
+      for-context: .Release
+      files: 
+        - file: $bin(test-access-sequences3)$
+        - file: $hex(test-access-sequences3)$
+        - file: $lib(test-access-sequences3)$

--- a/tools/projmgr/test/data/TestSolution/outdirs.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/outdirs.csolution.yml
@@ -20,5 +20,5 @@ solution:
     cprjdir: $Compiler$
     intdir: $OutDir(test1)$/$TargetType$
     outdir: $Project$/$BuildType$
-    rtedir: $Source()$/Custom/RTEDIR
+    rtedir: $ProjectDir()$/Custom/RTEDIR
     gendir: $Project$/gendir/$TargetType$


### PR DESCRIPTION
Relates to https://github.com/Open-CMSIS-Pack/devtools/issues/894

Exceptions:
- The access sequences `elf`, `bin`, `hex`, `lib`, `cmse-lib` must be refined after https://github.com/Open-CMSIS-Pack/devtools/issues/895