### PR TITLE
Improvements in evaluating dependencies (#569)

### DIFF
--- a/libs/rtemodel/src/RteCondition.cpp
+++ b/libs/rtemodel/src/RteCondition.cpp
@@ -305,6 +305,8 @@ RteItem::ConditionResult RteDenyExpression::Evaluate(RteConditionContext* contex
 
     case INSTALLED:
     case INCOMPATIBLE:
+    case INCOMPATIBLE_VARIANT:
+    case INCOMPATIBLE_VERSION:
     case SELECTABLE:
     case UNAVAILABLE:
     case UNAVAILABLE_PACK:

--- a/libs/rtemodel/test/src/RteConditionTest.cpp
+++ b/libs/rtemodel/test/src/RteConditionTest.cpp
@@ -71,6 +71,8 @@ TEST_F(RteConditionTest, MissingIgnoredFulfilledSelectable) {
   ASSERT_NE(denyAcceptDependency, nullptr);
   RteCondition* denyDenyDependency = pack->GetCondition("DenyDenyDependency");
   ASSERT_NE(denyDenyDependency, nullptr);
+  RteCondition* denyIncompatibleVariant = pack->GetCondition("DenyIncompatibleVariant");
+  ASSERT_NE(denyIncompatibleVariant, nullptr);
 
   // select component to check dependencies
   list<RteComponent*> components;
@@ -143,6 +145,27 @@ TEST_F(RteConditionTest, MissingIgnoredFulfilledSelectable) {
   EXPECT_EQ(denyRequireDependency->Evaluate(depSolver), RteItem::FULFILLED);
   EXPECT_EQ(denyAcceptDependency->Evaluate(depSolver), RteItem::INCOMPATIBLE);
   EXPECT_EQ(denyDenyDependency->Evaluate(depSolver), RteItem::FULFILLED);
+
+  // check deny dependencies incompatible variant
+
+  EXPECT_EQ(denyIncompatibleVariant->Evaluate(depSolver), RteItem::FULFILLED);
+  item.SetAttributes({ {"Cclass","RteTest" },
+                       {"Cgroup", "Dependency" },
+                       {"Csub", "Variant" },
+                       {"Cvariant","Compatible"},
+                       {"Cversion","0.9.9"},
+                     });
+  components.clear();
+  c = rteModel->FindComponents(item, components);
+  ASSERT_NE(c, nullptr);
+  activeTarget->SelectComponent(c, 1, true);
+  EXPECT_EQ(denyIncompatibleVariant->Evaluate(depSolver), RteItem::INCOMPATIBLE);
+  item.SetAttribute("Cvariant", "Incompatible");
+  components.clear();
+  c = rteModel->FindComponents(item, components);
+  activeTarget->SelectComponent(c, 1, true);
+  ASSERT_NE(c, nullptr);
+  EXPECT_EQ(denyIncompatibleVariant->Evaluate(depSolver), RteItem::FULFILLED);
 
   // evaluate other condition  possibilities
   RteRequireExpression deviceExpression(nullptr);

--- a/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
+++ b/test/packs/ARM/RteTest/0.1.0/ARM.RteTest.pdsc
@@ -71,6 +71,9 @@
     <condition id="DenyDenyDependency">
       <deny condition="DenyDependency"/>
     </condition>
+    <condition id="DenyIncompatibleVariant">
+      <deny condition="Incompatible Variant"/>
+    </condition>
 
   </conditions>
 

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2751,25 +2751,7 @@ bool ProjMgrWorker::ListDependencies(vector<string>& dependencies, const string&
 
 bool ProjMgrWorker::FormatValidationResults(set<string>& results, const ContextItem& context) {
   for (const auto& [result, component, expressions, aggregates] : context.validationResults) {
-    static const map<RteItem::ConditionResult, string> RESULTS = {
-      { RteItem::UNDEFINED             , "UNDEFINED"            },
-      { RteItem::R_ERROR               , "R_ERROR"              },
-      { RteItem::FAILED                , "FAILED"               },
-      { RteItem::MISSING               , "MISSING"              },
-      { RteItem::MISSING_API           , "MISSING_API"          },
-      { RteItem::MISSING_API_VERSION   , "MISSING_API_VERSION"  },
-      { RteItem::UNAVAILABLE           , "UNAVAILABLE"          },
-      { RteItem::UNAVAILABLE_PACK      , "UNAVAILABLE_PACK"     },
-      { RteItem::INCOMPATIBLE          , "INCOMPATIBLE"         },
-      { RteItem::INCOMPATIBLE_VERSION  , "INCOMPATIBLE_VERSION" },
-      { RteItem::INCOMPATIBLE_VARIANT  , "INCOMPATIBLE_VARIANT" },
-      { RteItem::CONFLICT              , "CONFLICT"             },
-      { RteItem::INSTALLED             , "INSTALLED"            },
-      { RteItem::SELECTABLE            , "SELECTABLE"           },
-      { RteItem::FULFILLED             , "FULFILLED"            },
-      { RteItem::IGNORED               , "IGNORED"              },
-    };
-    string resultStr = (RESULTS.find(result) == RESULTS.end() ? RESULTS.at(RteItem::UNDEFINED) : RESULTS.at(result)) + " " + component;
+    string resultStr = RteItem::ConditionResultToString(result) + " " + component;
     for (const auto& expression : expressions) {
       resultStr += "\n  " + expression;
     }


### PR DESCRIPTION
Fix deny of incompatible variant
reuse RteItem::ConditionResultToString()

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>