### PR TITLE
[rtemodel] Restore `RteKernel::GetUrlFromIndex` return value when local pack repo is absent

### DIFF
--- a/libs/rtemodel/src/RteKernel.cpp
+++ b/libs/rtemodel/src/RteKernel.cpp
@@ -477,7 +477,7 @@ bool RteKernel::GetUrlFromIndex(const string& rtePath, const string& name, const
 {
   unique_ptr<XMLTreeElement> pIndex(ParseLocalRepositoryIdx(rtePath));
   if (!pIndex) {
-    return true;
+    return false;
   }
   map<string, string> pdscMap;
   // Populate map with items matching name, vendor and version range

--- a/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.cpp
@@ -78,7 +78,7 @@ void CBuildGenTestFixture::RunCBuildGen(const TestParam& param, string projpath,
       param.command + (param.options.empty() ? "" : " ") + param.options;
   }
   else {
-    cmd = "bash -c \"source " + testout_folder +
+    cmd = SH + string(" \"source ") + testout_folder +
       "/cbuild/etc/setup && cbuildgen \"" + workingDir +
       '/' + param.targetArg + ".cprj\" " + param.command +
       (param.options.empty() ? "" : " ") + param.options + "\"";
@@ -89,7 +89,7 @@ void CBuildGenTestFixture::RunCBuildGen(const TestParam& param, string projpath,
 }
 
 void CBuildGenTestFixture::RunCBuildGenAux(const string& cmd, bool expect) {
-  string command = "bash -c \"source " + testout_folder +
+  string command = SH + string(" \"source ") + testout_folder +
     "/cbuild/etc/setup && cbuildgen " + cmd + "\"";
   int ret_val = system(command.c_str());
   ASSERT_EQ(expect, (ret_val == 0) ? true : false);

--- a/tools/buildmgr/test/integrationtests/src/CBuildGenTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildGenTests.cpp
@@ -369,6 +369,31 @@ TEST_F(CBuildGenTests, GeneratePackListTest) {
   CheckCPInstallFile    (param, true);  // .cpinstall.json
 }
 
+// Validate listing of missing packs in a packlist file with invalid pack repository
+TEST_F(CBuildGenTests, GeneratePackListTest_InvalidRepository) {
+  TestParam param = {
+    "ModelTest", "InvalidPackRepo",
+    "", "packlist", true
+  };
+
+  auto outFile = fs::path(
+    testdata_folder + "/" + param.name + "/" + param.targetArg + ".cpinstall");
+  error_code ec;
+
+  if (fs::exists(outFile, ec)) {
+    fs::remove(outFile, ec);
+  }
+
+  const string packRoot = CrossPlatformUtils::GetEnv("CMSIS_PACK_ROOT");
+  CrossPlatformUtils::SetEnv("CMSIS_PACK_ROOT", string(CMAKE_SOURCE_DIR) + "/test/packs-invalid");
+  RunCBuildGen(param, testdata_folder, false);
+  CheckCPInstallFile(param, false); // .cpinstall
+  CheckCPInstallFile(param, true);  // .cpinstall.json
+
+  // restore CMSIS_PACK_ROOT env variable
+  CrossPlatformUtils::SetEnv("CMSIS_PACK_ROOT", packRoot);
+}
+
 // Validate listing of missing packs in a packlist file
 TEST_F(CBuildGenTests, GeneratePackListDirTest) {
   TestParam param = {

--- a/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cpinstall.json.ref
+++ b/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cpinstall.json.ref
@@ -1,0 +1,6 @@
+[
+{"vendor": "ARM", "name": "CMSIS"},
+{"vendor": "Keil", "name": "ARM_Compiler"},
+{"vendor": "lwIP", "name": "lwIP", "version": "2.1.2"},
+{"vendor": "Keil", "name": "STM32L5xx_DFP", "version": "1.2.0"}
+]

--- a/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cpinstall.ref
+++ b/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cpinstall.ref
@@ -1,0 +1,4 @@
+ARM::CMSIS
+Keil::ARM_Compiler
+lwIP::lwIP@2.1.2
+Keil::STM32L5xx_DFP@1.2.0

--- a/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cprj
+++ b/tools/buildmgr/test/testinput/ModelTest/InvalidPackRepo.cprj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+
+  <created timestamp="2020-02-24T11:46:46" tool="µVision V5.29.0.30"/>
+
+  <info isLayer="false">
+    <description/>
+    <category/>
+    <keywords/>
+    <license/>
+  </info>
+
+  <packages>
+    <package name="CMSIS" vendor="ARM"/>
+    <package name="ARM_Compiler" vendor="Keil"/>
+    <package name="lwIP" vendor="lwIP" version="2.1.2:2.1.2"/>
+    <package name="STM32L5xx_DFP" vendor="Keil" version="1.2.0:1.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="GCC" version="9.2.1"/>
+  </compilers>
+
+  <target Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">
+    <output intdir="./" name="Blinky_GCC" type="exe"/>
+    <ldflags add="--entry=Reset_Handler --specs=nosys.specs -mthumb" compiler="GCC" file="./RTE/Device/ARMCM3/gcc_arm.ld"/>
+    <cflags add="-O -Wall -gdwarf-2 -mapcs-frame -mthumb" compiler="GCC"/>
+    <asflags add="--gdwarf-2 -mthumb" compiler="GCC"/>
+  </target>
+
+  <components>
+    <component Cclass="CMSIS" Cgroup="CORE" Cvendor="ARM"/>
+    <component Cclass="CMSIS" Cgroup="RTOS2" Csub="Keil RTX5" Cvariant="Source" Cvendor="ARM">
+      <file attr="config" category="source" name="CMSIS/RTOS2/RTX/Config/RTX_Config.c" version="5.1.0"/>
+      <file attr="config" category="header" name="CMSIS/RTOS2/RTX/Config/RTX_Config.h" version="5.5.0"/>
+    </component>
+    <component Cclass="Device" Cgroup="Startup" Cvendor="ARM">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/GCC/gcc_arm.ld" version="2.0.0"/>
+      <file attr="config" category="sourceAsm" name="Device/ARM/ARMCM3/Source/GCC/startup_ARMCM3.S" version="2.0.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/system_ARMCM3.c" version="1.0.0"/>
+    </component>
+  </components>
+
+  <files>
+    <group name="Source Files">
+      <file category="sourceC" name="./Blinky.c"/>
+    </group>
+    <group name="Documentation">
+      <file category="doc" name="./Abstract.txt"/>
+    </group>
+  </files>
+
+</cprj>


### PR DESCRIPTION
Fixes https://github.com/Open-CMSIS-Pack/devtools/issues/1232
Added `CBuildGenTests.GeneratePackListTest_InvalidRepository` test case.