### PR TITLE
[projmgr] Update `list layers` behaviour: consider layer type optional by default

### DIFF
--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -188,11 +188,13 @@ struct GeneratorsItem {
  * @brief layer item containing
  *        layer name,
  *        layer type,
+ *        optional flag,
  *        type inclusion
 */
 struct LayerItem {
   std::string layer;
   std::string type;
+  bool optional;
   TypeFilter typeFilter;
 };
 

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -649,7 +649,7 @@ protected:
   bool DiscoverMatchingLayers(ContextItem& context, const std::string& clayerSearchPath);
   void CollectConnections(ContextItem& context, ConnectionsCollectionVec& connections);
   void GetConsumesProvides(const ConnectionsCollectionVec& collection, ConnectionsList& connections);
-  ConnectionsCollectionMap ClassifyConnections(const ConnectionsCollectionVec& connections);
+  ConnectionsCollectionMap ClassifyConnections(const ConnectionsCollectionVec& connections, std::map<std::string, bool> optionalTypeFlags);
   ConnectionsValidationResult ValidateConnections(ConnectionsCollectionVec combination);
   void GetAllCombinations(const ConnectionsCollectionMap& src, const ConnectionsCollectionMap::iterator& it,
     std::vector<ConnectionsCollectionVec>& combinations, const ConnectionsCollectionVec& previous = ConnectionsCollectionVec());

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -92,6 +92,7 @@ static constexpr const char* YAML_MISC_LINK_C = "Link-C";
 static constexpr const char* YAML_MISC_LINK_CPP = "Link-CPP";
 static constexpr const char* YAML_NOTFORCONTEXT = "not-for-context";
 static constexpr const char* YAML_OPTIMIZE = "optimize";
+static constexpr const char* YAML_OPTIONAL = "optional";
 static constexpr const char* YAML_OPTIONS = "options";
 static constexpr const char* YAML_OUTPUT = "output";
 static constexpr const char* YAML_OUTPUTDIRS = "output-dirs";
@@ -181,6 +182,7 @@ protected:
   void ParseDefine(const YAML::Node& parent, std::vector<std::string>& define);
   void ParsePacks(const YAML::Node& parent, const std::string& file, std::vector<PackItem>& packs);
   void ParseProcessor(const YAML::Node& parent, ProcessorItem& processor);
+  void ParseBoolean(const YAML::Node& parent, const std::string& key, bool& value, bool def);
   void ParseString(const YAML::Node& parent, const std::string& key, std::string& value);
   void ParseVector(const YAML::Node& parent, const std::string& key, std::vector<std::string>& value);
   void ParseVectorOfStringPairs(const YAML::Node& parent, const std::string& key, std::vector<std::pair<std::string, std::string>>& value);

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -633,13 +633,17 @@
           "type": "string",
           "description": "Layer type for compatible layers matching"
         },
+        "optional": {
+          "type": "boolean",
+          "description": "Set optional to 'false' to require the layer type when searching compatible layers; default: 'true'"
+        },
         "for-context":     { "$ref": "#/definitions/ForContext" },
         "not-for-context": { "$ref": "#/definitions/NotForContext" }
       },
       "allOf": [
         { "$ref": "#/definitions/TypeListMutualExclusion" },
         { "anyOf": [
-            { "required": ["layer"] },
+            { "required": ["layer"], "not": {"required": ["optional"]} },
             { "required": ["type"]  }
           ]
         }

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -266,6 +266,15 @@ void ProjMgrYamlParser::ParsePortablePaths(const YAML::Node& parent, const strin
   }
 }
 
+void ProjMgrYamlParser::ParseBoolean(const YAML::Node& parent, const string& key, bool& value, bool def) {
+  if (parent[key].IsDefined()) {
+    value = parent[key].as<bool>();
+    if (parent[key].Type() == YAML::NodeType::Null) {
+      value = def;
+    }
+  }
+}
+
 void ProjMgrYamlParser::ParseString(const YAML::Node& parent, const string& key, string& value) {
   if (parent[key].IsDefined()) {
     value = parent[key].as<string>();
@@ -533,6 +542,7 @@ bool ProjMgrYamlParser::ParseLayers(const YAML::Node& parent, const string& file
       }
       ParsePortablePath(layerEntry, file, YAML_LAYER, layerItem.layer);
       ParseString(layerEntry, YAML_TYPE, layerItem.type);
+      ParseBoolean(layerEntry, YAML_OPTIONAL, layerItem.optional, true);
       layers.push_back(layerItem);
     }
   }
@@ -976,6 +986,7 @@ const set<string> linkerKeys = {
 const set<string> layersKeys = {
   YAML_LAYER,
   YAML_TYPE,
+  YAML_OPTIONAL,
   YAML_FORCONTEXT,
   YAML_NOTFORCONTEXT,
 };

--- a/tools/projmgr/test/data/TestLayers/genericlayers.cproject.yml
+++ b/tools/projmgr/test/data/TestLayers/genericlayers.cproject.yml
@@ -5,14 +5,23 @@ project:
 
   layers:
     - type: Board
+      optional: false
+      not-for-context: .OptionalLayerType
     - type: TestVariant
+      optional: false
       for-context: .CompatibleLayers
     - type: Incompatible
+      optional: false
       for-context: .IncompatibleLayers
     - type: UnknownType
+      optional: false
       for-context: .IncompatibleLayers
     - type: PdscType
+      optional: false
       for-context: .IncompatibleLayers
+    - type: Board
+      optional: true
+      for-context: .OptionalLayerType
 
   connections:
     - connect: Project Connections

--- a/tools/projmgr/test/data/TestLayers/genericlayers.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/genericlayers.csolution.yml
@@ -5,7 +5,7 @@ solution:
   build-types:
     - type: CompatibleLayers
     - type: IncompatibleLayers
-    - type: PdscTypeMismatch
+    - type: OptionalLayerType
 
   target-types:
     - type: Board3

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1097,6 +1097,44 @@ no valid combination of clayers was found\n\
   EXPECT_TRUE(regex_match(outStr, regex(expectedOutStr)));
 }
 
+TEST_F(ProjMgrUnitTests, ListLayersOptionalLayerType) {
+  StdStreamRedirect streamRedirect;
+  char* argv[8];
+  const string& csolution = testinput_folder + "/TestLayers/genericlayers.csolution.yml";
+  const string& context = "genericlayers.OptionalLayerType+AnyBoard";
+  argv[1] = (char*)"list";
+  argv[2] = (char*)"layers";
+  argv[3] = (char*)"--solution";
+  argv[4] = (char*)csolution.c_str();
+  argv[5] = (char*)"-c";
+  argv[6] = (char*)context.c_str();
+  argv[7] = (char*)"-d";
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+
+  const string& expected ="\
+check combined connections:\n\
+  .*/TestLayers/genericlayers.cproject.yml\n\
+    \\(Project Connections\\)\n\
+provided combined connections not consumed:\n\
+  .*/TestLayers/genericlayers.cproject.yml\n\
+    ExactMatch\n\
+    EmptyConsumedValue\n\
+    EmptyValues\n\
+    AddedValueLessThanProvided\n\
+    AddedValueEqualToProvided\n\
+    MultipleProvided\n\
+    MultipleProvidedNonIdentical0\n\
+    MultipleProvidedNonIdentical1\n\
+    ProvidedDontMatch\n\
+    ProvidedEmpty\n\
+    AddedValueHigherThanProvided\n\
+connections are invalid\n\
+";
+
+  const string& errStr = streamRedirect.GetErrorString();
+  EXPECT_TRUE(regex_search(errStr, regex(expected)));
+}
+
 TEST_F(ProjMgrUnitTests, ListLayersInvalidContext) {
   char* argv[7];
   const string& csolution = testinput_folder + "/TestLayers/genericlayers.csolution.yml";


### PR DESCRIPTION
Introduce `optional` flag when requiring layers by its `type`, default `true`.
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1092.