### PR TITLE
Update cdefault.yml

### DIFF
--- a/tools/projmgr/templates/cdefault.yml
+++ b/tools/projmgr/templates/cdefault.yml
@@ -18,6 +18,7 @@ default:
         - --entry=Reset_Handler
         - --map
         - --info summarysizes
+        - --summary_stderr
         - --diag_suppress=L6314W
 
     - for-compiler: GCC


### PR DESCRIPTION
AC6 - adding misc option `--summary_stderr` to see size info in console output e.g.
```
[6/6] Linking C executable C:\csolution-example\SimpleTrustZone\out\AVH\CM33_s.axf
Program Size: Code=996 RO-data=2040 RW-data=4 ZI-data=5352
info cbuild: build finished successfully!
```