### PR TITLE
Add initial support for <licenseSet> elements to RTE model (#593)

### DIFF
--- a/libs/rtemodel/include/RteItem.h
+++ b/libs/rtemodel/include/RteItem.h
@@ -749,6 +749,12 @@ public:
   virtual RteCondition* GetCondition(const std::string& id) const;
 
   /**
+   * @brief get license set associated with the item
+   * @return pointer to RteItem if found, nullptr otherwise
+  */
+  virtual RteItem* GetLicenseSet() const;
+
+  /**
    * @brief check if item is associated with a condition that depends on selected device
    * @return true if item's condition depends on selected device
   */
@@ -787,11 +793,18 @@ public:
  * @return value of device attribute "remove" as boolean
 */
   virtual bool IsRemove() const { return GetAttributeAsBool("remove"); }
+
   /**
-   * @brief determine value of device attribute "default" as boolean
-   * @return value of device attribute "default" as boolean
+   * @brief determine value of attribute "default" as boolean
+   * @return value of attribute "default" as boolean
   */
   virtual bool IsDefault() const { return GetAttributeAsBool("default"); }
+
+  /**
+   * @brief find child with attribute "default" set to true
+   * @return pointer to RteItem if found, nullptr otherwise
+  */
+  virtual RteItem* GetDefaultChild() const;
 
   /**
  * @brief evaluate attribute "isDefaultVariant"

--- a/libs/rtemodel/include/RtePackage.h
+++ b/libs/rtemodel/include/RtePackage.h
@@ -44,7 +44,6 @@ public:
   void Construct() override;
 };
 
-
 class RteGenerator;
 class RteDeviceFamilyContainer;
 
@@ -204,6 +203,12 @@ public:
    * @return pointer to RteItem representing container for releases
   */
   RteItem* GetReleases() const { return m_releases; }
+
+  /**
+   * @brief get <licensSets> element
+   * @return pointer to RteItem representing container for license sets
+  */
+  RteItem* GetLicenseSets() const { return m_licenseSets; }
 
   /**
    * @brief get <requirements> element
@@ -465,6 +470,19 @@ public:
   */
    std::string GetDownloadUrl(bool withVersion, const char* extension) const override;
 
+   /**
+    * @brief get license set with given ID
+    * @param id license set ID to search for
+    * @return pointer to RteItem if found, nullptr otherwise
+   */
+   RteItem* GetLicenseSet(const std::string& id) const;
+
+   /**
+    * @brief get default license set for the package items
+    * @return pointer to RteItem if found, nullptr otherwise
+   */
+   RteItem* GetDefaultLicenseSet() const;
+
   /**
    * @brief get condition with specified ID
    * @param id condition ID to search for
@@ -566,6 +584,7 @@ private:
   int m_nDominating;      // pack dominating flag (-1 if not set)
   int m_nDeprecated;      // pack deprecation flag (-1 if not set)
   RteItem* m_releases;    // <releases> element
+  RteItem* m_licenseSets; // <licenseSets> element
   RteItem* m_conditions;  // <conditions> element
   RteItem* m_components;  // <components> element
   RteItem* m_apis;        // <apis> element

--- a/libs/rtemodel/src/RteItem.cpp
+++ b/libs/rtemodel/src/RteItem.cpp
@@ -399,7 +399,11 @@ void RteItem::RemoveItem(RteItem* item)
 
 string RteItem::ConstructID()
 {
-  string id = GetName();
+  string id = GetAttribute("id");
+  if (!id.empty()) {
+    return id;
+  }
+  id = GetName();
   if (!GetVersionString().empty()) {
     id += ".";
     id += GetVersionString();
@@ -818,6 +822,25 @@ RteCondition* RteItem::GetCondition(const string& id) const
   return nullptr;
 }
 
+RteItem* RteItem::GetLicenseSet() const
+{
+  RtePackage* pack = GetPackage();
+  if(pack) {
+    return pack->GetLicenseSet(GetAttribute("licenseSet"));
+  }
+  return nullptr;
+}
+
+RteItem* RteItem::GetDefaultChild() const
+{
+  for (auto item : GetChildren()) {
+    if (item->IsDefault()) {
+      return item;
+    }
+  }
+  return nullptr;
+}
+
 bool RteItem::IsDeviceDependent() const
 {
   RteCondition *condition = GetCondition();
@@ -829,7 +852,6 @@ bool RteItem::IsBoardDependent() const
   RteCondition* condition = GetCondition();
   return condition && condition->IsBoardDependent();
 }
-
 
 RteItem::ConditionResult RteItem::Evaluate(RteConditionContext* context)
 {

--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -51,6 +51,7 @@ RtePackage::RtePackage(RteItem* parent, PackageState ps) :
   m_nDominating(-1),
   m_nDeprecated(-1),
   m_releases(0),
+  m_licenseSets(0),
   m_conditions(0),
   m_components(0),
   m_apis(0),
@@ -69,6 +70,7 @@ RtePackage::RtePackage(RteItem* parent, const map<string, string>& attributes) :
   m_nDominating(-1),
   m_nDeprecated(-1),
   m_releases(0),
+  m_licenseSets(0),
   m_conditions(0),
   m_components(0),
   m_apis(0),
@@ -93,6 +95,7 @@ void RtePackage::Clear()
 {
   m_nDeprecated = -1;
   m_releases = 0;
+  m_licenseSets = 0;
   m_components = 0;
   m_requirements = 0,
   m_conditions = 0;
@@ -549,6 +552,25 @@ RteComponent* RtePackage::GetComponent(const string& id) const
 }
 
 
+RteItem* RtePackage::GetLicenseSet(const string& id) const
+{
+  if (m_licenseSets) {
+    if (id.empty()) {
+      return GetDefaultLicenseSet();
+    }
+    return m_licenseSets->GetItem(id);
+  }
+  return nullptr;
+}
+
+RteItem* RtePackage::GetDefaultLicenseSet() const
+{
+  if (m_licenseSets) {
+    return m_licenseSets->GetDefaultChild();
+  }
+  return nullptr;
+}
+
 RteCondition* RtePackage::GetCondition(const string& id) const
 {
   if (m_conditions)
@@ -621,6 +643,9 @@ RteItem* RtePackage::CreateItem(const std::string& tag)
   } else if (tag == "conditions") {
       m_conditions = new RteConditionContainer(this);
     return m_conditions;
+  } else if (tag == "liceseSets") {
+    m_licenseSets = new RteItem(this);
+    return m_licenseSets;
   } else if (tag == "releases") {
       m_releases = new RteReleaseContainer(this);
       return m_releases;

--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -677,8 +677,20 @@ void RteTarget::CollectComponentSettings(RteComponentInstance* ci)
     if (c->IsDeviceStartup())
       m_deviceStartupComponent = c;
     const string& doc = c->GetDocFile();
-    if (!doc.empty())
+    if (!doc.empty()) {
       m_docs.insert(doc);
+    }
+    // collect license files
+    RteItem* ls = c->GetLicenseSet();
+    if (ls) {
+      for (auto lic : ls->GetChildren()) {
+        const string& licFile = lic->GetDocFile();
+        if (!licFile.empty()) {
+          m_docs.insert(licFile);
+        }
+      }
+    }
+
     CollectPreIncludeStrings(c, count);
   }
   const set<RteFile*>& files = GetFilteredFiles(c);


### PR DESCRIPTION
* Add initial support for <licenseSet> elements to RTE model

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>