### PR TITLE
[projmgr] Don't consider cbuild-pack.yml with --load <all|latest> (#1291)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1452,7 +1452,8 @@ void ProjMgrWorker::InsertPackRequirements(const vector<PackItem>& src, vector<P
  * @return True if sucessful
  */
 bool ProjMgrWorker::AddPackRequirements(ContextItem& context, const vector<PackItem>& packRequirements) {
-  const vector<ResolvedPackItem>& resolvedPacks = context.csolution ? context.csolution->cbuildPack.packs : vector<ResolvedPackItem>();
+  const bool ignoreCBuildPack = m_loadPacksPolicy == LoadPacksPolicy::ALL || m_loadPacksPolicy == LoadPacksPolicy::LATEST;
+  const vector<ResolvedPackItem>& resolvedPacks = context.csolution && !ignoreCBuildPack ? context.csolution->cbuildPack.packs : vector<ResolvedPackItem>();
  // Filter context specific package requirements
   vector<PackItem> packages;
   for (const auto& packItem : packRequirements) {

--- a/tools/projmgr/test/data/TestSolution/PackLocking/project_pack_lock_find_unspecified_pack_using_load_argument.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/project_pack_lock_find_unspecified_pack_using_load_argument.csolution.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: CM0
+      device: RteTest_ARMCM0
+  packs:
+    - pack: ARM::RteTest_DFP
+  projects:
+    - project: ./project_with_rtetest_and_dfp_components.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/PackLocking/project_pack_lock_using_load_argument.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/project_pack_lock_using_load_argument.csolution.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  target-types:
+    - type: CM0
+      device: RteTest_ARMCM0
+  packs:
+    - pack: ARM::RteTest_DFP
+    - pack: ARM::RteTest
+  projects:
+    - project: ./project_with_rtetest_and_dfp_components.cproject.yml

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-all.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-all.cbuild-pack.yml
@@ -1,0 +1,6 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest@0.1.0
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-latest.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-latest.cbuild-pack.yml
@@ -1,0 +1,6 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest@0.1.0
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required.cbuild-pack.yml
@@ -1,0 +1,5 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest_DFP@0.1.1
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required_updated.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required_updated.cbuild-pack.yml
@@ -1,0 +1,5 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-all.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-all.cbuild-pack.yml
@@ -1,0 +1,8 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest@0.1.0
+      selected-by-pack:
+        - ARM::RteTest
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-latest.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-latest.cbuild-pack.yml
@@ -1,0 +1,8 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest@0.1.0
+      selected-by-pack:
+        - ARM::RteTest
+    - resolved-pack: ARM::RteTest_DFP@0.2.0
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-required.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-required.cbuild-pack.yml
@@ -1,0 +1,8 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest@0.1.0
+      selected-by-pack:
+        - ARM::RteTest
+    - resolved-pack: ARM::RteTest_DFP@0.1.1
+      selected-by-pack:
+        - ARM::RteTest_DFP

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -972,6 +972,177 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_LockPackReselectSelectedByPack) {
   ProjMgrTestEnv::CompareFile(expectedCbuildPack, cbuildPack);
 }
 
+TEST_F(ProjMgrUnitTests, RunProjMgrSolution_LockPackLoadArgument) {
+  error_code ec;
+  char* argv[8];
+  StdStreamRedirect streamRedirect;
+
+  // convert --solution solution.yml
+  const string csolution = testinput_folder + "/TestSolution/PackLocking/project_pack_lock_using_load_argument.csolution.yml";
+  const string cbuildPack = testinput_folder + "/TestSolution/PackLocking/project_pack_lock_using_load_argument.cbuild-pack.yml";
+  const string expectedCbuildPackAll = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-all.cbuild-pack.yml";
+  const string expectedCbuildPackLatest = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-latest.cbuild-pack.yml";
+  const string expectedCbuildPackRequired = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_using_load_argument-required.cbuild-pack.yml";
+  const string output = testoutput_folder + "/testpacklock";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"--solution";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)output.c_str();
+  argv[6] = (char*)"--load";
+
+  // Test with --load all and without cbuild-pack.yml file
+  argv[7] = (char*)"all";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackAll, cbuildPack);
+
+  // Test with --load all and with cbuild-pack.yml file
+  argv[7] = (char*)"all";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackAll, cbuildPack);
+
+  // Test with --load latest and without cbuild-pack.yml file
+  argv[7] = (char*)"latest";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test with --load latest and with cbuild-pack.yml file
+  argv[7] = (char*)"latest";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test with --load required and without cbuild-pack.yml file
+  argv[7] = (char*)"required";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test with --load required and with cbuild-pack.yml file
+  argv[7] = (char*)"required";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file is already up-to-date"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequired, cbuildPack);
+
+  // Test without --load and without cbuild-pack.yml file
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test without --load but with cbuild-pack.yml file
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file is already up-to-date"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequired, cbuildPack);
+}
+
+TEST_F(ProjMgrUnitTests, RunProjMgrSolution_LockPackFindUnspecifiedPackUsingLoadArgument) {
+  error_code ec;
+  char* argv[8];
+  StdStreamRedirect streamRedirect;
+
+  // convert --solution solution.yml
+  const string csolution = testinput_folder + "/TestSolution/PackLocking/project_pack_lock_find_unspecified_pack_using_load_argument.csolution.yml";
+  const string cbuildPack = testinput_folder + "/TestSolution/PackLocking/project_pack_lock_find_unspecified_pack_using_load_argument.cbuild-pack.yml";
+  const string expectedCbuildPackAll = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-all.cbuild-pack.yml";
+  const string expectedCbuildPackLatest = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-latest.cbuild-pack.yml";
+  const string expectedCbuildPackRequired = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required.cbuild-pack.yml";
+  const string expectedCbuildPackRequiredUpdated = testinput_folder + "/TestSolution/PackLocking/ref/project_pack_lock_find_unspecified_pack_using_load_argument-required_updated.cbuild-pack.yml";
+  const string output = testoutput_folder + "/testpacklock";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"--solution";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)output.c_str();
+  argv[6] = (char*)"--load";
+
+  // Test with --load all and without cbuild-pack.yml file
+  argv[7] = (char*)"all";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackAll, cbuildPack);
+
+  // Test with --load all and with cbuild-pack.yml file
+  argv[7] = (char*)"all";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackAll, cbuildPack);
+
+  // Test with --load latest and without cbuild-pack.yml file
+  argv[7] = (char*)"latest";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test with --load latest and with cbuild-pack.yml file
+  argv[7] = (char*)"latest";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackLatest, cbuildPack);
+
+  // Test with --load required and without cbuild-pack.yml file
+  argv[7] = (char*)"required";
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(1, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  EXPECT_NE(streamRedirect.GetErrorString().find("error csolution: no component was found with identifier 'RteTest:ComponentLevel'"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequiredUpdated, cbuildPack);
+
+  // Test with --load required and with cbuild-pack.yml file
+  argv[7] = (char*)"required";
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(1, RunProjMgr(8, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file is already up-to-date"), string::npos);
+  EXPECT_NE(streamRedirect.GetErrorString().find("error csolution: no component was found with identifier 'RteTest:ComponentLevel'"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequired, cbuildPack);
+
+  // Test without --load and without cbuild-pack.yml file
+  RteFsUtils::RemoveFile(cbuildPack);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(1, RunProjMgr(6, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file generated successfully"), string::npos);
+  EXPECT_NE(streamRedirect.GetErrorString().find("error csolution: no component was found with identifier 'RteTest:ComponentLevel'"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequiredUpdated, cbuildPack);
+
+  // Test without --load but with cbuild-pack.yml file
+  fs::copy(fs::path(expectedCbuildPackRequired), fs::path(cbuildPack), fs::copy_options::overwrite_existing, ec);
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(1, RunProjMgr(6, argv, 0));
+  EXPECT_NE(streamRedirect.GetOutString().find(cbuildPack + " - info csolution: file is already up-to-date"), string::npos);
+  EXPECT_NE(streamRedirect.GetErrorString().find("error csolution: no component was found with identifier 'RteTest:ComponentLevel'"), string::npos);
+  ProjMgrTestEnv::CompareFile(expectedCbuildPackRequired, cbuildPack);
+}
+
 TEST_F(ProjMgrUnitTests, RunProjMgrSolution_CbuildPackLocalPackIgnored) {
   char* argv[6];
 


### PR DESCRIPTION
When `--load all` or `--load latest` argument is provided, the content of `cbuild-pack.yml` files should not be considered, but the file should be updated with the new resolved packs.

Contributed by STMicroelectronics