### PR TITLE
Support dry-running generators

### DIFF
--- a/libs/rtemodel/include/RteGenerator.h
+++ b/libs/rtemodel/include/RteGenerator.h
@@ -130,17 +130,19 @@ public:
  * @brief get all arguments as vector for the given host type
  * @param target pointer to RteTarget
  * @param hostType host type, empty to match current host
+ * @param dryRun include dry-run arguments
  * @return vector of arguments consisting of switch and value in pairs
 */
-  std::vector<std::pair<std::string, std::string> > GetExpandedArguments(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
+  std::vector<std::pair<std::string, std::string> > GetExpandedArguments(RteTarget* target, const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
 
  /**
    * @brief get full command line with arguments and expanded key sequences for specified target
    * @param target pointer to RteTarget
    * @param hostType host type, empty to match current host
+   * @param dryRun include dry-run arguments
    * @return expanded command line with arguments, properly quoted
   */
-  std::string GetExpandedCommandLine(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
+  std::string GetExpandedCommandLine(RteTarget* target, const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
 
   /**
    * @brief get absolute path to gpdsc file for specified target
@@ -207,6 +209,13 @@ public:
    * @return pointer to instance of type RteItem
   */
   RteItem* CreateItem(const std::string& tag) override;
+
+ /**
+  * @brief check whether the generator can be run in dry-run mode
+  * @param hostType host type, empty to match current host
+  * @return true if the generator is dry-run capable, false otherwise
+  */
+  bool IsDryRunCapable(const std::string& hostType = EMPTY_STRING) const;
 
 protected:
   /**

--- a/libs/rtemodel/test/src/RteChkTest.cpp
+++ b/libs/rtemodel/test/src/RteChkTest.cpp
@@ -30,9 +30,9 @@ Generic: 1\n\
 DFP: 3\n\
 BSP: 1\n\
 \n\
-Components: 51\n\
+Components: 52\n\
 From generic packs: 31\n\
-From DFP: 20\n\
+From DFP: 21\n\
 From BSP: 0\n\
 \n\
 Devices: 10\n\
@@ -51,7 +51,7 @@ completed\n";
   int res = rteChk.RunCheckRte();
   EXPECT_EQ(res, 0);
   EXPECT_EQ(rteChk.GetPackCount(), 5);
-  EXPECT_EQ(rteChk.GetComponentCount(), 51);
+  EXPECT_EQ(rteChk.GetComponentCount(), 52);
   EXPECT_EQ(rteChk.GetDeviceCount(), 10);
   EXPECT_EQ(rteChk.GetBoardCount(), 13);
 

--- a/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
@@ -53,6 +53,7 @@
         <argument>$S</argument>
         <!-- absolute path to the generator input file -->
         <argument>$G</argument>
+        <argument mode="dry-run">--dry-run</argument>
         <argument host="win" switch="/foo=">bar</argument>
         <argument host="linux" switch="--foo=">bar</argument>
         <argument host="mac" switch="--foo=">bar</argument>
@@ -91,6 +92,29 @@
       <workingDir>$PRTE/Device</workingDir>
       <exe>
       <command>Generator/noexe.sh</command>
+        <!-- path is specified either absolute or relative to PDSC or GPDSC file. If not specified it is the project directory configured by the environment -->
+        <!-- D = Device (Dname/Dvariant as configured by environment) -->
+        <argument>$D</argument>
+        <!-- Project path and project name (as configured by environment) -->
+        <argument>#P</argument>
+        <!-- absolute or relative to workingDir. $S = Device Family Pack base folder -->
+        <argument>$S</argument>
+        <!-- absolute path to the generator input file -->
+        <argument>$G</argument>
+      </exe>
+      <!-- path is either absolute or relative to working directory -->
+      <gpdsc name="$PRTE/Device/$D/RteTest.gpdsc"/>
+    </generator>
+
+    <!-- This generator is for testing of dry-running without "dry-run" support -->
+    <generator id="RteTestGeneratorNoDryRun">
+      <description>RteTest Generator Description</description>
+      <!-- path is specified either absolute or relative to PDSC or GPDSC file -->
+      <workingDir>$PRTE/Device</workingDir>
+      <exe>
+      <command host="win">Generator/script.bat</command>
+      <command host="linux">Generator/script.sh</command>
+      <command host="mac">Generator/script.sh</command>
         <!-- path is specified either absolute or relative to PDSC or GPDSC file. If not specified it is the project directory configured by the environment -->
         <!-- D = Device (Dname/Dvariant as configured by environment) -->
         <argument>$D</argument>
@@ -156,6 +180,9 @@
       <files>
         <file category="genAsset" name="Templates/RteTest.gpdsc.template" version ="1.0.0"/>
       </files>
+    </component>
+    <component generator="RteTestGeneratorNoDryRun" Cclass="Device" Cgroup="RteTest Generated Component" Csub="RteTestNoDryRun" Cversion="1.1.0">
+      <description>Configuration via RteTest script</description>
     </component>
     <bundle Cbundle="RteTestBundle" Cclass="Device" Cversion="1.0.0">
       <component generator="RteTestGeneratorIdentifier" Cgroup="RteTest Generated Component" Cversion="1.1.0">

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.bat
@@ -3,7 +3,14 @@ echo %1
 echo %2 
 echo %3
 echo %4
+echo %5
 
-mkdir %1
-copy "%3\Templates\RteTest.gpdsc.template" "%1\RteTest.gpdsc"
-copy "%3\Templates\RteTest_Generated_Component.c.template" "%1\RteTest_Generated_Component.c"
+if "%5" == "--dry-run" (
+  echo -----BEGIN GPDSC-----
+  type "%3\Templates\RteTest.gpdsc.template"
+  echo -----END GPDSC-----
+) else (
+  mkdir %1
+  copy "%3\Templates\RteTest.gpdsc.template" "%1\RteTest.gpdsc"
+  copy "%3\Templates\RteTest_Generated_Component.c.template" "%1\RteTest_Generated_Component.c"
+)

--- a/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -3,7 +3,14 @@ echo $1
 echo $2 
 echo $3
 echo $4
+echo $5
 
-mkdir $1
-cp "$3/Templates/RteTest.gpdsc.template" "$1/RteTest.gpdsc"
-cp "$3/Templates/RteTest_Generated_Component.c.template" "$1/RteTest_Generated_Component.c"
+if [ "$5" = "--dry-run" ]; then
+  echo "-----BEGIN GPDSC-----"
+  cat "$3/Templates/RteTest.gpdsc.template"
+  echo "-----END GPDSC-----"
+else
+  mkdir $1
+  cp "$3/Templates/RteTest.gpdsc.template" "$1/RteTest.gpdsc"
+  cp "$3/Templates/RteTest_Generated_Component.c.template" "$1/RteTest_Generated_Component.c"
+fi

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -108,6 +108,7 @@ protected:
   bool m_updateRteFiles;
   bool m_verbose;
   bool m_debug;
+  bool m_dryRun;
   bool m_ymlOrder;
   GroupNode m_files;
   std::vector<ContextItem*> m_processedContexts;

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -482,6 +482,12 @@ public:
   void SetDebug(bool debug);
 
   /**
+   * @brief set dry-run mode
+   * @param boolean dryRun
+  */
+  void SetDryRun(bool dryRun);
+
+  /**
    * @brief set load packs policy
    * @param reference to load packs policy
   */
@@ -562,6 +568,7 @@ protected:
   bool m_checkSchema;
   bool m_verbose;
   bool m_debug;
+  bool m_dryRun;
 
   bool LoadPacks(ContextItem& context);
   bool GetRequiredPdscFiles(ContextItem& context, const std::string& packRoot, std::set<std::string>& errMsgs);

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -38,6 +38,7 @@ Commands:\n\
 Options:\n\
   -c, --context arg [...]  Input context names [<project-name>][.<build-type>][+<target-type>]\n\
   -d, --debug              Enable debug messages\n\
+  -D, --dry-run            Enable dry-run\n\
   -e, --export arg         Set suffix for exporting <context><suffix>.cprj retaining only specified versions\n\
   -f, --filter arg         Filter words\n\
   -g, --generator arg      Code generator identifier\n\
@@ -130,6 +131,7 @@ int ProjMgr::RunProjMgr(int argc, char **argv, char** envp) {
   cxxopts::Option version("V,version", "Print version");
   cxxopts::Option verbose("v,verbose", "Enable verbose messages", cxxopts::value<bool>()->default_value("false"));
   cxxopts::Option debug("d,debug", "Enable debug messages", cxxopts::value<bool>()->default_value("false"));
+  cxxopts::Option dryRun("D,dry-run", "Enable dry-run", cxxopts::value<bool>()->default_value("false"));
   cxxopts::Option exportSuffix("e,export", "Set suffix for exporting <context><suffix>.cprj retaining only specified versions", cxxopts::value<string>());
   cxxopts::Option toolchain("t,toolchain","Selection of the toolchain used in the project optionally with version", cxxopts::value<string>());
   cxxopts::Option ymlOrder("yml-order", "Preserve order as specified in input yml", cxxopts::value<bool>()->default_value("false"));
@@ -139,7 +141,7 @@ int ProjMgr::RunProjMgr(int argc, char **argv, char** envp) {
     // command, optional args, options
     {"update-rte",        { false, {context, debug, load, schemaCheck, toolchain, verbose}}},
     {"convert",           { false, {context, debug, exportSuffix, load, schemaCheck, noUpdateRte, output, toolchain, verbose}}},
-    {"run",               { false, {context, debug, generator, load, schemaCheck, verbose}}},
+    {"run",               { false, {context, debug, generator, load, schemaCheck, verbose, dryRun}}},
     {"list packs",        { true,  {context, debug, filter, load, missing, schemaCheck, toolchain, verbose}}},
     {"list boards",       { true,  {context, debug, filter, load, schemaCheck, toolchain, verbose}}},
     {"list devices",      { true,  {context, debug, filter, load, schemaCheck, toolchain, verbose}}},
@@ -157,7 +159,7 @@ int ProjMgr::RunProjMgr(int argc, char **argv, char** envp) {
       {"positional", "", cxxopts::value<vector<string>>()},
       solution, context, filter, generator,
       load, clayerSearchPath, missing, schemaCheck, noUpdateRte, output,
-      help, version, verbose, debug, exportSuffix, toolchain, ymlOrder
+      help, version, verbose, debug, dryRun, exportSuffix, toolchain, ymlOrder
     });
     options.parse_positional({ "positional" });
 
@@ -169,7 +171,9 @@ int ProjMgr::RunProjMgr(int argc, char **argv, char** envp) {
     manager.m_verbose = parseResult.count("v");
     manager.m_worker.SetVerbose(manager.m_verbose);
     manager.m_debug = parseResult.count("d");
+    manager.m_dryRun = parseResult.count("D");
     manager.m_worker.SetDebug(manager.m_debug);
+    manager.m_worker.SetDryRun(manager.m_dryRun);
     manager.m_ymlOrder = parseResult.count("yml-order");
 
     vector<string> positionalArguments;

--- a/tools/projmgr/test/data/TestSolution/TestProject3_3/TestProject3_3.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/TestProject3_3/TestProject3_3.cproject.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  description: Project 3_3
+  components:
+    - component: Startup
+    - component: CORE
+    - component: Device:RteTest Generated Component:RteTestNoDryRun

--- a/tools/projmgr/test/data/TestSolution/gen_nodryrun.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/gen_nodryrun.csolution.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: TypeA
+      device: RteTestGen_ARMCM0
+
+  build-types:
+    - type: Debug
+      compiler: GCC@0.0.0
+
+  projects:
+    - project: ./TestProject3_3/TestProject3_3.cproject.yml
+
+  output-dirs:
+    outdir: $Project$/outdir/

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -2647,6 +2647,7 @@ TEST_F(ProjMgrUnitTests, ListComponents_MultiplePackSelection) {
     "ARM::Device&RteTestBundle:Startup@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTest@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0 (ARM::RteTestGenerator@0.1.0)",
+    "ARM::Device:RteTest Generated Component:RteTestNoDryRun@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTestSimple@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTestWithKey@1.1.0 (ARM::RteTestGenerator@0.1.0)",
     "ARM::Device:RteTest Generated Component:RteTestNoExe@1.1.0 (ARM::RteTestGenerator@0.1.0)"


### PR DESCRIPTION
Running generators in dry-run mode, expect the GPDSC content to be output to stdout. This allows consuming tools to parse the GPDSC and for example resolve dependencies without any files being updated on disk.

The csolution tool doesn't currently use the dry-run output from the generator. Since log messages from csolution and the generator also are written to stdout, the generator need to enclose the GPDSC content within special begin and end marks, so a tool running `csolution --dry-run run` has to ignore everything outside those marks.

Begin and end marks are currently not fixed, but would preferably be chosen to be consistent to avoid surprises.

Suggested begin mark: -----BEGIN GPDSC-----
Suggested end mark:   -----END GPDSC-----

Contributes to [#206](https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/issues/206). Support for `additionalInputs` is left for later.

Spec update: https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/pull/242

Contributed by STMicroelectronics