### PR TITLE
Fix crash when same pack is located on 2 paths

### DIFF
--- a/tools/projmgr/src/ProjMgrKernel.cpp
+++ b/tools/projmgr/src/ProjMgrKernel.cpp
@@ -127,6 +127,11 @@ bool ProjMgrKernel::LoadAndInsertPacks(std::list<RtePackage*>& packs, std::list<
   }
 
   globalModel->InsertPacks(newPacks);
-  packs.insert(packs.end(), newPacks.begin(), newPacks.end());
+
+  // Track only packs that were actually inserted into the model
+  packs.clear();
+  for (const auto& [_, pack] : globalModel->GetPackages()) {
+    packs.push_back(pack);
+  }
   return true;
 }

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -498,6 +498,30 @@ TEST_F(ProjMgrWorkerUnitTests, LoadDuplicatePacks) {
   EXPECT_EQ("ARM.RteTest_DFP.0.2.0", (*m_loadedPacks.begin())->GetPackageID());
 }
 
+TEST_F(ProjMgrWorkerUnitTests, LoadDuplicatePacksFromDifferentPaths) {
+  std::list<std::string> pdscFiles = { // Important that these 2 files contain the *same* vendor/name/version!
+    testcmsispack_folder + "/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc",
+    testinput_folder + "/SolutionSpecificPack/ARM.RteTest_DFP.pdsc"
+  };
+
+  m_kernel = ProjMgrKernel::Get();
+  ASSERT_TRUE(m_kernel);
+  m_model = m_kernel->GetGlobalModel();
+  ASSERT_TRUE(m_kernel);
+
+  EXPECT_TRUE(m_kernel->LoadAndInsertPacks(m_loadedPacks, pdscFiles));
+
+  // Check if only one pack is loaded
+  ASSERT_EQ(1, m_loadedPacks.size());
+  EXPECT_EQ("ARM.RteTest_DFP.0.2.0", (*m_loadedPacks.begin())->GetPackageID());
+
+  // Check that warning is issued
+  EXPECT_FALSE(m_model->Validate());
+  const auto& errors = m_model->GetErrors();
+  EXPECT_EQ(errors.size(), 1);
+  EXPECT_NE(string::npos, errors.front().find("warning #500:"));
+}
+
 TEST_F(ProjMgrWorkerUnitTests, LoadRequiredPacks) {
   CsolutionItem csolution;
   SetCsolutionPacks(&csolution, { "ARM::RteTest_DFP@0.2.0"}, "Test");


### PR DESCRIPTION
Scenario:
csolution.yml:
```yml
packs:
  - pack: ARM::CMSIS@5.9.0
    path: ./ARM.CMSIS.5.9.0/
```

cproject.yml:
```yml
packs:
  - pack: ARM.CMSIS@5.9.0
```

In the above scenario, the same pack is defined on 2 different paths. The one in the csolution.yml is a project local path, and for the cproject.yml, it can be found in the $CMSIS_PACK_ROOT.

As the RteModel does not allow "duplicates", the RtePackage pointer, for the second pdsc file to be loaded, will be released when calling RteModel->Validate() and thus, only instances that is known by the model should be contained in m_loadedPacks in the ProjMgrWorker instance.

Contributed by STMicroelectronics