### PR TITLE
Implement *.cbuild-gen.yml

### DIFF
--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -38,7 +38,7 @@ public:
    * @param context pointer to the context
    * @return true if executed successfully
   */
-  static bool GenerateCbuild(ContextItem* context);
+  static bool GenerateCbuild(ContextItem* context, const RteGenerator* generator = nullptr);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -32,6 +32,7 @@ static constexpr const char* YAML_CLAYER = "clayer";
 static constexpr const char* YAML_CPROJECTS = "cprojects";
 static constexpr const char* YAML_CPROJECT = "cproject";
 static constexpr const char* YAML_CSOLUTION = "csolution";
+static constexpr const char* YAML_CURRENT_GENERATOR = "current-generator";
 static constexpr const char* YAML_CONSUMES = "consumes";
 static constexpr const char* YAML_COMMAND = "command";
 static constexpr const char* YAML_COMPILER = "compiler";

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -494,12 +494,13 @@
       "description": "General generator info",
       "type": "object",
       "properties": {
+        "from-pack": { "$ref": "#/definitions/PackID" },
         "generator": { "type": "string", "description": "Section for a specific generator" },
         "path":      { "type": "string", "description": "Path name for storing the files generated" },
         "gpdsc":     { "type": "string", "description": "File name of the *.GDPSC file that stores the information in path" },
         "command":   { "$ref": "#/definitions/CommandType" }
       },
-      "required": [ "generator", "path", "gpdsc", "command" ]
+      "required": [ "generator", "from-pack", "path", "gpdsc", "command" ]
     },
     "CommandType": {
       "type": "object",
@@ -531,9 +532,10 @@
       "type": "object",
       "properties": {
         "id": { "type": "string" },
+        "from-pack": { "$ref": "#/definitions/PackID"},
         "files": { "$ref": "#/definitions/FilesType" }
       },
-      "required": [ "id" ]
+      "required": [ "id", "from-pack" ]
     },
     "ComponentID": {
       "type": "string",
@@ -735,6 +737,16 @@
         "generated-by": {
           "type": "string",
           "description": "Tool name along with version information used to generate this application"
+        },
+        "current-generator": {
+          "type": "object",
+          "description": "What generator configuration to use",
+          "prorperties": {
+            "from-pack": { "$ref": "#/definitions/PackID" },
+            "id":        { "type": "string" }
+          },
+          "additionalProperties": false,
+          "required": [ "from-pack", "id" ]
         },
         "solution": {
           "type": "string",

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3423,7 +3423,7 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
     generatorDestination += '/';
   }
 
-  if (!ProjMgrYamlEmitter::GenerateCbuild(&context)) {
+  if (!ProjMgrYamlEmitter::GenerateCbuild(&context, generator)) {
     return false;
   }
 

--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -30,6 +30,7 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
         files:
           - file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Templates/RteTestGen.c.template
             category: genSource
@@ -46,6 +47,7 @@ build:
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/MultipleComponents/RteTestGeneratorIdentifier
       gpdsc: ../data/TestGenerator/MultipleComponents/RteTestGeneratorIdentifier/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -55,7 +57,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -63,7 +65,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -71,7 +73,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../multiple-components.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/multiple-components.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/multiple-components/CM0/Debug/multiple-components.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -31,12 +31,14 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/layer/RTE/Device
       gpdsc: ../data/TestGenerator/layer/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -46,7 +48,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -54,7 +56,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -62,7 +64,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../../test-gpdsc-layer.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../../output/test-gpdsc-layer.Debug+CM0.cbuild.yml
+            - ../../../../../output/tmp/test-gpdsc-layer/CM0/Debug/test-gpdsc-layer.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -31,18 +31,21 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::Device:RteTest Generated Component:RteTestWithKey@1.1.0
       condition: RteDevice
       from-pack: ARM::RteTestGenerator@0.1.0
       selected-by: Device:RteTest Generated Component:RteTestWithKey
       generator:
         id: RteTestGeneratorWithKey
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorIdentifier
       gpdsc: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorIdentifier/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -52,7 +55,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -60,7 +63,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -68,9 +71,10 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
             - --foo=bar
     - generator: RteTestGeneratorWithKey
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorWithKey
       gpdsc: ../data/TestGenerator/GeneratedFiles/RteTestGeneratorWithKey/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -80,21 +84,21 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/script.sh
           arguments:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/script.sh
           arguments:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc-multiple-generators.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc-multiple-generators/CM0/Debug/test-gpdsc-multiple-generators.Debug+CM0.cbuild-gen.yml
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct
     regions: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/regions_RteTestGen_ARMCM0.h

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -31,12 +31,14 @@ build:
           category: sourceC
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: RteTest:CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: ../data/TestGenerator/RTE/Device
       gpdsc: ../data/TestGenerator/RTE/Device/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -46,7 +48,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -54,7 +56,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -62,7 +64,7 @@ build:
             - RteTestGen_ARMCM0
             - ../../test-gpdsc.Debug+CM0.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../../../../output/test-gpdsc.Debug+CM0.cbuild.yml
+            - ../../../../output/tmp/test-gpdsc/CM0/Debug/test-gpdsc.Debug+CM0.cbuild-gen.yml
             - --foo=bar
   linker:
     script: ${CMSIS_COMPILER_ROOT}/ac6_linker_script.sct

--- a/tools/projmgr/test/data/TestSolution/TestProject3_4/TestProject3_4.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/TestProject3_4/TestProject3_4.cproject.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.0.0/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  description: Project 3_4
+  components:
+    - component: Startup
+    - component: CORE
+    - component: Device:RteTest Generated Component:RteTestGenFiles

--- a/tools/projmgr/test/data/TestSolution/TestProject3_4/main.c
+++ b/tools/projmgr/test/data/TestSolution/TestProject3_4/main.c
@@ -1,0 +1,5 @@
+#include "RTE_Components.h"
+
+int main (void) {
+  return 1;
+}

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
@@ -1,0 +1,119 @@
+build:
+  generated-by: csolution version 2.1.0+p16-gf314eb6d
+  current-generator:
+    id: RteTestGeneratorIdentifier
+    from-pack: ARM::RteTestGenerator@0.1.0
+  solution: ${DEVTOOLS(data)}/TestSolution/genfiles.csolution.yml
+  project: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/TestProject3_1.cproject.yml
+  context: TestProject3_1.Debug+TypeA
+  compiler: GCC@0.0.0
+  device: RteTestGen_ARMCM0
+  packs:
+    - pack: ARM::RteTestGenerator@0.1.0
+      path: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0
+    - pack: ARM::RteTest_DFP@0.2.0
+      path: ${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0
+  define:
+    - _RTE_
+  add-path:
+    - ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/_Debug_TypeA
+    - ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Include
+    - ${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+  output-dirs:
+    intdir: ../tmp/TestProject3_1/TypeA/Debug
+    outdir: outdir/
+    rtedir: RTE
+  output:
+    - type: elf
+      file: TestProject3_1.elf
+  components:
+    - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
+      from-pack: ARM::RteTestGenerator@0.1.0
+      selected-by: Device:RteTest Generated Component:RteTestGenFiles
+      generator:
+        id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
+        files:
+          - file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
+            category: genAsset
+            version: 1.0.0
+          - file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Templates/RteTestGen.h.template
+            category: genHeader
+            version: 1.0.0
+          - file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Templates/RteTestGen.c.template
+            category: genSource
+            version: 1.0.0
+          - file: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/Device/RteTestGen_ARMCM0/RteTestGen.params
+            category: genParams
+            attr: config
+            version: 0.9.0
+    - component: ARM::Device:Startup&RteTest Startup@2.0.3
+      condition: ARMCM0 RteTest
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: Startup
+      files:
+        - file: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/Device/RteTestGen_ARMCM0/gcc_arm.ld
+          category: linkerScript
+          attr: config
+          version: 2.0.0
+        - file: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/Device/RteTestGen_ARMCM0/startup_ARMCM0.c
+          category: sourceC
+          attr: config
+          version: 2.0.3
+        - file: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/Device/RteTestGen_ARMCM0/system_ARMCM0.c
+          category: sourceC
+          attr: config
+          version: 1.0.0
+    - component: ARM::RteTest:CORE@0.1.1
+      condition: Cortex-M Device
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: CORE
+  generators:
+    - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
+      path: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/gendir
+      gpdsc: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/gendir/RteTestGen_ARMCM0/RteTest.gpdsc
+      command:
+        win:
+          file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Generator/script.bat
+          arguments:
+            - RteTestGen_ARMCM0
+            - ${DEVTOOLS(data)}/TestSolution/TestProject3_1/TestProject3_1.Debug+TypeA.cprj
+            - ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0
+            - ${DEVTOOLS(data)}/TestSolution/tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+            - /foo=bar
+        linux:
+          file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+          arguments:
+            - RteTestGen_ARMCM0
+            - ${DEVTOOLS(data)}/TestSolution/TestProject3_1/TestProject3_1.Debug+TypeA.cprj
+            - ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0
+            - ${DEVTOOLS(data)}/TestSolution/tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+            - --foo=bar
+        mac:
+          file: ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
+          arguments:
+            - RteTestGen_ARMCM0
+            - ${DEVTOOLS(data)}/TestSolution/TestProject3_1/TestProject3_1.Debug+TypeA.cprj
+            - ${DEVTOOLS(packs)}/ARM/RteTestGenerator/0.1.0
+            - ${DEVTOOLS(data)}/TestSolution/tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+            - --foo=bar
+  linker:
+    script: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/Device/RteTestGen_ARMCM0/gcc_arm.ld
+  constructed-files:
+    - file: ${DEVTOOLS(data)}/TestSolution/TestProject3_1/RTE/_Debug_TypeA/RTE_Components.h
+      category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -29,6 +29,7 @@ build:
       selected-by: Device:RteTest Generated Component:RteTestGenFiles
       generator:
         id: RteTestGeneratorIdentifier
+        from-pack: ARM::RteTestGenerator@0.1.0
         files:
           - file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Templates/RteTest.gpdsc.template
             category: genAsset
@@ -66,6 +67,7 @@ build:
       selected-by: CORE
   generators:
     - generator: RteTestGeneratorIdentifier
+      from-pack: ARM::RteTestGenerator@0.1.0
       path: gendir
       gpdsc: gendir/RteTestGen_ARMCM0/RteTest.gpdsc
       command:
@@ -75,7 +77,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - /foo=bar
         linux:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -83,7 +85,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - --foo=bar
         mac:
           file: ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0/Generator/script.sh
@@ -91,7 +93,7 @@ build:
             - RteTestGen_ARMCM0
             - ../TestProject3_1.Debug+TypeA.cprj
             - ${CMSIS_PACK_ROOT}/ARM/RteTestGenerator/0.1.0
-            - ../TestProject3_1.Debug+TypeA.cbuild.yml
+            - ../../tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml
             - --foo=bar
   linker:
     script: RTE/Device/RteTestGen_ARMCM0/gcc_arm.ld

--- a/tools/projmgr/test/data/TestSolution/test_fail_creating_directories.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/test_fail_creating_directories.csolution.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.0.0/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: TypeA
+      device: RteTestGen_ARMCM0
+
+  build-types:
+    - type: Debug
+      compiler: GCC@0.0.0
+
+  projects:
+    - project: ./TestProject3_4/TestProject3_4.cproject.yml
+
+  output-dirs:
+    outdir: $Project$/outdir/
+
+  generators:
+    options:
+      - generator: RteTestGeneratorIdentifier
+        path: $Project$/gendir/

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -120,7 +120,7 @@ void ProjMgrTestEnv::TearDown() {
   // Reserved
 }
 
-void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2) {
+void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2, LineReplaceFunc_t file2LineReplaceFunc) {
   ifstream f1, f2;
   string l1, l2;
   bool ret_val;
@@ -151,6 +151,10 @@ void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2) {
       l2.pop_back();
     }
 
+    if (file2LineReplaceFunc) {
+      l2 = file2LineReplaceFunc(l2);
+    }
+
     if (l1 != l2) {
       // ignore 'timestamp'
       if ((!l1.empty() && (l1.find("timestamp=") != string::npos)) && (!l2.empty() && (l2.find("timestamp=") != string::npos))) {
@@ -159,7 +163,7 @@ void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2) {
       if ((!l1.empty() && (l1.find("generated-by") != string::npos)) && (!l2.empty() && (l2.find("generated-by") != string::npos))) {
         continue;
       }
-      FAIL() << "error: " << file1 << " is different from " << file2;
+      FAIL() << "error: " << file1 << " is different from " << file2 << "\nLine1: " << l1 << "\nLine2: " << l2;
     }
   }
 

--- a/tools/projmgr/test/src/ProjMgrTestEnv.h
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.h
@@ -36,6 +36,8 @@ private:
   std::streambuf*   m_stdcerrStreamBuf;
 };
 
+typedef std::string (*LineReplaceFunc_t)(const std::string&);
+
 /**
  * @brief global test environment for all the test suites
 */
@@ -43,7 +45,7 @@ class ProjMgrTestEnv : public ::testing::Environment {
 public:
   void SetUp() override;
   void TearDown() override;
-  static void CompareFile(const std::string& file1, const std::string& file2);
+  static void CompareFile(const std::string& file1, const std::string& file2, LineReplaceFunc_t file2LineReplaceFunc = nullptr);
   static const std::string& GetCmsisPackRoot();
   static std::list<std::string> GetInstalledPdscFiles(bool bLatestsOnly = false);
   static std::string GetFilteredPacksString(const std::list<std::string>& pdscFiles, const std::string& includeIds);


### PR DESCRIPTION
To facilitate implementation of generators, create `*.cbuild-gen.yml` with:
- any file and directory paths inside expanded to `absolute paths` in cbuild-gen.yml.
- new node, `current-generator` that can be used to identify what generator node in the cbuild-gen.yml that the current invocation is for.

Both `*.cbuild.yml` and `*.cbuild-gen.yml` are created inside the `intdir`, since they are both temporary files used by generators and builders.

The `$G` parameter for generators now expands to the `*.cbuild-gen.yml` file.

In both *.cbuild.yml and *.cbuild-gen.yml, all generator nodes now also includes the `from-pack` node that defines in what pack that the generator was defined.

For more background, see [2023-08-22 Open-CMSIS-Pack meeting](https://linaro.atlassian.net/wiki/spaces/CMSIS/pages/28990341176/Open-CMSIS-Pack+Technical+Meeting+2023-08-22) and https://github.com/Open-CMSIS-Pack/devtools/pull/1007.

Example `cbuild-gen.yml`:
```yml
build:
  generated-by: csolution version 2.2.0
  current-generator:
    id: RteTestGeneratorIdentifier
    from-pack: ARM::RteTestGenerator@0.1.0
```

Example `cbuild.yml` with new `from-pack` node on `generator-nodes`:
```yml
build:
  components:
    - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
      generator:
        id: RteTestGeneratorIdentifier
        from-pack: ARM::RteTestGenerator@0.1.0
  generators:
    - generator: RteTestGeneratorIdentifier
      from-pack: ARM::RteTestGenerator@0.1.0
```


Contributed by STMicroelectronics