### PR TITLE
Define $generator_id and $pack_id variables in generator arguments

### DIFF
--- a/libs/rtemodel/include/RtePackage.h
+++ b/libs/rtemodel/include/RtePackage.h
@@ -448,6 +448,12 @@ public:
   void SetPackageState(PackageState packState) { m_packState = packState; }
 
   /**
+   * @brief get full pack ID in YAML format
+   * @return full pack ID in YAML format
+   */
+  std::string GetPackYamlID() const;
+
+  /**
    * @brief get full or common pack ID
    * @param withVersion flag to return full (true) or common (false) ID
    * @return full or common pack ID depending on argument

--- a/libs/rtemodel/src/RteGenerator.cpp
+++ b/libs/rtemodel/src/RteGenerator.cpp
@@ -145,12 +145,18 @@ string RteGenerator::GetExecutable(RteTarget* target, const std::string& hostTyp
 vector<pair<string, string> > RteGenerator::GetExpandedArguments(RteTarget* target, const string& hostType) const
 {
   vector<pair<string, string> > args;
+  string packId = GetPackage()->GetPackYamlID();
+  string generatorId = GetGeneratorName();
+
   RteItem* argsItem = GetArgumentsItem("exe");
   if (argsItem) {
     for (auto arg : argsItem->GetChildren()) {
       if (arg->GetTag() != "argument" || !arg->MatchesHost(hostType))
         continue;
-      args.push_back({arg->GetAttribute("switch"), ExpandString(arg->GetText())});
+      string res = arg->GetText();
+      RteUtils::ReplaceAll(res, "$pack_id", packId);
+      RteUtils::ReplaceAll(res, "$generator_id", generatorId);
+      args.push_back({arg->GetAttribute("switch"), ExpandString(res)});
     }
   }
   return args;

--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -743,6 +743,26 @@ string RtePackage::ConstructID()
 }
 
 
+string RtePackage::GetPackYamlID() const
+{
+  string res;
+
+  const auto& vendor = GetVendorString().empty() ? "" : GetVendorString() + "::";
+  const vector<pair<const char*, const string&>> elements = {
+    {"",  vendor},
+    {"",  GetName()},
+    {"@", GetVersionString()},
+  };
+
+  for (const auto& element : elements) {
+    if (!element.second.empty()) {
+      res += element.first + element.second;
+    }
+  }
+  return res;
+}
+
+
 string RtePackage::GetPackageID(bool withVersion) const
 {
   if (withVersion)

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -478,12 +478,13 @@
       "description": "General generator info",
       "type": "object",
       "properties": {
+        "from-pack": { "$ref": "#/definitions/PackID"},
         "generator": { "type": "string", "description": "Section for a specific generator" },
         "path":      { "type": "string", "description": "Path name for storing the files generated" },
         "gpdsc":     { "type": "string", "description": "File name of the *.GDPSC file that stores the information in path" },
         "command":   { "$ref": "#/definitions/CommandType" }
       },
-      "required": [ "generator", "path", "gpdsc", "command" ]
+      "required": [ "generator", "from-pack", "path", "gpdsc", "command" ]
     },
     "CommandType": {
       "type": "object",
@@ -515,9 +516,10 @@
       "type": "object",
       "properties": {
         "id": { "type": "string" },
+        "from-pack": { "$ref": "#/definitions/PackID"},
         "files": { "$ref": "#/definitions/FilesType" }
       },
-      "required": [ "id" ]
+      "required": [ "id", "from-pack" ]
     },
     "ComponentID": {
       "type": "string",

--- a/tools/projmgr/src/ProjMgrYamlEmitter.cpp
+++ b/tools/projmgr/src/ProjMgrYamlEmitter.cpp
@@ -157,8 +157,16 @@ void ProjMgrYamlCbuild::SetComponentsNode(YAML::Node node, const ContextItem* co
     }
     SetControlsNode(componentNode, componentItem->build);
     SetComponentFilesNode(componentNode[YAML_FILES], context, componentId);
-    SetNodeValue(componentNode[YAML_GENERATOR][YAML_ID], component.generator);
-    SetGeneratorFiles(componentNode[YAML_GENERATOR], context, componentId);
+    if (!component.generator.empty()) {
+      if (context->generators.find(component.generator) != context->generators.end()) {
+        const RteGenerator* rteGenerator = context->generators.at(component.generator);
+        SetNodeValue(componentNode[YAML_GENERATOR][YAML_ID], component.generator);
+        SetNodeValue(componentNode[YAML_GENERATOR][YAML_FROM_PACK], rteGenerator->GetPackage()->GetPackYamlID());
+        SetGeneratorFiles(componentNode[YAML_GENERATOR], context, componentId);
+      } else {
+        ProjMgrLogger::Warn(string("Component ") + componentId + " uses unknown generator " + component.generator);
+      }
+    }
     node.push_back(componentNode);
   }
 }
@@ -204,6 +212,7 @@ void ProjMgrYamlCbuild::SetGeneratorsNode(YAML::Node node, const ContextItem* co
         break;
       }
     }
+    SetNodeValue(genNode[YAML_FROM_PACK], generator->GetPackage()->GetPackYamlID());
     SetNodeValue(genNode[YAML_PATH], FormatPath(workingDir, context->directories.cprj));
     SetNodeValue(genNode[YAML_GPDSC], FormatPath(gpdscFile, context->directories.cprj));
 

--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -30,6 +30,7 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
         files:
           - file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Templates/RteTestGen.c.template
             category: genSource
@@ -46,6 +47,7 @@ build:
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/MultipleComponents/RteTestGeneratorIdentifier
       gpdsc: ../data/TestGenerator/MultipleComponents/RteTestGeneratorIdentifier/RteTestGen_ARMCM0/RteTest.gpdsc
       command:

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -31,12 +31,14 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/layer/RTE/Device
       gpdsc: ../data/TestGenerator/layer/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
       command:

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -31,18 +31,21 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::Device:RteTest Generated Component:RteTestWithKey@1.1.0
       condition: RteDevice
       from-pack: ARM::RteTestGenerator@0.1.0
       selected-by: Device:RteTest Generated Component:RteTestWithKey
       generator:
         id: RteTestGeneratorWithKey
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorIdentifier
       gpdsc: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorIdentifier/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -71,6 +74,7 @@ build:
             - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
             - --foo=bar
     - generator: RteTestGeneratorWithKey
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorWithKey
       gpdsc: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorWithKey/RteTestGen_ARMCM0/RteTest.gpdsc
       command:

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -31,12 +31,14 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/RTE/Device
       gpdsc: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
       command:

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -29,6 +29,7 @@ build:
       selected-by: Device:RteTest Generated Component:RteTestGenFiles
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
         files:
           - file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
             category: genAsset
@@ -66,6 +67,7 @@ build:
       selected-by: CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: gendir
       gpdsc: gendir/RteTestGen_ARMCM0/RteTest.gpdsc
       command:


### PR DESCRIPTION
$generator_id resolves to the current generator id
$pack_id resolves to the current pack id in YAML format

Also, add from-pack property on the generator nodes in the cbuild.yml to identify what pack the generator is defined in. This resolves potential conflicts when using generators from multiple packs that has the same name.

Contributed by STMicroelectronics