### PR TITLE
Add missing includes

### DIFF
--- a/tools/packchk/include/PackOptions.h
+++ b/tools/packchk/include/PackOptions.h
@@ -7,6 +7,7 @@
 #ifndef PACKOPTIONS_H
 #define PACKOPTIONS_H
 
+#include <cstdint>
 #include <string>
 #include <set>
 

--- a/tools/svdconv/SVDConv/include/SvdOptions.h
+++ b/tools/svdconv/SVDConv/include/SvdOptions.h
@@ -7,6 +7,7 @@
 #ifndef SvdOptions_H
 #define SvdOptions_H
 
+#include <cstdint>
 #include <string>
 #include <set>
 

--- a/tools/svdconv/SVDModel/include/SvdTypes.h
+++ b/tools/svdconv/SVDModel/include/SvdTypes.h
@@ -6,6 +6,7 @@
 #ifndef SvdTypes_H
 #define SvdTypes_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <set>

--- a/tools/svdconv/SVDModel/include/SvdUtils.h
+++ b/tools/svdconv/SVDModel/include/SvdUtils.h
@@ -6,6 +6,7 @@
 #ifndef SvdUtils_H
 #define SvdUtils_H
 
+#include <cstdint>
 #include <string>
 #include <list>
 #include <set>


### PR DESCRIPTION
Using integer types with specific width requirements requires such as `uint32_t` requires including `<cstdint>`.