### PR TITLE
Create *.cbuild-gen.yml with absolute paths

### DIFF
--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -55,7 +55,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -63,7 +63,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -71,7 +71,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -46,7 +46,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -54,7 +54,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -62,7 +62,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -52,7 +52,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -60,7 +60,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -68,7 +68,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - --foo=bar
     - generator: RteTestGeneratorWithKey
       path: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorWithKey
@@ -80,21 +80,21 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/script.sh
           arguments:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/script.sh
           arguments:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct
     regions: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/regions_RteTestGen_ARMCM0.h

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -46,7 +46,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -54,7 +54,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -62,7 +62,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -18,7 +18,7 @@ build:
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
   output-dirs:
     intdir: ../tmp/TestProject3_1/TypeA/Debug
-    outdir: outdir/
+    outdir: outdir
     rtedir: RTE
   output:
     - type: elf
@@ -75,7 +75,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -83,7 +83,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -91,7 +91,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - --foo=bar
   linker:
     script: RTE/Device/RteTestGen_ARMCM0/gcc_arm.ld


### PR DESCRIPTION
To facilitate implementation of generators, create *.cbuild-gen.yml in addition to *.cbuild.yml with any file and directory paths inside expanded to absolute paths.

The *.cbuild-gen.yml is created inside the intdir, since this resolved version is only a temporary file used by generators.

The $G parameter for generators now expands to the *.cbuild-gen.yml file.

Contributed by STMicroelectronics