### PR TITLE
[projmgr] Option -S without -c should issue a warning when cbuild-set.yml is not present

### DIFF
--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -57,9 +57,12 @@ public:
   /**
    * @brief generate cbuild set file
    * @param contexts vector with pointers to contexts
+   * @param selectedCompiler name of the selected compiler
+   * @param cbuildSetFile path to *.cbuild-set file to be generated
    * @return true if executed successfully
   */
-  static bool GenerateCbuildSet(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, const std::string& selectedCompiler);
+  static bool GenerateCbuildSet(const std::vector<ContextItem*> contexts,
+    const std::string& selectedCompiler, const std::string& cbuildSetFile);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -503,10 +503,18 @@ bool ProjMgr::RunConfigure(bool printConfig) {
     }
   }
 
-  // Generate cbuild-set file
-  if (m_contextSet && (!m_processedContexts.empty())) {
-    if (!m_emitter.GenerateCbuildSet(m_parser, m_processedContexts, m_selectedToolchain)) {
-      return false;
+  if (m_contextSet) {
+    const string& cbuildSetFile = m_parser.GetCsolution().directory + "/" +
+      m_parser.GetCsolution().name + ".cbuild-set.yml";
+
+    if ((m_context.size() == 0) && (RteFsUtils::Exists(cbuildSetFile) == false)) {
+      ProjMgrLogger::Warn("unable to locate " + cbuildSetFile + " file.");
+    }
+    else if (!m_processedContexts.empty()) {
+      // Generate cbuild-set file
+      if (!m_emitter.GenerateCbuildSet(m_processedContexts, m_selectedToolchain, cbuildSetFile)) {
+        return false;
+      }
     }
   }
 

--- a/tools/projmgr/src/ProjMgrYamlEmitter.cpp
+++ b/tools/projmgr/src/ProjMgrYamlEmitter.cpp
@@ -641,16 +641,13 @@ bool ProjMgrYamlEmitter::GenerateCbuild(ContextItem* context, const string& gene
   return cbuild.WriteFile(rootNode, filename);
 }
 
-bool ProjMgrYamlEmitter::GenerateCbuildSet(ProjMgrParser& parser,
-  const std::vector<ContextItem*> contexts, const string& selectedCompiler)
+bool ProjMgrYamlEmitter::GenerateCbuildSet(const std::vector<ContextItem*> contexts,
+  const string& selectedCompiler, const string& cbuildSetFile)
 {
-  const string& filename = parser.GetCsolution().directory + "/" +
-    parser.GetCsolution().name + ".cbuild-set.yml";
-
   YAML::Node rootNode;
   ProjMgrYamlCbuild cbuild(rootNode[YAML_CBUILD_SET], contexts, selectedCompiler);
 
-  return cbuild.WriteFile(rootNode, filename);
+  return cbuild.WriteFile(rootNode, cbuildSetFile);
 }
 
 ProjMgrYamlCbuild::ProjMgrYamlCbuild(YAML::Node node, const vector<ContextItem*>& siblings,

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -3920,8 +3920,9 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_cbuildset_file) {
 
   {
     CleanUp();
+    StdStreamRedirect streamRedirect;
     // Test 2: Run without contexts specified (no existing cbuild-set file with -S)
-    // Expectation: *.cbuild-set.yml file should be generated and all available
+    // Expectation: *.cbuild-set.yml file should not be generated and all available
     //              contexts should be processed
     argv[1] = (char*)"convert";
     argv[2] = (char*)"--solution";
@@ -3931,12 +3932,13 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_cbuildset_file) {
     argv[6] = (char*)"-S";
 
     EXPECT_EQ(0, RunProjMgr(7, argv, 0));
-    EXPECT_TRUE(RteFsUtils::Exists(cbuildSetFile));
-    ProjMgrTestEnv::CompareFile(cbuildSetFile, testinput_folder + "/TestSolution/ref/cbuild/all_contexts_test.cbuild-set.yml");
+    EXPECT_FALSE(RteFsUtils::Exists(cbuildSetFile));
     EXPECT_TRUE(RteFsUtils::Exists(outputDir + "/test2.Debug+CM0.cbuild.yml"));
     EXPECT_TRUE(RteFsUtils::Exists(outputDir + "/test1.Debug+CM0.cbuild.yml"));
     EXPECT_TRUE(RteFsUtils::Exists(outputDir + "/test2.Debug+CM3.cbuild.yml"));
     EXPECT_TRUE(RteFsUtils::Exists(outputDir + "/test1.Release+CM0.cbuild.yml"));
+    const auto& errStr = streamRedirect.GetErrorString();
+    EXPECT_NE(string::npos, errStr.find("warning csolution: unable to locate " + cbuildSetFile + " file."));
   }
 
   {


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/devtools/issues/1199