### PR TITLE
Add target-types and projects as required property

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -627,23 +627,13 @@
       "additionalProperties": false
     },
     "SolutionDescType": {
-      "type": ["object", "null"],
+      "type": "object",
       "properties": {
-        "target-types": {
-          "$ref": "#/definitions/TargetTypes"
-        },
-        "build-types": {
-          "$ref": "#/definitions/BuildTypes"
-        },
-        "output-dirs": {
-          "$ref": "#/definitions/OutputDirectoriesType"
-        },
-        "packs": {
-           "$ref": "#/definitions/PacksType"
-        },
-        "projects": {
-          "$ref": "#/definitions/ProjectsType"
-        },
+        "target-types": { "$ref": "#/definitions/TargetTypes" },
+        "build-types":  { "$ref": "#/definitions/BuildTypes" },
+        "output-dirs":  { "$ref": "#/definitions/OutputDirectoriesType" },
+        "packs":        { "$ref": "#/definitions/PacksType" },
+        "projects":     { "$ref": "#/definitions/ProjectsType" },
         "processor":    { "$ref": "#/definitions/ProcessorType" },
         "compiler":     { "$ref": "#/definitions/CompilerType" },
         "optimize":     { "$ref": "#/definitions/OptimizeType" },
@@ -667,7 +657,8 @@
         "cdefault":    { "type": "null", "description": "Enable use of cdefault.yml file" },
         "generators":  { "$ref": "#/definitions/GeneratorsOutputType" }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [ "target-types", "projects" ]
     },
     "ProjectDescType": {
       "type": ["object", "null"],

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Debug+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Debug+TEST_TARGET.cprj
@@ -15,11 +15,11 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Secure" Dvendor="ARM:82" Pname="cm0_core0">
-    <output bin="test-access-sequences3.bin" cmse-lib="test-access-sequences3_CMSE_Lib.o" elf="test-access-sequences3.axf" hex="test-access-sequences3.hex" intdir="tmp/test-access-sequences3/Debug" name="test-access-sequences3" outdir="out/test-access-sequences3/Debug" rtedir="../data/TestAccessSequences/RTE"/>
+    <output bin="test-access-sequences3.bin" cmse-lib="test-access-sequences3_CMSE_Lib.o" elf="test-access-sequences3.axf" hex="test-access-sequences3.hex" intdir="tmp/test-access-sequences3/TEST_TARGET/Debug" name="test-access-sequences3" outdir="out/test-access-sequences3/TEST_TARGET/Debug" rtedir="../data/TestAccessSequences/RTE"/>
     <cflags add="-O1 -g" compiler="AC6"/>
     <cxxflags add="-O1 -g" compiler="AC6"/>
     <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0_Dual_cm0_core0/regions_RteTest_ARMCM0_Dual_cm0_core0.h"/>
-    <defines>DEF1-PROJ1-out/test-access-sequences3/Debug/test-access-sequences3.axf;DEF2-PROJ1-out/test-access-sequences3/Release/test-access-sequences3.axf;Device_RteTest_ARMCM0_Dual_Processor_cm0_core0</defines>
+    <defines>DEF1-PROJ1-out/test-access-sequences3/TEST_TARGET/Debug/test-access-sequences3.axf;DEF2-PROJ1-out/test-access-sequences3/TEST_TARGET/Release/test-access-sequences3.axf;Device_RteTest_ARMCM0_Dual_Processor_cm0_core0</defines>
   </target>
 
   <components>
@@ -28,7 +28,7 @@
 
   <files>
     <group name="CMSE">
-      <file category="object" name="out/test-access-sequences3/Debug/test-access-sequences3_CMSE_Lib.o"/>
+      <file category="object" name="out/test-access-sequences3/TEST_TARGET/Debug/test-access-sequences3_CMSE_Lib.o"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/test-access-sequences3.Release+TEST_TARGET.cprj
@@ -15,12 +15,12 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0_Dual" Dsecure="Secure" Dvendor="ARM:82" Pname="cm0_core0">
-    <output bin="test-access-sequences3.bin" cmse-lib="test-access-sequences3_CMSE_Lib.o" elf="test-access-sequences3.axf" hex="test-access-sequences3.hex" intdir="tmp/test-access-sequences3/Release" name="test-access-sequences3" outdir="out/test-access-sequences3/Release" rtedir="../data/TestAccessSequences/RTE"/>
+    <output bin="test-access-sequences3.bin" cmse-lib="test-access-sequences3_CMSE_Lib.o" elf="test-access-sequences3.axf" hex="test-access-sequences3.hex" intdir="tmp/test-access-sequences3/TEST_TARGET/Release" name="test-access-sequences3" outdir="out/test-access-sequences3/TEST_TARGET/Release" rtedir="../data/TestAccessSequences/RTE"/>
     <asflags add="-DEF_SOLUTION=../data/TestAccessSequences/test-access-sequences2" compiler="AC6"/>
     <cflags add="-O3" compiler="AC6"/>
     <cxxflags add="-O3" compiler="AC6"/>
     <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestAccessSequences/RTE/Device/RteTest_ARMCM0_Dual_cm0_core0/regions_RteTest_ARMCM0_Dual_cm0_core0.h"/>
-    <defines>DEF1-PROJ1-out/test-access-sequences3/Debug/test-access-sequences3.axf;DEF2-PROJ1-out/test-access-sequences3/Release/test-access-sequences3.axf;Device_RteTest_ARMCM0_Dual_Processor_cm0_core0</defines>
+    <defines>DEF1-PROJ1-out/test-access-sequences3/TEST_TARGET/Debug/test-access-sequences3.axf;DEF2-PROJ1-out/test-access-sequences3/TEST_TARGET/Release/test-access-sequences3.axf;Device_RteTest_ARMCM0_Dual_Processor_cm0_core0</defines>
   </target>
 
   <components>
@@ -29,11 +29,11 @@
 
   <files>
     <group name="CMSE">
-      <file category="object" name="out/test-access-sequences3/Release/test-access-sequences3_CMSE_Lib.o"/>
+      <file category="object" name="out/test-access-sequences3/TEST_TARGET/Release/test-access-sequences3_CMSE_Lib.o"/>
     </group>
     <group name="Artifacts">
-      <file category="other" name="out/test-access-sequences3/Release/test-access-sequences3.bin"/>
-      <file category="other" name="out/test-access-sequences3/Release/test-access-sequences3.hex"/>
+      <file category="other" name="out/test-access-sequences3/TEST_TARGET/Release/test-access-sequences3.bin"/>
+      <file category="other" name="out/test-access-sequences3/TEST_TARGET/Release/test-access-sequences3.hex"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-access-sequences2.csolution.yml
@@ -1,6 +1,7 @@
 ### CMSIS Project Description ###
 solution:
-
+  target-types:
+    - type: TEST_TARGET
   build-types:
     - type: Debug
       compiler: AC6

--- a/tools/projmgr/test/data/TestAccessSequences/test-malformed-access-sequences1.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-malformed-access-sequences1.csolution.yml
@@ -1,4 +1,7 @@
 ### CMSIS Project Description ###
 solution:
+  target-types:
+    - type: TEST_TARGET
+
   projects:
     - project: ./malformed-access-sequences1.cproject.yml

--- a/tools/projmgr/test/data/TestAccessSequences/test-malformed-access-sequences2.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/test-malformed-access-sequences2.csolution.yml
@@ -1,5 +1,8 @@
 ### CMSIS Project Description ###
 solution:
+  target-types:
+    - type: TEST_TARGET
+
   projects:
     - project: ./malformed-access-sequences1.cproject.yml
     - project: ./malformed-access-sequences2.cproject.yml

--- a/tools/projmgr/test/data/TestDefault/empty.csolution.yml
+++ b/tools/projmgr/test/data/TestDefault/empty.csolution.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
 
   packs:
     - pack: ARM::RteTest_DFP@0.1.1

--- a/tools/projmgr/test/data/TestDefault/full.csolution.yml
+++ b/tools/projmgr/test/data/TestDefault/full.csolution.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
+
   build-types:
     - type: Debug
       compiler: AC6

--- a/tools/projmgr/test/data/TestDefault/ref/empty/empty.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/empty.cbuild-idx.yml
@@ -5,9 +5,9 @@ build-idx:
   cprojects:
     - cproject: ../../data/TestDefault/project.cproject.yml
   cbuilds:
-    - cbuild: project.Debug.cbuild.yml
+    - cbuild: project.Debug+TEST_TARGET.cbuild.yml
       project: project
-      configuration: .Debug+
-    - cbuild: project.Release.cbuild.yml
+      configuration: .Debug+TEST_TARGET
+    - cbuild: project.Release+TEST_TARGET.cbuild.yml
       project: project
-      configuration: .Release+
+      configuration: .Release+TEST_TARGET

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
@@ -2,7 +2,7 @@ build:
   generated-by: csolution version 0.0.0+g11955b66
   solution: ../../data/TestDefault/empty.csolution.yml
   project: ../../data/TestDefault/project.cproject.yml
-  context: project.Release
+  context: project.Debug+TEST_TARGET
   compiler: GCC
   device: RteTest_ARMCM0
   processor:
@@ -18,11 +18,11 @@ build:
     - ARMCM0
     - _RTE_
   add-path:
-    - ../../data/TestDefault/RTE/_Release
+    - ../../data/TestDefault/RTE/_Debug_TEST_TARGET
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Device/ARM/ARMCM0/Include
   output-dirs:
-    intdir: tmp/project/Release
-    outdir: out/project/Release
+    intdir: tmp/project/TEST_TARGET/Debug
+    outdir: out/project/TEST_TARGET/Debug
     rtedir: ../../data/TestDefault/RTE
   output:
     - type: elf
@@ -41,5 +41,5 @@ build:
         - file: ../../data/TestDefault/main.c
           category: sourceC
   constructed-files:
-    - file: ../../data/TestDefault/RTE/_Release/RTE_Components.h
+    - file: ../../data/TestDefault/RTE/_Debug_TEST_TARGET/RTE_Components.h
       category: header

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cprj
@@ -15,7 +15,7 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="project.elf" intdir="tmp/project/Release" name="project" outdir="out/project/Release" rtedir="../../data/TestDefault/RTE"/>
+    <output elf="project.elf" intdir="tmp/project/TEST_TARGET/Debug" name="project" outdir="out/project/TEST_TARGET/Debug" rtedir="../../data/TestDefault/RTE"/>
     <asflags add="defaultMiscASM-RteTest_ARMCM0" compiler="GCC"/>
     <ldflags compiler="GCC" file="../../data/TestToolchains/gcc_linker_script.ld" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
   </target>

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
@@ -2,7 +2,7 @@ build:
   generated-by: csolution version 0.0.0+g11955b66
   solution: ../../data/TestDefault/empty.csolution.yml
   project: ../../data/TestDefault/project.cproject.yml
-  context: project.Debug
+  context: project.Release+TEST_TARGET
   compiler: GCC
   device: RteTest_ARMCM0
   processor:
@@ -18,11 +18,11 @@ build:
     - ARMCM0
     - _RTE_
   add-path:
-    - ../../data/TestDefault/RTE/_Debug
+    - ../../data/TestDefault/RTE/_Release_TEST_TARGET
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Device/ARM/ARMCM0/Include
   output-dirs:
-    intdir: tmp/project/Debug
-    outdir: out/project/Debug
+    intdir: tmp/project/TEST_TARGET/Release
+    outdir: out/project/TEST_TARGET/Release
     rtedir: ../../data/TestDefault/RTE
   output:
     - type: elf
@@ -41,5 +41,5 @@ build:
         - file: ../../data/TestDefault/main.c
           category: sourceC
   constructed-files:
-    - file: ../../data/TestDefault/RTE/_Debug/RTE_Components.h
+    - file: ../../data/TestDefault/RTE/_Release_TEST_TARGET/RTE_Components.h
       category: header

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cprj
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:33:13" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T12:32:18" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
   </info>
 
   <packages>
-    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+    <package name="RteTest_DFP" vendor="ARM" version="0.1.1:0.1.1"/>
   </packages>
 
   <compilers>
-    <compiler name="AC6" version="6.18.0"/>
+    <compiler name="GCC" version="11.2.1"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="project.axf" intdir="tmp/project/Debug" name="project" outdir="out/project/Debug" rtedir="../../data/TestDefault/RTE"/>
-    <cflags add="solutionMiscC defaultMiscC" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../../data/TestToolchains/ac6_linker_script.sct" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
+    <output elf="project.elf" intdir="tmp/project/TEST_TARGET/Release" name="project" outdir="out/project/TEST_TARGET/Release" rtedir="../../data/TestDefault/RTE"/>
+    <asflags add="defaultMiscASM-RteTest_ARMCM0" compiler="GCC"/>
+    <ldflags compiler="GCC" file="../../data/TestToolchains/gcc_linker_script.ld" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestDefault/ref/full/project.Debug+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/full/project.Debug+TEST_TARGET.cprj
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:32:18" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T12:33:13" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
   </info>
 
   <packages>
-    <package name="RteTest_DFP" vendor="ARM" version="0.1.1:0.1.1"/>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
   </packages>
 
   <compilers>
-    <compiler name="GCC" version="11.2.1"/>
+    <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="project.elf" intdir="tmp/project/Debug" name="project" outdir="out/project/Debug" rtedir="../../data/TestDefault/RTE"/>
-    <asflags add="defaultMiscASM-RteTest_ARMCM0" compiler="GCC"/>
-    <ldflags compiler="GCC" file="../../data/TestToolchains/gcc_linker_script.ld" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
+    <output elf="project.axf" intdir="tmp/project/TEST_TARGET/Debug" name="project" outdir="out/project/TEST_TARGET/Debug" rtedir="../../data/TestDefault/RTE"/>
+    <cflags add="solutionMiscC defaultMiscC" compiler="AC6"/>
+    <ldflags compiler="AC6" file="../../data/TestToolchains/ac6_linker_script.sct" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestDefault/ref/full/project.Release+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestDefault/ref/full/project.Release+TEST_TARGET.cprj
@@ -15,7 +15,7 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="project.out" intdir="tmp/project/Release" name="project" outdir="out/project/Release" rtedir="../../data/TestDefault/RTE"/>
+    <output elf="project.out" intdir="tmp/project/TEST_TARGET/Release" name="project" outdir="out/project/TEST_TARGET/Release" rtedir="../../data/TestDefault/RTE"/>
     <ldflags compiler="IAR" file="../../data/TestToolchains/iar_linker_script.icf" regions="../../data/TestDefault/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
   </target>
 

--- a/tools/projmgr/test/data/TestDefault/test.csolution.yml
+++ b/tools/projmgr/test/data/TestDefault/test.csolution.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
+
   build-types:
     - type: Debug
       compiler: AC6

--- a/tools/projmgr/test/data/TestLayers/ref/testlayers/testlayers.Debug+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/testlayers/testlayers.Debug+TEST_TARGET.cprj
@@ -15,7 +15,7 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="testlayers.axf" intdir="tmp/testlayers/Debug" name="testlayers" outdir="out/testlayers/Debug" rtedir="../../data/TestLayers/RTE"/>
+    <output elf="testlayers.axf" intdir="tmp/testlayers/TEST_TARGET/Debug" name="testlayers" outdir="out/testlayers/TEST_TARGET/Debug" rtedir="../../data/TestLayers/RTE"/>
     <cflags add="--layer1-flag --layer2-flag" compiler="AC6"/>
     <ldflags compiler="AC6" file="../../data/TestLayers/Layer2/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
     <defines>DEF_LAYER1;DEF_LAYER2</defines>

--- a/tools/projmgr/test/data/TestLayers/ref/testlayers/testlayers.Release+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/testlayers/testlayers.Release+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:18:41" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T12:58:29" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -16,21 +16,21 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="testlayers.axf" intdir="tmp/testlayers/Release" name="testlayers" outdir="out/testlayers/Release" rtedir="RTE"/>
+    <output elf="testlayers.axf" intdir="tmp/testlayers/TEST_TARGET/Release" name="testlayers" outdir="out/testlayers/TEST_TARGET/Release" rtedir="../../data/TestLayers/RTE"/>
     <cflags add="--layer1-flag --layer3-flag" compiler="AC6"/>
-    <ldflags compiler="AC6" file="Layer3/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+    <ldflags compiler="AC6" file="../../data/TestLayers/Layer3/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
     <defines>DEF_LAYER1;DEF_LAYER3</defines>
-    <includes>Layer1/path/to/layer1;Layer3/path/to/layer3</includes>
+    <includes>../../data/TestLayers/Layer1/path/to/layer1;../../data/TestLayers/Layer3/path/to/layer3</includes>
   </target>
 
   <components>
-    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="Layer3/RTE">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../../data/TestLayers/Layer3/RTE">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
     </component>
     <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
-    <component Cclass="RteTest" Cgroup="ComponentLevel" Cvendor="ARM" Cversion="0.0.1" rtedir="Layer3/RTE">
+    <component Cclass="RteTest" Cgroup="ComponentLevel" Cvendor="ARM" Cversion="0.0.1" rtedir="../../data/TestLayers/Layer3/RTE">
       <file attr="config" category="preIncludeLocal" name="ComponentLevel/ComponentLevelConfig.h" version="0.0.1"/>
       <file attr="config" category="header" name="ComponentLevel/Include/MyDir/RelativeComponentLevelConfig.h" version="0.0.1"/>
     </component>
@@ -38,10 +38,10 @@
 
   <files>
     <group name="Sources Layer 1">
-      <file category="sourceC" name="Layer1/layer1.c"/>
+      <file category="sourceC" name="../../data/TestLayers/Layer1/layer1.c"/>
     </group>
     <group name="Sources Layer 3">
-      <file category="sourceC" name="Layer3/layer3.c"/>
+      <file category="sourceC" name="../../data/TestLayers/Layer3/layer3.c"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestLayers/ref2/testlayers.Debug+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref2/testlayers.Debug+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-04T15:19:19" tool="csolution 0.9.2+p111-g80000aa"/>
+  <created timestamp="2022-07-06T12:18:41" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -15,12 +15,15 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="test_linker_script.axf" intdir="tmp/test_linker_script" name="test_linker_script" outdir="out/test_linker_script" rtedir="../data/TestSolution/TestProject4/RTE"/>
-    <ldflags compiler="AC6" file="../data/TestSolution/TestProject4/linker.sct"/>
+    <output elf="testlayers.axf" intdir="tmp/testlayers/TEST_TARGET/Debug" name="testlayers" outdir="out/testlayers/TEST_TARGET/Debug" rtedir="RTE"/>
+    <cflags add="--layer1-flag --layer2-flag" compiler="AC6"/>
+    <ldflags compiler="AC6" file="Layer2/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+    <defines>DEF_LAYER1;DEF_LAYER2</defines>
+    <includes>Layer1/path/to/layer1;Layer2/path/to/layer2</includes>
   </target>
 
   <components>
-    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="Layer2/RTE">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
@@ -29,9 +32,11 @@
   </components>
 
   <files>
-    <group name="Sources">
-      <file category="sourceC" name="../data/TestSolution/TestProject4/main.c"/>
-      <file category="linkerScript" name="../data/TestSolution/TestProject4/linker.sct"/>
+    <group name="Sources Layer 1">
+      <file category="sourceC" name="Layer1/layer1.c"/>
+    </group>
+    <group name="Sources Layer 2">
+      <file category="sourceC" name="Layer2/layer2.c"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestLayers/ref2/testlayers.Release+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref2/testlayers.Release+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:58:29" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T12:18:41" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -16,21 +16,21 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="testlayers.axf" intdir="tmp/testlayers/Release" name="testlayers" outdir="out/testlayers/Release" rtedir="../../data/TestLayers/RTE"/>
+    <output elf="testlayers.axf" intdir="tmp/testlayers/TEST_TARGET/Release" name="testlayers" outdir="out/testlayers/TEST_TARGET/Release" rtedir="RTE"/>
     <cflags add="--layer1-flag --layer3-flag" compiler="AC6"/>
-    <ldflags compiler="AC6" file="../../data/TestLayers/Layer3/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
+    <ldflags compiler="AC6" file="Layer3/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
     <defines>DEF_LAYER1;DEF_LAYER3</defines>
-    <includes>../../data/TestLayers/Layer1/path/to/layer1;../../data/TestLayers/Layer3/path/to/layer3</includes>
+    <includes>Layer1/path/to/layer1;Layer3/path/to/layer3</includes>
   </target>
 
   <components>
-    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../../data/TestLayers/Layer3/RTE">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="Layer3/RTE">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
     </component>
     <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
-    <component Cclass="RteTest" Cgroup="ComponentLevel" Cvendor="ARM" Cversion="0.0.1" rtedir="../../data/TestLayers/Layer3/RTE">
+    <component Cclass="RteTest" Cgroup="ComponentLevel" Cvendor="ARM" Cversion="0.0.1" rtedir="Layer3/RTE">
       <file attr="config" category="preIncludeLocal" name="ComponentLevel/ComponentLevelConfig.h" version="0.0.1"/>
       <file attr="config" category="header" name="ComponentLevel/Include/MyDir/RelativeComponentLevelConfig.h" version="0.0.1"/>
     </component>
@@ -38,10 +38,10 @@
 
   <files>
     <group name="Sources Layer 1">
-      <file category="sourceC" name="../../data/TestLayers/Layer1/layer1.c"/>
+      <file category="sourceC" name="Layer1/layer1.c"/>
     </group>
     <group name="Sources Layer 3">
-      <file category="sourceC" name="../../data/TestLayers/Layer3/layer3.c"/>
+      <file category="sourceC" name="Layer3/layer3.c"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestLayers/testlayers.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.csolution.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
 
   build-types:
     - type: Debug

--- a/tools/projmgr/test/data/TestLayers/testlayers.csolution_invalid_layer.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.csolution_invalid_layer.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
 
   build-types:
     - type: Debug

--- a/tools/projmgr/test/data/TestLayers/testlayers.csolution_no_device_name.yml
+++ b/tools/projmgr/test/data/TestLayers/testlayers.csolution_no_device_name.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
 
   build-types:
     - type: Debug

--- a/tools/projmgr/test/data/TestLayers/variables-notdefined.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/variables-notdefined.csolution.yml
@@ -4,7 +4,7 @@ solution:
 
   build-types:
     - type: BuildType
-      compiler: AC6        
+      compiler: AC6
 
   target-types:
     - type: TargetType

--- a/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build AC6+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build AC6+TEST_TARGET.cprj
@@ -15,7 +15,7 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="setup-test.axf" intdir="tmp/setup-test/Build AC6" name="setup-test" outdir="out/setup-test/Build AC6" rtedir="../data/TestProjectSetup/RTE"/>
+    <output elf="setup-test.axf" intdir="tmp/setup-test/TEST_TARGET/Build AC6" name="setup-test" outdir="out/setup-test/TEST_TARGET/Build AC6" rtedir="../data/TestProjectSetup/RTE"/>
     <ldflags compiler="AC6" file="../data/TestToolchains/ac6_linker_script.sct" regions="../data/TestProjectSetup/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
     <defines>SETUP_AC6</defines>
   </target>

--- a/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build GCC+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build GCC+TEST_TARGET.cprj
@@ -15,7 +15,7 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="TZ-disabled" Dvendor="ARM:82">
-    <output elf="setup-test.elf" intdir="tmp/setup-test/Build GCC" name="setup-test" outdir="out/setup-test/Build GCC" rtedir="../data/TestProjectSetup/RTE"/>
+    <output elf="setup-test.elf" intdir="tmp/setup-test/TEST_TARGET/Build GCC" name="setup-test" outdir="out/setup-test/TEST_TARGET/Build GCC" rtedir="../data/TestProjectSetup/RTE"/>
     <ldflags compiler="GCC" file="../data/TestToolchains/gcc_linker_script.ld" regions="../data/TestProjectSetup/RTE/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h"/>
     <defines>SETUP_GCC</defines>
   </target>

--- a/tools/projmgr/test/data/TestProjectSetup/setup-test.csolution.yml
+++ b/tools/projmgr/test/data/TestProjectSetup/setup-test.csolution.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
 
   projects:
     - project: ./setup-test.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/TestProject4/test+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestSolution/TestProject4/test+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:27:56" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T11:52:39" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -14,13 +14,12 @@
     <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
-  <target Bname="RteTest Test board-3" Brevision="1.1.1" Bvendor="Keil" Bversion="1.1.1" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="test.axf" intdir="tmp/test" name="test" outdir="out/test" rtedir="../data/TestSolution/TestProject4/RTE"/>
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output elf="test.axf" intdir="tmp/test/TEST_TARGET" name="test" outdir="out/test/TEST_TARGET" rtedir="../data/TestSolution/TestProject4/RTE"/>
     <ldflags compiler="AC6" file="../data/TestSolution/TestProject4/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
   </target>
 
   <components>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>

--- a/tools/projmgr/test/data/TestSolution/TestProject4/test_linker_script+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestSolution/TestProject4/test_linker_script+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T12:18:41" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-04T15:19:19" tool="csolution 0.9.2+p111-g80000aa"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -15,15 +15,12 @@
   </compilers>
 
   <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="testlayers.axf" intdir="tmp/testlayers/Debug" name="testlayers" outdir="out/testlayers/Debug" rtedir="RTE"/>
-    <cflags add="--layer1-flag --layer2-flag" compiler="AC6"/>
-    <ldflags compiler="AC6" file="Layer2/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
-    <defines>DEF_LAYER1;DEF_LAYER2</defines>
-    <includes>Layer1/path/to/layer1;Layer2/path/to/layer2</includes>
+    <output elf="test_linker_script.axf" intdir="tmp/test_linker_script/TEST_TARGET" name="test_linker_script" outdir="out/test_linker_script/TEST_TARGET" rtedir="../data/TestSolution/TestProject4/RTE"/>
+    <ldflags compiler="AC6" file="../data/TestSolution/TestProject4/linker.sct"/>
   </target>
 
   <components>
-    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="Layer2/RTE">
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/system_ARMCM0.c" version="1.0.0"/>
@@ -32,11 +29,9 @@
   </components>
 
   <files>
-    <group name="Sources Layer 1">
-      <file category="sourceC" name="Layer1/layer1.c"/>
-    </group>
-    <group name="Sources Layer 2">
-      <file category="sourceC" name="Layer2/layer2.c"/>
+    <group name="Sources">
+      <file category="sourceC" name="../data/TestSolution/TestProject4/main.c"/>
+      <file category="linkerScript" name="../data/TestSolution/TestProject4/linker.sct"/>
     </group>
   </files>
 </cprj>

--- a/tools/projmgr/test/data/TestSolution/TestProject4/test_only_board+TEST_TARGET.cprj
+++ b/tools/projmgr/test/data/TestSolution/TestProject4/test_only_board+TEST_TARGET.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2022-07-06T11:52:39" tool="csolution 0.9.2+p113-gd70521c"/>
+  <created timestamp="2022-07-06T12:27:56" tool="csolution 0.9.2+p113-gd70521c"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -14,12 +14,13 @@
     <compiler name="AC6" version="6.18.0"/>
   </compilers>
 
-  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
-    <output elf="test.axf" intdir="tmp/test" name="test" outdir="out/test" rtedir="../data/TestSolution/TestProject4/RTE"/>
+  <target Bname="RteTest Test board-3" Brevision="1.1.1" Bvendor="Keil" Bversion="1.1.1" Dfpu="NO_FPU" Dname="RteTest_ARMCM0" Dsecure="Non-secure" Dvendor="ARM:82">
+    <output elf="test.axf" intdir="tmp/test/TEST_TARGET" name="test" outdir="out/test/TEST_TARGET" rtedir="../data/TestSolution/TestProject4/RTE"/>
     <ldflags compiler="AC6" file="../data/TestSolution/TestProject4/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
   </target>
 
   <components>
+    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM0/Source/ARM/ARMCM0_ac6.sct" version="1.0.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM0/Source/startup_ARMCM0.c" version="2.0.3"/>

--- a/tools/projmgr/test/data/TestSolution/test.csolution_validate_project.yml
+++ b/tools/projmgr/test/data/TestSolution/test.csolution_validate_project.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
   projects:
     - project: <TEST>
 

--- a/tools/projmgr/test/data/TrustZoneSolutionLayers/TrustZone.csolution.yml
+++ b/tools/projmgr/test/data/TrustZoneSolutionLayers/TrustZone.csolution.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+  target-types:
+    - type: TEST_TARGET
+
   projects:
     - project: ./Secure_CM33_Debug.cproject.yml
     - project: ./Secure_CM33_Release.cproject.yml

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -154,13 +154,14 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListPacks_project) {
   argv[3] = (char*)"-s";
   argv[4] = (char*)csolution.c_str();
   argv[5] = (char*)"-c";
-  argv[6] = (char*)"project.Debug";
+  argv[6] = (char*)"project.Debug+TEST_TARGET";
   EXPECT_EQ(0, RunProjMgr(7, argv, 0));
 
   GetFilesInTree(rteFolder, rteFilesAfter);
   EXPECT_EQ(rteFilesBefore, rteFilesAfter);
 
   auto outStr = streamRedirect.GetOutString();
+  auto errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(regex_match(outStr, regex("ARM::RteTest_DFP@0.1.1 \\(.*\\)\n")));
 }
 
@@ -348,8 +349,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ConvertProject) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJ
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test.cprj",
-    testinput_folder + "/TestSolution/TestProject4/test.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test+TEST_TARGET.cprj",
+    testinput_folder + "/TestSolution/TestProject4/test+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_EnforcedComponent) {
@@ -381,8 +382,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_LinkerScript) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJ
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test_linker_script.cprj",
-    testinput_folder + "/TestSolution/TestProject4/test_linker_script.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test_linker_script+TEST_TARGET.cprj",
+    testinput_folder + "/TestSolution/TestProject4/test_linker_script+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_With_Schema_Check) {
@@ -408,8 +409,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_Skip_Schema_Check) {
   EXPECT_EQ(0, RunProjMgr(7, argv, 0));
 
   // Check generated CPRJ
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test.cprj",
-    testinput_folder + "/TestSolution/TestProject4/test.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test+TEST_TARGET.cprj",
+    testinput_folder + "/TestSolution/TestProject4/test+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgrContextSolution) {
@@ -602,10 +603,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgrLayers) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/testlayers/testlayers.Debug.cprj",
-    testinput_folder + "/TestLayers/ref/testlayers/testlayers.Debug.cprj");
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/testlayers/testlayers.Release.cprj",
-    testinput_folder + "/TestLayers/ref/testlayers/testlayers.Release.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/testlayers/testlayers.Debug+TEST_TARGET.cprj",
+    testinput_folder + "/TestLayers/ref/testlayers/testlayers.Debug+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/testlayers/testlayers.Release+TEST_TARGET.cprj",
+    testinput_folder + "/TestLayers/ref/testlayers/testlayers.Release+TEST_TARGET.cprj");
 
   // Check creation of layers rte folders
   EXPECT_TRUE(RteFsUtils::Exists(testinput_folder + "/TestLayers/Layer2/RTE/Device/RteTest_ARMCM0"));
@@ -623,10 +624,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgrLayers2) {
   EXPECT_EQ(0, RunProjMgr(4, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testinput_folder + "/TestLayers/testlayers.Debug.cprj",
-    testinput_folder + "/TestLayers/ref2/testlayers.Debug.cprj");
- ProjMgrTestEnv:: CompareFile(testinput_folder + "/TestLayers/testlayers.Release.cprj",
-    testinput_folder + "/TestLayers/ref2/testlayers.Release.cprj");
+ ProjMgrTestEnv:: CompareFile(testinput_folder + "/TestLayers/testlayers.Debug+TEST_TARGET.cprj",
+    testinput_folder + "/TestLayers/ref2/testlayers.Debug+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testinput_folder + "/TestLayers/testlayers.Release+TEST_TARGET.cprj",
+    testinput_folder + "/TestLayers/ref2/testlayers.Release+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, ListLayersAll) {
@@ -1236,10 +1237,10 @@ TEST_F(ProjMgrUnitTests, AccessSequences2) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test-access-sequences3.Debug.cprj",
-    testinput_folder + "/TestAccessSequences/ref/test-access-sequences3.Debug.cprj");
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test-access-sequences3.Release.cprj",
-    testinput_folder + "/TestAccessSequences/ref/test-access-sequences3.Release.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test-access-sequences3.Debug+TEST_TARGET.cprj",
+    testinput_folder + "/TestAccessSequences/ref/test-access-sequences3.Debug+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test-access-sequences3.Release+TEST_TARGET.cprj",
+    testinput_folder + "/TestAccessSequences/ref/test-access-sequences3.Release+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_MalformedAccessSequences1) {
@@ -1683,8 +1684,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_Only_Board_Info) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJ
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test.cprj",
-    testinput_folder + "/TestSolution/TestProject4/test_only_board.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test+TEST_TARGET.cprj",
+    testinput_folder + "/TestSolution/TestProject4/test_only_board+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_Only_Board_No_Pname) {
@@ -2449,10 +2450,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_DefaultFile1) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/empty/project.Debug.cprj",
-    testinput_folder + "/TestDefault/ref/empty/project.Debug.cprj");
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/empty/project.Release.cprj",
-    testinput_folder + "/TestDefault/ref/empty/project.Release.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/empty/project.Debug+TEST_TARGET.cprj",
+    testinput_folder + "/TestDefault/ref/empty/project.Debug+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/empty/project.Release+TEST_TARGET.cprj",
+    testinput_folder + "/TestDefault/ref/empty/project.Release+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgrSolution_DefaultFile2) {
@@ -2469,10 +2470,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_DefaultFile2) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/full/project.Debug.cprj",
-    testinput_folder + "/TestDefault/ref/full/project.Debug.cprj");
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/full/project.Release.cprj",
-    testinput_folder + "/TestDefault/ref/full/project.Release.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/full/project.Debug+TEST_TARGET.cprj",
+    testinput_folder + "/TestDefault/ref/full/project.Debug+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/full/project.Release+TEST_TARGET.cprj",
+    testinput_folder + "/TestDefault/ref/full/project.Release+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgrSolution_DefaultFileInCompilerRoot) {
@@ -2492,10 +2493,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_DefaultFileInCompilerRoot) {
   // Check generated cbuild YMLs
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/empty/empty.cbuild-idx.yml",
     testinput_folder + "/TestDefault/ref/empty/empty.cbuild-idx.yml");
-  ProjMgrTestEnv::CompareFile(testoutput_folder + "/empty/project.Debug.cbuild.yml",
-    testinput_folder + "/TestDefault/ref/empty/project.Debug.cbuild.yml");
-  ProjMgrTestEnv::CompareFile(testoutput_folder + "/empty/project.Release.cbuild.yml",
-    testinput_folder + "/TestDefault/ref/empty/project.Release.cbuild.yml");
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/empty/project.Debug+TEST_TARGET.cbuild.yml",
+    testinput_folder + "/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml");
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/empty/project.Release+TEST_TARGET.cbuild.yml",
+    testinput_folder + "/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml");
 
   RteFsUtils::MoveExistingFile(cdefaultInCompilerRoot, cdefault);
 }
@@ -2521,8 +2522,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_NoUpdateRTEFiles) {
   EXPECT_EQ(rteFilesBefore, rteFilesAfter);
 
   // CPRJ should still be generated
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test.cprj",
-    testinput_folder + "/TestSolution/TestProject4/test.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/test+TEST_TARGET.cprj",
+    testinput_folder + "/TestSolution/TestProject4/test+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, LoadPacks_MultiplePackSelection) {
@@ -2697,10 +2698,10 @@ TEST_F(ProjMgrUnitTests, ProjectSetup) {
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
 
   // Check generated CPRJs
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/setup-test.Build AC6.cprj",
-    testinput_folder + "/TestProjectSetup/ref/setup-test.Build AC6.cprj");
- ProjMgrTestEnv:: CompareFile(testoutput_folder + "/setup-test.Build GCC.cprj",
-    testinput_folder + "/TestProjectSetup/ref/setup-test.Build GCC.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/setup-test.Build AC6+TEST_TARGET.cprj",
+    testinput_folder + "/TestProjectSetup/ref/setup-test.Build AC6+TEST_TARGET.cprj");
+ ProjMgrTestEnv:: CompareFile(testoutput_folder + "/setup-test.Build GCC+TEST_TARGET.cprj",
+    testinput_folder + "/TestProjectSetup/ref/setup-test.Build GCC+TEST_TARGET.cprj");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_help) {


### PR DESCRIPTION
changed `target-types`  and `projects` node to **required** properties as per [specs](https://github.com/Open-CMSIS-Pack/devtools/blob/main/tools/projmgr/docs/Manual/YML-Input-Format.md#solution)