### PR TITLE
Erase all xmlns: and xs: attributes when reading packs (#695)

### DIFF
--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -651,11 +651,12 @@ RteItem* RtePackage::CreateItem(const std::string& tag)
 void RtePackage::Construct()
 {
   // remove attributes that we do not need:
-  RemoveAttribute("xmlns:xs");
-  RemoveAttribute("xs:noNamespaceSchemaLocation");
+  EraseAttributes("xmlns:*");
+  EraseAttributes("xs:*");
   // some XML readers strip namespaces
   RemoveAttribute("xs");
   RemoveAttribute("noNamespaceSchemaLocation");
+  RemoveAttribute("schemaLocation");
 
   if (m_releases) {
     AddAttribute("version", m_releases->GetVersionString());

--- a/libs/xmltree/include/XmlItem.h
+++ b/libs/xmltree/include/XmlItem.h
@@ -180,6 +180,14 @@ public:
   bool RemoveAttribute(const std::string& name);
 
   /**
+   * @brief removes several attributes matching given pattern
+   * @param pattern attribute pattern to remove
+   * @return true if at least one attribute is removed, false otherwise
+  */
+  bool EraseAttributes(const std::string& pattern);
+
+
+  /**
    * @brief getter for attribute
    * @param name pointer to attribute name
    * @return string containing attribute value or empty string if attribute does not exist

--- a/libs/xmltree/src/XmlItem.cpp
+++ b/libs/xmltree/src/XmlItem.cpp
@@ -122,6 +122,22 @@ bool XmlItem::RemoveAttribute(const char* name)
   return false;
 }
 
+bool XmlItem::EraseAttributes(const std::string& pattern)
+{
+  set<string> attributesToErase;
+  for (const auto [key, _] : m_attributes) {
+    if (WildCards::Match(pattern, key)) {
+      attributesToErase.insert(key);
+    }
+  }
+  if (attributesToErase.empty()) {
+    return false;
+  }
+  for (const auto& key : attributesToErase) {
+    RemoveAttribute(key);
+  }
+  return true;
+}
 
 const string& XmlItem::GetAttribute(const char* name) const
 {

--- a/libs/xmltree/test/src/XmlTreeTest.cpp
+++ b/libs/xmltree/test/src/XmlTreeTest.cpp
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "XMLTree.h"
+#include "RteUtils.h"
 
 TEST(XmlTreeTest, GetAttribute) {
 
@@ -51,4 +52,24 @@ TEST(XmlTreeTest, GetAttribute) {
   EXPECT_EQ(e.GetAttributeAsUnsigned("ten"), 10U);
   EXPECT_EQ(e.GetAttributeAsUnsigned("zeroTen"), 8); // treated as octal
   EXPECT_EQ(e.GetAttributeAsUnsigned("minusOne"), 0xFFFFFFFF);
+
+  // remove and erase
+  EXPECT_TRUE(e.HasValue("strVal"));
+  e.RemoveAttribute("string");
+  EXPECT_FALSE(e.HasValue("strVal"));
+  EXPECT_FALSE(e.HasAttribute("string"));
+
+  for (long i = 100; i < 103; i++) {
+    std::string val = RteUtils::LongToString(i);
+    std::string key = "attr_" + val;
+    e.SetAttribute(key.c_str(), i);
+    EXPECT_TRUE(e.HasValue(val));
+  }
+  EXPECT_TRUE(e.EraseAttributes("attr*"));
+  for (long i = 100; i < 103; i++) {
+    std::string val = RteUtils::LongToString(i);
+    EXPECT_FALSE(e.HasValue(val));
+  }
+  EXPECT_FALSE(e.EraseAttributes("attr*"));
 }
+// end of XmlTreeTest.cpp


### PR DESCRIPTION
* Erase all xmlns: and xs: attributes when reading packs
no need in that info (we do not write packs back)

Co-authored-by: Evgueni Driouk <evgueni.driouk@arm.com>
Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>