### PR TITLE
Make files with different number of lines unequal

### DIFF
--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
@@ -42,3 +42,10 @@ build:
   constructed-files:
     - file: ../../data/TestDefault/RTE/_Debug_TEST_TARGET/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTest_DFP@0.1.1
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
@@ -42,3 +42,10 @@ build:
   constructed-files:
     - file: ../../data/TestDefault/RTE/_Release_TEST_TARGET/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTest_DFP@0.1.1
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -79,3 +79,20 @@ build:
   constructed-files:
     - file: ../data/TestGenerator/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@1.0.0
+      components:
+        - component: ARM::Device&RteTestBundle:RteTest Generated Component@1.1.0
+        - component: ARM::Device&RteTestBundle:Startup@1.0.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -70,3 +70,19 @@ build:
   constructed-files:
     - file: ../data/TestGenerator/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@1.0.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -101,3 +101,21 @@ build:
   constructed-files:
     - file: ../data/TestGenerator/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTestWithKey@1.1.0
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@1.0.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -70,3 +70,19 @@ build:
   constructed-files:
     - file: ../data/TestGenerator/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@1.0.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
@@ -34,3 +34,8 @@ build:
   constructed-files:
     - file: ../data/TestSolution/ContextMap/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
@@ -34,3 +34,8 @@ build:
   constructed-files:
     - file: ../data/TestSolution/ContextMap/RTE/_Release_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
@@ -34,3 +34,8 @@ build:
   constructed-files:
     - file: ../data/TestSolution/ContextMap/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
@@ -34,3 +34,8 @@ build:
   constructed-files:
     - file: ../data/TestSolution/ContextMap/RTE/_Release_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/LanguageAndScope/ref/lang-scope.Debug_AC6+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LanguageAndScope/ref/lang-scope.Debug_AC6+RteTest_ARMCM3.cbuild.yml
@@ -51,3 +51,13 @@ build:
   constructed-files:
     - file: ../data/TestSolution/LanguageAndScope/RTE/_Debug_AC6_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTest@0.1.0-alpha0
+      components:
+        - component: ARM::RteTest:LanguageAndScope@0.9.9
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
@@ -35,3 +35,10 @@ build:
   constructed-files:
     - file: ../data/TestSolution/LinkerOptions/RTE/_Debug_AC6_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ARM::Board:Test:Rev1@1.1.1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
@@ -41,3 +41,10 @@ build:
   constructed-files:
     - file: ../data/TestSolution/LinkerOptions/RTE/_Debug_GCC_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ARM::Board:Test:Rev1@1.1.1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
@@ -63,3 +63,13 @@ build:
   constructed-files:
     - file: ../data/TestSolution/LinkerOptions/RTE/_PriorityDefines_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Board:Test:Rev1@1.1.1
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
@@ -61,3 +61,13 @@ build:
   constructed-files:
     - file: ../data/TestSolution/LinkerOptions/RTE/_PriorityRegions_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Board:Test:Rev1@1.1.1
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
@@ -58,3 +58,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/StandardLibrary/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -98,3 +98,17 @@ build:
   constructed-files:
     - file: RTE/_Debug_TypeA/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestGenerator@0.1.0
+      components:
+        - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
@@ -146,3 +146,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/TestProject1/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
@@ -137,3 +137,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/TestProject1/RTE/_Release_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
@@ -89,3 +89,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/TestProject2/RTE/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
@@ -86,3 +86,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/TestProject2/RTE/_Debug_CM3/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
@@ -54,3 +54,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/RTE/_Debug_Target/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
@@ -50,3 +50,12 @@ build:
   constructed-files:
     - file: ../data/TestSolution/RTE/_Library_Target/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
@@ -94,3 +94,28 @@ build:
       category: preIncludeGlobal
     - file: ../data/TestSolution/RTE/_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <proprietary> Proprietary Test License
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/licenses/ProprietaryLicense.txt
+      packs:
+        - pack: ARM::RteTest@0.1.0
+      components:
+        - component: ARM::RteTest:ComponentLevel@0.0.1
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1
+    - license: BSD-3-Clause
+      packs:
+        - pack: ARM::RteTest@0.1.0
+      components:
+        - component: ARM::RteTest:GlobalLevel@0.0.2
+    - license: MIT
+      packs:
+        - pack: ARM::RteTest@0.1.0
+      components:
+        - component: ARM::RteTest:GlobalLevel@0.0.2

--- a/tools/projmgr/test/data/TestSolution/ref/rtedir.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/rtedir.Debug+CM0.cbuild.yml
@@ -46,3 +46,10 @@ build:
   constructed-files:
     - file: ../data/TestSolution/AC6/_Debug_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/data/TestSolution/ref/rtedir.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/rtedir.Release+CM0.cbuild.yml
@@ -46,3 +46,10 @@ build:
   constructed-files:
     - file: ../data/TestSolution/GCC/_Release_CM0/RTE_Components.h
       category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -133,7 +133,16 @@ void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2) {
   ret_val = f2.is_open();
   ASSERT_EQ(ret_val, true) << "Failed to open " << file2;
 
-  while (getline(f1, l1) && getline(f2, l2)) {
+  while (true) {
+    if (getline(f1, l1)) {
+      if (!getline(f2, l2)) {
+        FAIL() << "error: " << file1 << " is longer than " << file2 << "\nLine not in " << file2 << ":" << l1;
+      }
+    } else if (getline(f2, l2)) {
+        FAIL() << "error: " << file1 << " is shorter than " << file2 << "\nLine not in " << file1 << ": " << l2;
+    } else {
+      break;
+    }
     if (!l1.empty() && l1.rfind('\r') == l1.length() - 1) {
       l1.pop_back();
     }


### PR DESCRIPTION
Previously, files with different number of lines could be considered equal, since the comparison stopped with success when any of the files ended.

Contributed by STMicroelectronics