### PR TITLE
[projmgr] Add --frozen-packs argument to csolution

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -436,14 +436,18 @@ void RteProject::AddCprjComponents(const Collection<RteItem*>& selItems, RteTarg
   // update file versions
   for (auto [instanceName, fi] : m_files) {
     string version;
+    auto rteFile = fi->GetFile(target->GetName());
     auto itver = configFileVersions.find(instanceName); // file in cprj can be specified by its instance name
     if (itver == configFileVersions.end())
       itver = configFileVersions.find(fi->GetName()); // or by original name
     if (itver != configFileVersions.end()) {
       version = itver->second;
+    } else {
+      // Fall back to the version noted in the pack
+      version = rteFile->GetVersionString();
     }
     UpdateFileInstanceVersion(fi, version);
-    UpdateConfigFileBackups(fi, fi->GetFile(target->GetName()));
+    UpdateConfigFileBackups(fi, rteFile);
   }
 }
 

--- a/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/RTE/Device/ARMCM33_DSP_FP_TZ/gcc_arm.ld.base@1.0.0
+++ b/tools/buildmgr/test/testinput/Examples/GCC/TrustZone/CM33_s/RTE/Device/ARMCM33_DSP_FP_TZ/gcc_arm.ld.base@1.0.0
@@ -1,0 +1,1 @@
+/* Intentionally left empty to trigger upgrade scenario in test case */

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -130,6 +130,7 @@ protected:
   bool m_ymlOrder;
   bool m_contextSet;
   bool m_relativePaths;
+  bool m_frozenPacks;
   GroupNode m_files;
   std::vector<ContextItem*> m_processedContexts;
 

--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -499,8 +499,9 @@ public:
    * @brief parse csolution
    * @param checkSchema false to skip schema validation
    * @param input csolution.yml file
+   * @param frozenPacks false to allow missing cbuild-packs.yml file
   */
-  bool ParseCsolution(const std::string& input, bool checkSchema);
+  bool ParseCsolution(const std::string& input, bool checkSchema, bool frozenPacks);
 
   /**
    * @brief parse clayer

--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -68,9 +68,10 @@ public:
    * @brief generate cbuild pack file
    * @param contexts vector with pointers to contexts
    * @param keepExistingPackContent if true, all entries from existing cbuild-pack should be preserved
+   * @param cbuildPackFrozen if true, reject updates to cbuild pack file
    * @return true if executed successfully
   */
-  static bool GenerateCbuildPack(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, bool keepExistingPackContent);
+  static bool GenerateCbuildPack(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, bool keepExistingPackContent, bool cbuildPackFrozen);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -176,9 +176,10 @@ public:
    * @param input csolution.yml file
    * @param reference to store parsed csolution item
    * @param checkSchema false to skip schema validation
+   * @param frozenPacks false to allow missing cbuild-packs.yml file
   */
   bool ParseCsolution(const std::string& input, CsolutionItem& csolution,
-    bool checkSchema);
+    bool checkSchema, bool frozenPacks);
 
   /**
    * @brief parse cproject

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -502,7 +502,7 @@ bool ProjMgr::RunConfigure(bool printConfig) {
     if (!m_worker.IsContextSelected(contextName)) {
       continue;
     }
-    if (!m_worker.ProcessContext(contextItem, true, true, m_updateRteFiles)) {
+    if (!m_worker.ProcessContext(contextItem, true, true, false)) {
       ProjMgrLogger::Error("processing context '" + contextName + "' failed");
       error = true;
     } else {
@@ -558,6 +558,14 @@ bool ProjMgr::RunConfigure(bool printConfig) {
   // Generate cbuild-pack file
   const bool isUsingContexts = m_contextSet || m_context.size() != 0;
   m_emitter.GenerateCbuildPack(m_parser, m_processedContexts, isUsingContexts);
+
+  // Update the RTE files
+  if (m_updateRteFiles) {
+    for (auto& contextItem : m_processedContexts) {
+      contextItem->rteActiveProject->SetAttribute("update-rte-files", "1");
+      contextItem->rteActiveProject->UpdateRte();
+    }
+  }
 
   return !error;
 }

--- a/tools/projmgr/src/ProjMgrParser.cpp
+++ b/tools/projmgr/src/ProjMgrParser.cpp
@@ -28,9 +28,9 @@ bool ProjMgrParser::ParseCdefault(const string& input, bool checkSchema) {
   return ProjMgrYamlParser().ParseCdefault(input, m_cdefault, checkSchema);
 }
 
-bool ProjMgrParser::ParseCsolution(const string& input, bool checkSchema) {
+bool ProjMgrParser::ParseCsolution(const string& input, bool checkSchema, bool frozenPacks) {
   // Parse solution file
-  return ProjMgrYamlParser().ParseCsolution(input, m_csolution, checkSchema);
+  return ProjMgrYamlParser().ParseCsolution(input, m_csolution, checkSchema, frozenPacks);
 }
 
 bool ProjMgrParser::ParseCproject(const string& input, bool checkSchema, bool single) {

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -52,13 +52,16 @@ bool ProjMgrYamlParser::ParseCdefault(const string& input,
 }
 
 bool ProjMgrYamlParser::ParseCsolution(const string& input,
-  CsolutionItem& csolution, bool checkSchema) {
+  CsolutionItem& csolution, bool checkSchema, bool frozenPacks) {
 
   string cbuildPackFile = RteUtils::RemoveSuffixByString(input, ".csolution.yml") + ".cbuild-pack.yml";
   if (fs::exists(cbuildPackFile)) {
     if (!ParseCbuildPack(cbuildPackFile, csolution.cbuildPack, checkSchema)) {
       return false;
     }
+  } else if (frozenPacks) {
+    ProjMgrLogger::Error(cbuildPackFile, "file is missing and required due to use of --frozen-packs option");
+    return false;
   }
 
   try {

--- a/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen.cbuild-pack.yml
@@ -1,0 +1,5 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest_DFP@0.1.1
+      selected-by:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen.csolution.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: CM3
+      device: RteTest_ARMCM3
+  packs:
+    - pack: ARM::RteTest_DFP@0.2.0
+  projects:
+    - project: ./project_with_dfp_components.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen_no_pack_file.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/cbuild_pack_frozen_no_pack_file.csolution.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: CM0
+      device: RteTest_ARMCM0
+  packs:
+    - pack: ARM::RteTest_DFP@0.2.0
+  projects:
+    - project: ./project_with_dfp_components.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/cbuild_pack_frozen.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/cbuild_pack_frozen.cbuild-pack.yml
@@ -1,0 +1,5 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by:
+        - ARM::RteTest_DFP@0.2.0


### PR DESCRIPTION
The `--frozen-packs` option is only applicable for the following commands:
- `convert`
- `update-rte`

If `cbuild-pack.yml` needs to be created or updated, then `--frozen-pack` will treat this as an error and fail the command.

Contributed by STMicroelectronics