### PR TITLE
[projmgr] Update default linker script for AC6

### DIFF
--- a/tools/projmgr/templates/ac6_linker_script.sct.src
+++ b/tools/projmgr/templates/ac6_linker_script.sct.src
@@ -44,8 +44,8 @@ LR_ROM0 __ROM0_BASE __ROM0_SIZE  {
 #endif
 
   RW_NOINIT __RAM0_BASE UNINIT (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE) {
-    *.o(.noinit)
-    *.o(.noinit.*)
+    *.o(.bss.noinit)
+    *.o(.bss.noinit.*)
   }
 
   RW_RAM0 AlignExpr(+0, 8) (__RAM0_SIZE - __HEAP_SIZE - __STACK_SIZE - __STACKSEAL_SIZE - AlignExpr(ImageLength(RW_NOINIT), 8)) {


### PR DESCRIPTION
- added .bss at beginning of the .noinit section names as required by Arm Compiler 6