### PR TITLE
IAR single precision FPU error

### DIFF
--- a/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/IAR.9.32.1.cmake
@@ -104,13 +104,13 @@ elseif(CPU STREQUAL "Cortex-M35P")
 
 elseif(CPU STREQUAL "Cortex-M55")
   set(IAR_CPU      "Cortex-M55")
-  set(FPU_FLAGS    "none" "ERROR" "VFPv5_d16" "VFPv5_d16")
+  set(FPU_FLAGS    "none" "VFPv5_d16" "VFPv5_d16" "VFPv5_d16")
   set(SUPPORTS_MVE TRUE)
   set(SUPPORTS_TZ  TRUE)
 
 elseif(CPU STREQUAL "Cortex-M85")
   set(IAR_CPU             "Cortex-M85")
-  set(FPU_FLAGS           "none" "ERROR" "VFPv5_d16" "VFPv5_d16")
+  set(FPU_FLAGS           "none" "VFPv5_d16" "VFPv5_d16" "VFPv5_d16")
   set(SUPPORTS_BRANCHPROT TRUE)
   set(SUPPORTS_MVE        TRUE)
   set(SUPPORTS_TZ         TRUE)
@@ -162,7 +162,8 @@ if("${FPU}" STREQUAL "FPU")
 else()
   set(IAR_CPU             "Cortex-R52")
 endif()
-set(FPU_FLAGS           "none" "VFPv5sp" "VFPv5_d16" "VFPv5")
+# No sp libraries yet
+set(FPU_FLAGS           "none" "ERROR" "VFPv5_d16" "VFPv5")
 
 elseif(CPU STREQUAL "Cortex-R52+")
 if("${FPU}" STREQUAL "FPU")
@@ -170,7 +171,8 @@ if("${FPU}" STREQUAL "FPU")
 else()
   set(IAR_CPU             "Cortex-R52+")
 endif()
-set(FPU_FLAGS           "none" "VFPv5sp" "VFPv5_d16" "VFPv5")
+# No sp libraries yet
+set(FPU_FLAGS           "none" "ERROR" "VFPv5_d16" "VFPv5")
 
 endif()
 


### PR DESCRIPTION
#1146 
Since hardware is double or nothing:
- Selecting SP_FPU should map onto DP hardware on Cortex-M55 and M85. 
- Did not change the behavior for A-series processors. Here ARMCLANG maps SP_FPU -> NO_FPU which hardly seems correct, so throwing error here does not seem too bad.
- R52 and R52+ Does not support SP_FPU yet, it's a known issue EWARM-9425