### PR TITLE
Update gcc_linker_script.ld

### DIFF
--- a/tools/projmgr/templates/gcc_linker_script.ld
+++ b/tools/projmgr/templates/gcc_linker_script.ld
@@ -155,6 +155,9 @@ SECTIONS
   {
     . = ALIGN(4);
     __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG ((__bss_end__ - __bss_start__) / 4)
+
     /* Add each additional bss section here */
 /*
     LONG (__bss2_start__)


### PR DESCRIPTION
missing start and length for bss (1) in zero table.