### PR TITLE
Add option to packchk to fail if warning/info violations are detected #886 (#583)

### DIFF
--- a/tools/packchk/include/PackOptions.h
+++ b/tools/packchk/include/PackOptions.h
@@ -16,8 +16,12 @@ public:
   CPackOptions();
   ~CPackOptions();
 
+  enum class PedanticLevel { NONE = 0, WARNING, INFO };
+
 
   bool SetWarnLevel(const uint32_t warnLevel);
+  bool SetPedantic(const PedanticLevel pedanticLevel);
+  PedanticLevel GetPedantic();
   bool SetLogFile(const std::string& m_logFile);
   bool SetXsdFile();
   bool SetXsdFile(const std::string& m_xsdFile);
@@ -54,6 +58,7 @@ public:
 private:
   bool m_bIgnoreOtherPdscFiles;
   bool m_bDisableValidation;
+  PedanticLevel m_pedanticLevel;
 
   std::string m_urlRef;    // package URL reference, check the URL of the PDSC against this value. if not std::set it is compared against the Keil Pack Server URL
   std::string m_packNamePath;

--- a/tools/packchk/include/ParseOptions.h
+++ b/tools/packchk/include/ParseOptions.h
@@ -27,6 +27,7 @@ public:
 
 protected:
   bool SetWarnLevel(const std::string& warnLevel);
+  bool SetPedantic(const std::string& pedanticLevel);
   bool SetTestPdscFile(const std::string& filename);
   bool SetLogFile(const std::string& m_logFile);
   bool SetXsdFile();

--- a/tools/packchk/src/PackChk.cpp
+++ b/tools/packchk/src/PackChk.cpp
@@ -201,5 +201,12 @@ int PackChk::Check(int argc, const char* argv[], const char* envp[])
     return 1;
   }
 
+  CPackOptions::PedanticLevel pedantic = m_packOptions.GetPedantic();
+  if(pedantic != CPackOptions::PedanticLevel::NONE) {
+    if(ErrLog::Get()->GetWarnCnt()) {
+      return 1;
+    }
+  }
+
   return 0;
 }

--- a/tools/packchk/src/PackOptions.cpp
+++ b/tools/packchk/src/PackOptions.cpp
@@ -20,7 +20,8 @@ using namespace std;
 */
 CPackOptions::CPackOptions() :
   m_bIgnoreOtherPdscFiles(false),
-  m_bDisableValidation(false)
+  m_bDisableValidation(false),
+  m_pedanticLevel(PedanticLevel::NONE)
 {
 }
 
@@ -450,6 +451,29 @@ bool CPackOptions::SetWarnLevel(const uint32_t warnLevel)
   }
 
   return true;
+}
+
+
+/**
+ * @brief set the pedantic level to return with error flag
+ * @param warnLevel PEDANTIC_LEVEL pedantic level
+ * @return passed / failed
+ */
+bool CPackOptions::SetPedantic(const PedanticLevel pedanticLevel)
+{
+  m_pedanticLevel = pedanticLevel;
+
+  return true;
+}
+
+/**
+ * @brief get the pedantic level to return with error flag
+ * @param none
+ * @return level
+ */
+CPackOptions::PedanticLevel CPackOptions::GetPedantic()
+{
+  return m_pedanticLevel;
 }
 
 /**

--- a/tools/packchk/src/ParseOptions.cpp
+++ b/tools/packchk/src/ParseOptions.cpp
@@ -55,6 +55,19 @@ bool ParseOptions::SetWarnLevel(const string& warnLevel)
   return m_packOptions.SetWarnLevel(level);
 }
 
+bool ParseOptions::SetPedantic(const string& pedanticLevel)
+{
+  if(pedanticLevel.empty() || pedanticLevel == "info") {
+    return m_packOptions.SetPedantic(CPackOptions::PedanticLevel::INFO);
+  }
+  else if(pedanticLevel == "warning") {
+    return m_packOptions.SetPedantic(CPackOptions::PedanticLevel::WARNING);
+  }
+  else {
+    return false;
+  }
+}
+
 /**
  * @brief option "v,verbose"
  * @param bVerbose set verbose mode
@@ -208,6 +221,7 @@ ParseOptions::Result ParseOptions::Parse(int argc, const char* argv[])
         {"allow-suppress-error", "Allow to suppress error messages", cxxopts::value<bool>()->default_value("false")},
         {"break", "Debug halt after start", cxxopts::value<bool>()->default_value("false")},
         {"ignore-other-pdsc", "Ignores other PDSC files in working folder", cxxopts::value<bool>()->default_value("false")},
+        {"pedantic", "Return with error value on warning", cxxopts::value<bool>()->default_value("false")},
       });
 
     options.parse_positional({"input"});
@@ -280,6 +294,12 @@ ParseOptions::Result ParseOptions::Parse(int argc, const char* argv[])
 
     if(parseResult.count("w")) {
       if(!SetWarnLevel(parseResult["w"].as<string>())) {
+        bOk = false;
+      }
+    }
+
+    if(parseResult.count("pedantic")) {
+      if(!SetPedantic("warning")) {
         bOk = false;
       }
     }


### PR DESCRIPTION
added:
- option "--pedantic" (as bool), where packchk returns 1 on WARNINGs
- prepared for "--pedantic [warning|info]", this would touch ErrLog library