### PR TITLE
Support for external generators in RTE Model

### DIFF
--- a/libs/crossplatform/include/CrossPlatformUtils.h
+++ b/libs/crossplatform/include/CrossPlatformUtils.h
@@ -84,6 +84,13 @@ public:
   */
   static bool CanExecute(const std::string& file);
 
+  /**
+   * @brief execute shell command
+   * @param cmd string shell command to be executed
+   * @return command execution result <string, error_code>
+  */
+  static const std::pair<std::string, int> ExecCommand(const std::string& cmd);
+
   enum class REG_STATUS {
     ENABLED,
     DISABLED,

--- a/libs/crossplatform/src/CrossPlatformUtils.cpp
+++ b/libs/crossplatform/src/CrossPlatformUtils.cpp
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "CrossPlatformUtils.h"
+#include "CrossPlatform.h"
 #include "constants.h"
 
 #include <time.h>
+#include <array>
+#include <functional>
 
 std::string CrossPlatformUtils::GetEnv(const std::string& name)
 {
@@ -62,6 +65,27 @@ const std::string& CrossPlatformUtils::GetHostType()
   // OS name is defined at compile time
   static const std::string os_name = HOST_TYPE;
   return os_name;
+}
+
+
+const std::pair<std::string, int> CrossPlatformUtils::ExecCommand(const std::string& cmd)
+{
+  std::array<char, 128> buffer;
+  std::string result;
+  int ret_code = -1;
+  std::function<int(FILE*)> close = _pclose;
+  std::function<FILE* (const char*, const char*)> open = _popen;
+
+  auto deleter = [&close, &ret_code](FILE* cmd) { ret_code = close(cmd); };
+  {
+    const std::unique_ptr<FILE, decltype(deleter)> pipe(open(cmd.c_str(), "r"), deleter);
+    if (pipe) {
+      while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
+        result += buffer.data();
+      }
+    }
+  }
+  return std::make_pair(result, ret_code);
 }
 
 // end of CrossplatformUtils.cpp

--- a/libs/crossplatform/test/src/UnitTests.cpp
+++ b/libs/crossplatform/test/src/UnitTests.cpp
@@ -107,4 +107,19 @@ TEST(CrossPlatformUnitTests, GetLongPathRegStatus) {
     EXPECT_EQ(CrossPlatformUtils::REG_STATUS::NOT_SUPPORTED, status);
   }
 }
+
+TEST(CrossPlatformUnitTests, ExecCommand) {
+  auto result = CrossPlatformUtils::ExecCommand("invalid command");
+  EXPECT_EQ(false, (0 == result.second) ? true : false) << result.first;
+
+  string testdir = "mkdir_test_dir";
+  error_code ec;
+  if (filesystem::exists(testdir)) {
+    filesystem::remove(testdir);
+  }
+  result = CrossPlatformUtils::ExecCommand("mkdir " + testdir);
+  EXPECT_TRUE(filesystem::exists(testdir));
+  EXPECT_EQ(true, (0 == result.second) ? true : false) << result.first;
+}
+
 // end of UnitTests.cpp

--- a/libs/rtefsutils/include/RteFsUtils.h
+++ b/libs/rtefsutils/include/RteFsUtils.h
@@ -8,7 +8,7 @@
 */
 /******************************************************************************/
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,7 +66,7 @@ public:
    * @param content string to be stored in the created file
    * @return true if file is created
   */
-  static bool CreateFile(const std::string& file, const std::string& content);
+  static bool CreateTextFile(const std::string& file, const std::string& content);
   /**
    * @brief copy string to file in binary mode. Previous content of file is destroyed.
    * @param fileName name of file
@@ -377,6 +377,14 @@ public:
    * @return absolute file name if found, empty string otherwise
   */
   static std::string FindFileInEtc(const std::string& fileName, const std::string& baseDir);
+
+   /**
+   * @brief get file category according to file extension
+   * @param filename with extension
+   * @return string category
+  */
+  static const std::string& FileCategoryFromExtension(const std::string& file);
+
 };
 
 #endif // RteFsUtils_H

--- a/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
+++ b/libs/rtefsutils/test/src/RteFsUtilsTest.cpp
@@ -83,7 +83,7 @@ void RteFsUtilsTest::CreateInputFiles(const string& dir) {
   // Create dummy test files
   for (auto fileName : sortedFileSet) {
     string filePath = dir + "/" + fileName;
-    RteFsUtils::CreateFile(filePath, fileName);
+    RteFsUtils::CreateTextFile(filePath, fileName);
   }
 }
 
@@ -111,7 +111,7 @@ TEST_F(RteFsUtilsTest, BackupFile) {
   string ret;
   error_code ec;
 
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
 
   // Test filename with regular separators and multiple backup
   ret = RteUtils::SlashesToOsSlashes(RteFsUtils::BackupFile(filenameRegular));
@@ -161,7 +161,7 @@ TEST_F(RteFsUtilsTest, BackupFile) {
 TEST_F(RteFsUtilsTest, CmpFileMem) {
   bool ret;
 
-  RteFsUtils::CreateFile(filenameRegular, bufferFoo);
+  RteFsUtils::CreateTextFile(filenameRegular, bufferFoo);
 
   // Test filename with regular separators
   ret = RteFsUtils::CmpFileMem(filenameRegular, bufferFoo);
@@ -231,7 +231,7 @@ TEST_F(RteFsUtilsTest, CopyBufferToFile) {
   RteFsUtils::RemoveFile(filenameRegular);
 
   // Test existent file with same content
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::CopyBufferToFile(filenameRegular, bufferFoo, false);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), true);
@@ -239,7 +239,7 @@ TEST_F(RteFsUtilsTest, CopyBufferToFile) {
   RteFsUtils::RemoveFile(filenameRegular);
 
   // Test existent file with different content and backup argument
-  RteFsUtils::CreateFile(filenameRegular, bufferFoo);
+  RteFsUtils::CreateTextFile(filenameRegular, bufferFoo);
   ret = RteFsUtils::CopyBufferToFile(filenameRegular, bufferBar, true);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), true);
@@ -254,7 +254,7 @@ TEST_F(RteFsUtilsTest, CopyCheckFile) {
   bool ret;
   error_code ec;
 
-  RteFsUtils::CreateFile(filenameRegular, bufferFoo);
+  RteFsUtils::CreateTextFile(filenameRegular, bufferFoo);
 
   // Test filename with regular separators
   ret = RteFsUtils::CopyCheckFile(filenameRegular, filenameRegularCopy, false);
@@ -305,7 +305,7 @@ TEST_F(RteFsUtilsTest, ExpandFile) {
   bool ret;
   string buffer;
 
-  RteFsUtils::CreateFile(filenameRegular, "%Instance%");
+  RteFsUtils::CreateTextFile(filenameRegular, "%Instance%");
 
   // Test filename with regular separators
   ret = RteFsUtils::ExpandFile(filenameRegular, 1, buffer);
@@ -337,7 +337,7 @@ TEST_F(RteFsUtilsTest, CopyMergeFile) {
   bool ret;
   error_code ec;
 
-  RteFsUtils::CreateFile(filenameRegular, "%Instance%");
+  RteFsUtils::CreateTextFile(filenameRegular, "%Instance%");
 
   // Test filename with regular separators
   ret = RteFsUtils::CopyMergeFile(filenameRegular, filenameRegularCopy, 1, false);
@@ -391,8 +391,8 @@ TEST_F(RteFsUtilsTest, CopyTree) {
   // use CountFilesInFolder if additionall test
   EXPECT_EQ(RteFsUtils::CountFilesInFolder(dirnameBase), 0);
 
-  RteFsUtils::CreateFile(filenameRegular, "foo");
-  RteFsUtils::CreateFile(filenameRegularCopy, "bar");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegularCopy, "bar");
 
   EXPECT_EQ(RteFsUtils::CountFilesInFolder(dirnameBase), 2);
 
@@ -470,19 +470,19 @@ TEST_F(RteFsUtilsTest, DeleteFileAutoRetry) {
   error_code ec;
 
   // Test filename with regular separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteFileAutoRetry(filenameRegular);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
 
   // Test filename with backslashes separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteFileAutoRetry(filenameBackslash);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
 
   // Test filename with mixed separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteFileAutoRetry(filenameMixed);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -496,13 +496,13 @@ TEST_F(RteFsUtilsTest, DeleteFileAutoRetry) {
   EXPECT_EQ(ret, true);
 
   // Test delay argument equal to zero
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteFileAutoRetry(filenameRegular, 5U, 0U);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
 
   // Test retry argument equal to zero
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteFileAutoRetry(filenameRegular, 0U, 1U);
   EXPECT_EQ(ret, false);
   RteFsUtils::RemoveFile(filenameRegular);
@@ -513,37 +513,37 @@ TEST_F(RteFsUtilsTest, DeleteTree) {
   error_code ec;
 
   // Test dirname with regular separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameSubdir);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
 
   // Test dirname with backslashes separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameSubdirBackslash);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
 
   // Test dirname with mixed separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameSubdirMixed);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
 
   // Test dirname with regular separators and trailing
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameSubdirWithTrailing);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
 
   // Test dirname with backslashes separators and trailing
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameBackslashWithTrailing);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
 
   // Test dirname with mixed separators and trailing
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(dirnameMixedWithTrailing);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(dirnameSubdir), false);
@@ -557,7 +557,7 @@ TEST_F(RteFsUtilsTest, DeleteTree) {
   EXPECT_EQ(ret, true);
 
   // Test source not a directory
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::DeleteTree(filenameRegular);
   EXPECT_EQ(ret, false);
   RteFsUtils::RemoveFile(filenameRegular);
@@ -568,7 +568,7 @@ TEST_F(RteFsUtilsTest, MoveExistingFile) {
   error_code ec;
 
   // Test filename with regular separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveExistingFile(filenameRegular, filenameRegularCopy);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -576,7 +576,7 @@ TEST_F(RteFsUtilsTest, MoveExistingFile) {
   RteFsUtils::RemoveFile(filenameRegularCopy);
 
   // Test filename with backslashes separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveExistingFile(filenameBackslash, filenameBackslashCopy);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -584,7 +584,7 @@ TEST_F(RteFsUtilsTest, MoveExistingFile) {
   RteFsUtils::RemoveFile(filenameRegularCopy);
 
   // Test filename with mixed separators
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveExistingFile(filenameMixed, filenameMixedCopy);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -605,7 +605,7 @@ TEST_F(RteFsUtilsTest, MoveExistingFile) {
 TEST_F(RteFsUtilsTest, MoveFileExAutoRetry) {
   bool ret;
   // Test filename with default retry and delay arguments
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveFileExAutoRetry(filenameRegular, filenameRegularCopy);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -613,7 +613,7 @@ TEST_F(RteFsUtilsTest, MoveFileExAutoRetry) {
   RteFsUtils::RemoveFile(filenameRegularCopy);
 
   // Test filename with delay argument equal to 0
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveFileExAutoRetry(filenameRegular, filenameRegularCopy, 5U, 0U);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), false);
@@ -621,7 +621,7 @@ TEST_F(RteFsUtilsTest, MoveFileExAutoRetry) {
   RteFsUtils::RemoveFile(filenameRegularCopy);
 
   // Test filename with retry argument equal to 0
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::MoveFileExAutoRetry(filenameRegular, filenameRegularCopy, 0U, 1U);
   EXPECT_EQ(ret, false);
   RteFsUtils::RemoveFile(filenameRegular);
@@ -642,7 +642,7 @@ TEST_F(RteFsUtilsTest, CopyFileExAutoRetry) {
   EXPECT_FALSE(RteFsUtils::Exists(filenameRegularCopy));
 
   // Test filename with default retry and delay arguments
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::CopyFileExAutoRetry(filenameRegular, filenameRegularCopy);
   EXPECT_EQ(ret, true);
   EXPECT_EQ(RteFsUtils::Exists(filenameRegular), true);
@@ -706,7 +706,7 @@ TEST_F(RteFsUtilsTest, RemoveDirectoryAutoRetry) {
   EXPECT_EQ(ret, true);
 
   // Test path is not a directory
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   ret = RteFsUtils::RemoveDirectoryAutoRetry(filenameRegular);
   EXPECT_EQ(ret, false);
   RteFsUtils::RemoveFile(filenameRegular);
@@ -729,7 +729,7 @@ TEST_F(RteFsUtilsTest, SetFileReadOnly) {
   error_code ec;
   constexpr fs::perms write_mask = fs::perms::owner_write | fs::perms::group_write | fs::perms::others_write;
 
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
   const fs::perms initial_perm = fs::status(filenameRegular, ec).permissions();
 
   // Test filename with regular separators
@@ -775,7 +775,7 @@ TEST_F(RteFsUtilsTest, SetTreeReadOnly) {
   constexpr fs::perms write_mask = fs::perms::owner_write | fs::perms::group_write | fs::perms::others_write;
 
   const string validationDir = dirnameSubdir + "/foo/bar";
-  RteFsUtils::CreateFile(validationDir + "/baz.txt", "foo");
+  RteFsUtils::CreateTextFile(validationDir + "/baz.txt", "foo");
   const fs::perms initial_perm = fs::status(validationDir, ec).permissions();
 
   // Set parent directory read-only for the reminder of the test
@@ -829,7 +829,7 @@ TEST_F(RteFsUtilsTest, MakePathCanonical) {
   const string dirnameCanonical = fs::current_path(ec).append(dirnameSubdir).generic_string();
 
   // create file and with parent directories for reliability of the tests
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
 
   // Test filename with regular separators, file exists
   ret = RteFsUtils::MakePathCanonical(filenameRegular);
@@ -885,7 +885,7 @@ TEST_F(RteFsUtilsTest, GetCurrentFolder) {
   const string expectedDir = fs::current_path(ec).append(dirnameSubdir).generic_string() + "/";
   string curDir = RteFsUtils::GetCurrentFolder();
 
-  RteFsUtils::CreateFile(filenameRegular, "");
+  RteFsUtils::CreateTextFile(filenameRegular, "");
   fs::current_path(dirnameSubdir, ec);
   currDir = RteFsUtils::GetCurrentFolder();
   EXPECT_EQ(expectedDir, currDir);
@@ -1064,6 +1064,10 @@ TEST_F(RteFsUtilsTest, GetMatchingFiles) {
   RteFsUtils::GetMatchingFiles(files, ".h", dirnameDir, 3, false);
   EXPECT_EQ(files.size(), 3);
 
+  files.clear();
+  RteFsUtils::GetMatchingFiles(files, ".bar.h", dirnameDir, 3, true);
+  EXPECT_EQ(files.size(), 4);
+
   RteFsUtils::RemoveDir(dirnameDir);
 }
 
@@ -1083,15 +1087,15 @@ TEST_F(RteFsUtilsTest, GetFilesSorted) {
 
 TEST_F(RteFsUtilsTest, CreateExtendedName) {
 
-  RteFsUtils::CreateFile(filenameRegular, bufferFoo);
+  RteFsUtils::CreateTextFile(filenameRegular, bufferFoo);
 
   string backup = RteFsUtils::CreateExtendedName(filenameRegular, "backup");
   EXPECT_EQ(backup, filenameRegular + "_backup_0");
-  RteFsUtils::CreateFile(backup, "0");
+  RteFsUtils::CreateTextFile(backup, "0");
 
   backup = RteFsUtils::CreateExtendedName(filenameRegular, "backup");
   EXPECT_EQ(backup, filenameRegular + "_backup_1");
-  RteFsUtils::CreateFile(backup, "1");
+  RteFsUtils::CreateTextFile(backup, "1");
 
   backup = RteFsUtils::CreateExtendedName(filenameRegular, "backup");
   EXPECT_EQ(backup, filenameRegular + "_backup_2");
@@ -1104,7 +1108,7 @@ TEST_F(RteFsUtilsTest, AbsolutePath) {
   error_code ec;
   const string absFilePath = fs::current_path(ec).append(filenameRegular).generic_string();
 
-  RteFsUtils::CreateFile(filenameRegular, "foo");
+  RteFsUtils::CreateTextFile(filenameRegular, "foo");
 
   // Test empty path
   path = RteFsUtils::AbsolutePath("");
@@ -1123,7 +1127,7 @@ TEST_F(RteFsUtilsTest, FindFileRegEx) {
   const string& testdir = dirnameBase + "/FindFileRegEx";
   const string& fileName = testdir + "/test.cdefault.yml";
   RteFsUtils::CreateDirectories(testdir);
-  RteFsUtils::CreateFile(fileName, "");
+  RteFsUtils::CreateTextFile(fileName, "");
   string discoveredFile;
   vector<string> searchPaths = { testdir };
   EXPECT_EQ(true, RteFsUtils::FindFileRegEx(searchPaths, ".*\\.cdefault\\.yml", discoveredFile));
@@ -1136,8 +1140,8 @@ TEST_F(RteFsUtilsTest, FindFileRegEx_MultipleMatches) {
   const string& fileName1 = testdir + "/test1.cdefault.yml";
   const string& fileName2 = testdir + "/test2.cdefault.yml";
   RteFsUtils::CreateDirectories(testdir);
-  RteFsUtils::CreateFile(fileName1, "");
-  RteFsUtils::CreateFile(fileName2, "");
+  RteFsUtils::CreateTextFile(fileName1, "");
+  RteFsUtils::CreateTextFile(fileName2, "");
   string finding;
   vector<string> searchPaths = { testdir };
   EXPECT_EQ(false, RteFsUtils::FindFileRegEx(searchPaths, ".*\\.cdefault\\.yml", finding));
@@ -1151,6 +1155,24 @@ TEST_F(RteFsUtilsTest, FindFileRegEx_NoMatch) {
   vector<string> searchPaths = { testdir };
   EXPECT_EQ(false, RteFsUtils::FindFileRegEx(searchPaths, ".*\\.cdefault\\.yml", finding));
   RteFsUtils::RemoveDir(testdir);
+}
+
+TEST_F(RteFsUtilsTest, FileCategoryFromExtension) {
+  map<string, vector<string>> testDataVec = {
+    {"sourceC",      {"sourceFile.c", "sourceFile.C"}},
+    {"sourceCpp",    {"sourceFile.cpp", "sourceFile.c++", "sourceFile.C++", "sourceFile.cxx", "sourceFile.cc", "sourceFile.CC"}},
+    {"sourceAsm",    {"sourceFile.asm", "sourceFile.s", "sourceFile.S"}},
+    {"header",       {"headerFile.h", "headerFile.hpp"}},
+    {"library",      {"libraryFile.a", "libraryFile.lib"}},
+    {"object",       {"objectFile.o"}},
+    {"linkerScript", {"linkerFile.sct", "linkerFile.scf", "linkerFile.ld", "linkerFile.icf"}},
+    {"doc",          {"documentFile.txt", "documentFile.md", "documentFile.pdf", "documentFile.htm", "documentFile.html"}},
+  };
+  for (const auto& [expected, files] : testDataVec) {
+    for (const auto& file : files) {
+      EXPECT_EQ(RteFsUtils::FileCategoryFromExtension(file), expected);
+    }
+  }
 }
 
 TEST_F(RteFsUtilsTest, GetAbsPathFromLocalUrl) {
@@ -1186,4 +1208,7 @@ TEST_F(RteFsUtilsTest, GetAbsPathFromLocalUrl) {
   const string& testUrlOmittedHost = "file:" + absoluteFilename;
   EXPECT_EQ(absoluteFilename, RteFsUtils::GetAbsPathFromLocalUrl(testUrlOmittedHost));
 #endif
+
 }
+
+// end of RteFsUtilsTest.cpp

--- a/libs/rtemodel/include/RteCallback.h
+++ b/libs/rtemodel/include/RteCallback.h
@@ -181,11 +181,11 @@ public:
   };
 
   /**
-   * @brief obtains globally defined generator
+   * @brief obtains globally defined external generator
    * @param id generator id
    * @return pointer to RteGenerator if found, nullptr otherwise
   */
-  virtual RteGenerator* GetGenerator(const std::string& id) const { return nullptr; }
+  virtual RteGenerator* GetExternalGenerator(const std::string& id) const;
 
   /**
    * @brief get global RteCallback object

--- a/libs/rtemodel/include/RteGenerator.h
+++ b/libs/rtemodel/include/RteGenerator.h
@@ -36,7 +36,7 @@ public:
   * @brief constructor
   * @param parent pointer to RteItem parent
   */
-  RteGenerator(RteItem* parent);
+  RteGenerator(RteItem* parent, bool bExternal = false);
 
   /**
    * @brief virtual destructor
@@ -44,25 +44,30 @@ public:
    ~RteGenerator() override;
 
   /**
-   * @brief get generator commands for all host types without expansion
-   * @return map with host type ("win", "linux", "mac", "other", or "all") as key and generator command as value
+   * @brief get generator "run" attribute
+   * @return generator run command
   */
-  std::map<std::string, std::string> GetCommands() const;
+   const std::string& GetRunAttribute() const { return GetAttribute("run"); }
+
+  /**
+   * @brief get generator "path" attribute
+   * @return generator path
+  */
+   const std::string& GetPathAttribute() const { return GetAttribute("path"); }
 
   /**
    * @brief get generator command without expansion
    * @param hostType host type to match, empty to match current host
    * @return generator command for specified host type
   */
-  const std::string GetCommand(const std::string& hostType = EMPTY_STRING ) const;
+  virtual const std::string GetCommand(const std::string& hostType = EMPTY_STRING ) const;
 
   /**
   * @brief get expanded generator executable command
-  * @param target pointer to RteTarget
   * @param hostType host type to match, empty to match current host
   * @return generator command for specified host type
  */
-  std::string GetExecutable(RteTarget* target, const std::string& hostType = EMPTY_STRING) const;
+  virtual std::string GetExecutable(const std::string& hostType = EMPTY_STRING) const;
 
   /**
    * @brief get item containing command line arguments
@@ -124,25 +129,29 @@ public:
   * @brief get generator working directory
   * @return working directory value
  */
-  const std::string& GetWorkingDir() const { return GetItemValue("workingDir"); }
+  const std::string& GetWorkingDir() const;
+
+ /**
+  * @brief return value of attribute "download-url"
+  * @return value of attribute "download-url"
+  */
+  const std::string& GetURL() const override { return GetAttribute("download-url"); }
 
  /**
  * @brief get all arguments as vector for the given host type
- * @param target pointer to RteTarget
  * @param hostType host type, empty to match current host
  * @param dryRun include dry-run arguments
  * @return vector of arguments consisting of switch and value in pairs
 */
-  std::vector<std::pair<std::string, std::string> > GetExpandedArguments(RteTarget* target, const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
+  std::vector<std::pair<std::string, std::string> > GetExpandedArguments(const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
 
  /**
    * @brief get full command line with arguments and expanded key sequences for specified target
-   * @param target pointer to RteTarget
    * @param hostType host type, empty to match current host
    * @param dryRun include dry-run arguments
    * @return expanded command line with arguments, properly quoted
   */
-  std::string GetExpandedCommandLine(RteTarget* target, const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
+  std::string GetExpandedCommandLine(const std::string& hostType = EMPTY_STRING, bool dryRun = false) const;
 
   /**
    * @brief get absolute path to gpdsc file for specified target
@@ -217,6 +226,13 @@ public:
   */
   bool IsDryRunCapable(const std::string& hostType = EMPTY_STRING) const;
 
+ /**
+  * @brief check if the generator is external
+  * @return true if the generator is external, default returns false
+  */
+  bool IsExternal() const { return m_bExternal; }
+
+
 protected:
   /**
    * @brief construct generator ID
@@ -227,8 +243,8 @@ protected:
 private:
   RteItem* m_pDeviceAttributes;
   RteFileContainer* m_files;
+  bool m_bExternal;
 };
-
 
 /**
  * @brief class to support <generator> element in *.pdsc files

--- a/libs/rtemodel/include/RteItem.h
+++ b/libs/rtemodel/include/RteItem.h
@@ -960,6 +960,13 @@ public:
     m_rootFileName = rootFileName;
   }
 
+  /**
+   * @brief create a new instance of type RteItem
+   * @param tag name of tag
+   * @return pointer to instance of type RteItem
+  */
+   RteItem* CreateItem(const std::string& tag) override;
+
 protected:
   std::string m_rootFileName; // absolute filename of this item's file
 };

--- a/libs/rtemodel/include/RteKernel.h
+++ b/libs/rtemodel/include/RteKernel.h
@@ -45,6 +45,12 @@ public:
   virtual ~RteKernel();
 
   /**
+   * @brief initialize kernel
+   * @return true if successful
+  */
+  virtual bool Init();
+
+  /**
    * @brief getter for CMSIS pack root folder
    * @return CMSIS pack root folder
   */
@@ -81,6 +87,29 @@ public:
    * @param callback pointer to RteCallback object to set
   */
   void SetRteCallback(RteCallback* callback);
+
+  /**
+   * @brief get collection of externals generators
+   * @return map of id to RteGenerator pointer
+  */
+  const std::map<std::string, RteGenerator*>& GetExternalGenerators() const { return  m_externalGenerators; }
+
+  /**
+   * @brief get global external generator for given ID
+   * @param id generator ID string
+   * @return pointer to RteGenerator if found, nullptr otherwise
+  */
+  RteGenerator* GetExternalGenerator(const std::string& id) const;
+
+  /**
+   * @brief loads external generators
+  */
+  void LoadExternalGenerators();
+
+  /**
+   * @brief clear and deletes external generators
+  */
+  void ClearExternalGenerators();
 
   /**
    * @brief getter for global CMSIS RTE model
@@ -290,7 +319,6 @@ public:
   void SetToolInfo(const XmlItem& attr) { m_toolInfo = attr; }
 
 protected:
-
   bool GetUrlFromIndex(const std::string& indexFile, const std::string& name, const std::string& vendor, const std::string& version, std::string& indexedUrl, std::string& indexedVersion) const;
   bool GetLocalPacksUrls(const std::string& rtePath, std::list<std::string>& urls) const;
   XMLTreeElement* ParseLocalRepositoryIdx(const std::string& rtePath) const;
@@ -309,12 +337,15 @@ protected:
   */
   virtual YmlTree* CreateYmlTree(IXmlItemBuilder* itemBuilder) const;
 
-protected:
   /**
    * @brief get this pointer to use in const methods
    * @return this
   */
   RteKernel* GetThisKernel() const { return const_cast<RteKernel*>(this); }
+
+
+// data
+protected:
 
   RteGlobalModel* m_globalModel;
   bool m_bOwnModel;
@@ -322,5 +353,8 @@ protected:
   XmlItem m_toolInfo;
   std::string m_cmsisPackRoot;
   std::string m_cmsisToolboxDir;
+  std::map<std::string, RteItem*> m_externalGeneratorFiles;
+  std::map<std::string, RteGenerator*> m_externalGenerators;
+
 };
 #endif // RteKernel_H

--- a/libs/rtemodel/src/RteCallback.cpp
+++ b/libs/rtemodel/src/RteCallback.cpp
@@ -50,6 +50,14 @@ long RteCallback::ShowMessageBox(const string& title, const string& message, uns
   return defaultVal;
 }
 
+RteGenerator* RteCallback::GetExternalGenerator(const std::string& id) const
+{
+  if(GetRteKernel()) {
+    return GetRteKernel()->GetExternalGenerator(id);
+  }
+  return nullptr;
+}
+
 RteCallback* RteCallback::GetGlobal()
 {
   if(theGlobalCallback) {

--- a/libs/rtemodel/src/RteComponent.cpp
+++ b/libs/rtemodel/src/RteComponent.cpp
@@ -317,7 +317,7 @@ RteGenerator* RteComponent::GetGenerator() const
       generator = pack->GetGenerator(generatorName);
     }
     if (!generator && GetCallback()) {
-      generator = GetCallback()->GetGenerator(generatorName);
+      generator = GetCallback()->GetExternalGenerator(generatorName);
     }
   }
   return generator;

--- a/libs/rtemodel/src/RteItem.cpp
+++ b/libs/rtemodel/src/RteItem.cpp
@@ -18,6 +18,7 @@
 #include "RtePackage.h"
 #include "RteProject.h"
 #include "RteModel.h"
+#include "RteGenerator.h"
 #include "RteConstants.h"
 
 #include "RteFsUtils.h"
@@ -1021,5 +1022,16 @@ void RteItem::SortChildren(CompareRteItemType cmp)
 {
   m_children.sort(cmp);
 }
+
+
+RteItem* RteRootItem::CreateItem(const std::string& tag)
+{
+  // for YAML files create corresponding items depending on the root itself
+  if(GetTag() == "generator") {
+    return new RteGenerator(this, true);
+  }
+  return RteItem::CreateItem(tag);
+}
+
 
 // End of RteItem.cpp

--- a/libs/rtemodel/src/RteItemBuilder.cpp
+++ b/libs/rtemodel/src/RteItemBuilder.cpp
@@ -39,8 +39,6 @@ RteItem* RteItemBuilder::CreateRootItem(const string& tag)
   } else if (tag == "cprj") {
     m_cprjFile = new CprjFile(m_rootParent);
     pRoot = m_cprjFile;
-  } else if (m_rootParent) {
-    pRoot = m_rootParent;
   } else {
     pRoot = new RteRootItem(m_rootParent);
   }

--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -1172,7 +1172,7 @@ RteGpdscInfo* RteProject::AddGpdscInfo(RteComponent* c, RteTarget* target)
     return NULL;
 
   RteGenerator* gen = c->GetGenerator();
-  if (!gen)
+  if (!gen || gen->IsExternal()) // TODO : remove external check when implemented
     return NULL; // nothing to insert
 
 

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -37,7 +37,7 @@ public:
   ~ExtGenRteCallback() override{
     delete m_pExtGenerator;
   }
-  RteGenerator* GetGenerator(const std::string& id) const override {
+  RteGenerator* GetExternalGenerator(const std::string& id) const override {
      if (m_pExtGenerator->GetID() == "RteTestExternalGenerator") {
        return m_pExtGenerator;
      }

--- a/libs/rteutils/CMakeLists.txt
+++ b/libs/rteutils/CMakeLists.txt
@@ -2,7 +2,7 @@ project(RteUtils VERSION 1.0.0)
 
 add_subdirectory("test")
 
-SET(SOURCE_FILES AlnumCmp.cpp DeviceVendor.cpp RteError.cpp RteUtils.cpp VersionCmp.cpp WildCards.cpp)
+SET(SOURCE_FILES AlnumCmp.cpp CollectionUtils.cpp DeviceVendor.cpp RteConstants.cpp RteError.cpp RteUtils.cpp VersionCmp.cpp WildCards.cpp)
 SET(HEADER_FILES AlnumCmp.h CollectionUtils.h DeviceVendor.h RteConstants.h RteError.h RteUtils.h ISchemaChecker.h VersionCmp.h WildCards.h)
 
 list(TRANSFORM SOURCE_FILES PREPEND src/)

--- a/libs/rteutils/include/CollectionUtils.h
+++ b/libs/rteutils/include/CollectionUtils.h
@@ -7,7 +7,13 @@
 #ifndef COLLECTION_UTILS_H
 #define COLLECTION_UTILS_H
 
+#include <algorithm>
+#include <list>
 #include <map>
+#include <vector>
+#include <set>
+#include <string>
+
 /**
  * @brief Returns value stored in a map for a given key or default value if no entry is found
  * @tparam M template parameter representing a map
@@ -48,5 +54,109 @@ template<typename M>
 bool contains_key(const M& m, const typename M::key_type& k) {
     return m.find(k) != m.end();
 }
+
+/**
+  * @brief string pair
+ */
+typedef std::pair<std::string, std::string> StrPair;
+
+/**
+  * @brief string pair
+ */
+typedef std::pair<std::string, int> StrIntPair;
+
+/**
+ * @brief string vector
+*/
+typedef std::vector<std::string> StrVec;
+
+/**
+ * @brief string set
+*/
+typedef std::set<std::string> StrSet;
+
+/**
+ * @brief vector of string pair
+*/
+typedef std::vector<StrPair> StrPairVec;
+
+/**
+ * @brief vector of string pair pointer
+*/
+typedef std::vector<const StrPair*> StrPairPtrVec;
+
+/**
+ * @brief map of vector of string pair
+*/
+typedef std::map<std::string, StrPairVec> StrPairVecMap;
+
+/**
+ * @brief map of string vector
+*/
+typedef std::map<std::string, StrVec> StrVecMap;
+
+/**
+ * @brief map of int
+*/
+typedef std::map<std::string, int> IntMap;
+
+/**
+ * @brief map of bool
+*/
+typedef std::map<std::string, bool> BoolMap;
+
+/**
+ * @brief map of string
+*/
+typedef std::map<std::string, std::string> StrMap;
+
+class CollectionUtils
+{
+private:
+  CollectionUtils() {}; // private constructor to forbid instantiation of a utility class
+
+public:
+  /**
+   * @brief add a string value into a vector if it does not already exist in the vector
+   * @param vec the vector to add the value into
+   * @param value the string value to add
+  */
+  static void PushBackUniquely(std::vector<std::string>& vec, const std::string& value);
+
+  /**
+   * @brief add a string value into a list if it does not already exist in the list
+   * @param lst the list to add the value into
+   * @param value the value to add
+  */
+  static void PushBackUniquely(std::list<std::string>& lst, const std::string& value);
+
+  /**
+   * @brief add a value pair into a vector if it does not already exist in the vector
+   * @param vec the vector to add the value into
+   * @param value the value pair to add
+  */
+  static void PushBackUniquely(StrPairVec& vec, const StrPair& value);
+
+  /**
+   * @brief merge two string vector maps
+   * @param map1 first string vector map
+   * @param map2 second string vector map
+   * @return StrVecMap merged map
+  */
+ static StrVecMap MergeStrVecMap(const StrVecMap& map1, const StrVecMap& map2);
+
+   /**
+   * @brief remove duplicate elements from vector without changing the order of elements
+   * @param input vector to be processed
+  */
+  template <typename T>
+  static void RemoveVectorDuplicates(std::vector<T>& elemVec) {
+    auto end = elemVec.end();
+    for (auto itr = elemVec.begin(); itr != end; ++itr) {
+      end = std::remove(itr + 1, end, *itr);
+    }
+    elemVec.erase(end, elemVec.end());
+  }
+};
 
 #endif // COLLECTION_UTILS_H

--- a/libs/rteutils/include/RteConstants.h
+++ b/libs/rteutils/include/RteConstants.h
@@ -17,6 +17,7 @@
 #include <list>
 #include <vector>
 #include <set>
+#include "CollectionUtils.h"
 
 class RteConstants
 {
@@ -82,6 +83,116 @@ public:
   static constexpr const char* SUFFIX_PACK_VENDOR = "::";
   static constexpr const char* PREFIX_PACK_VERSION = "@";
   static constexpr const char  PREFIX_PACK_VERSION_CHAR = '@';
+
+  /**
+   * @brief output types
+  */
+  static constexpr const char* OUTPUT_TYPE_BIN = "bin";
+  static constexpr const char* OUTPUT_TYPE_ELF = "elf";
+  static constexpr const char* OUTPUT_TYPE_HEX = "hex";
+  static constexpr const char* OUTPUT_TYPE_LIB = "lib";
+  static constexpr const char* OUTPUT_TYPE_CMSE = "cmse-lib";
+
+  /**
+   * @brief access sequences
+  */
+  static constexpr const char* AS_SOLUTION = "Solution";
+  static constexpr const char* AS_PROJECT = "Project";
+  static constexpr const char* AS_COMPILER = "Compiler";
+  static constexpr const char* AS_BUILD_TYPE = "BuildType";
+  static constexpr const char* AS_TARGET_TYPE = "TargetType";
+  static constexpr const char* AS_DNAME = "Dname";
+  static constexpr const char* AS_PNAME = "Pname";
+  static constexpr const char* AS_BNAME = "Bname";
+
+  static constexpr const char* AS_SOLUTION_DIR = "SolutionDir";
+  static constexpr const char* AS_PROJECT_DIR = "ProjectDir";
+  static constexpr const char* AS_OUT_DIR = "OutDir";
+  static constexpr const char* AS_BIN = OUTPUT_TYPE_BIN;
+  static constexpr const char* AS_ELF = OUTPUT_TYPE_ELF;
+  static constexpr const char* AS_HEX = OUTPUT_TYPE_HEX;
+  static constexpr const char* AS_LIB = OUTPUT_TYPE_LIB;
+  static constexpr const char* AS_CMSE = OUTPUT_TYPE_CMSE;
+
+  /**
+   * @brief default and toolchain specific output affixes
+  */
+  static constexpr const char* DEFAULT_ELF_SUFFIX = ".elf";
+  static constexpr const char* DEFAULT_LIB_PREFIX = "";
+  static constexpr const char* DEFAULT_LIB_SUFFIX = ".a";
+
+  static constexpr const char* AC6_ELF_SUFFIX = ".axf";
+  static constexpr const char* GCC_ELF_SUFFIX = ".elf";
+  static constexpr const char* IAR_ELF_SUFFIX = ".out";
+  static constexpr const char* AC6_LIB_PREFIX = "";
+  static constexpr const char* GCC_LIB_PREFIX = "lib";
+  static constexpr const char* IAR_LIB_PREFIX = "";
+  static constexpr const char* AC6_LIB_SUFFIX = ".lib";
+  static constexpr const char* GCC_LIB_SUFFIX = ".a";
+  static constexpr const char* IAR_LIB_SUFFIX = ".a";
+
+  /**
+   * @brief device attributes maps
+  */
+  static constexpr const char* YAML_FPU = "fpu";
+  static constexpr const char* YAML_DSP = "dsp";
+  static constexpr const char* YAML_MVE = "mve";
+  static constexpr const char* YAML_ENDIAN = "endian";
+  static constexpr const char* YAML_TRUSTZONE = "trustzone";
+  static constexpr const char* YAML_BRANCH_PROTECTION = "branch-protection";
+
+  static constexpr const char* YAML_ON = "on";
+  static constexpr const char* YAML_OFF = "off";
+  static constexpr const char* YAML_FPU_DP = "dp";
+  static constexpr const char* YAML_FPU_SP = "sp";
+  static constexpr const char* YAML_MVE_FP = "fp";
+  static constexpr const char* YAML_MVE_INT = "int";
+  static constexpr const char* YAML_ENDIAN_BIG = "big";
+  static constexpr const char* YAML_ENDIAN_LITTLE = "little";
+  static constexpr const char* YAML_BP_BTI = "bti";
+  static constexpr const char* YAML_BP_BTI_SIGNRET = "bti-signret";
+  static constexpr const char* YAML_TZ_SECURE = "secure";
+  static constexpr const char* YAML_TZ_NON_SECURE = "non-secure";
+
+  static constexpr const char* RTE_DFPU = "Dfpu";
+  static constexpr const char* RTE_DDSP = "Ddsp";
+  static constexpr const char* RTE_DMVE = "Dmve";
+  static constexpr const char* RTE_DENDIAN = "Dendian";
+  static constexpr const char* RTE_DSECURE = "Dsecure";
+  static constexpr const char* RTE_DTZ = "Dtz";
+  static constexpr const char* RTE_DBRANCHPROT = "DbranchProt";
+  static constexpr const char* RTE_DPACBTI = "Dpacbti";
+
+  static constexpr const char* RTE_DP_FPU = "DP_FPU";
+  static constexpr const char* RTE_SP_FPU = "SP_FPU";
+  static constexpr const char* RTE_NO_FPU = "NO_FPU";
+  static constexpr const char* RTE_DSP = "DSP";
+  static constexpr const char* RTE_NO_DSP = "NO_DSP";
+  static constexpr const char* RTE_MVE = "MVE";
+  static constexpr const char* RTE_FP_MVE = "FP_FVE";
+  static constexpr const char* RTE_NO_MVE = "NO_MVE";
+  static constexpr const char* RTE_ENDIAN_BIG = "Big-endian";
+  static constexpr const char* RTE_ENDIAN_LITTLE = "Little-endian";
+  static constexpr const char* RTE_ENDIAN_CONFIGURABLE = "Configurable";
+  static constexpr const char* RTE_SECURE = "Secure";
+  static constexpr const char* RTE_NON_SECURE = "Non-secure";
+  static constexpr const char* RTE_TZ_DISABLED = "TZ-disabled";
+  static constexpr const char* RTE_NO_TZ = "NO_TZ";
+  static constexpr const char* RTE_BTI = "BTI";
+  static constexpr const char* RTE_BTI_SIGNRET = "BTI_SIGNRET";
+  static constexpr const char* RTE_NO_BRANCHPROT = "NO_BRANCHPROT";
+  static constexpr const char* RTE_NO_PACBTI = "NO_PACBTI";
+
+  static const StrMap        DeviceAttributesKeys;
+  static const StrPairVecMap DeviceAttributesValues;
+
+  /**
+   * @brief get equivalent device attribute
+   * @param key device attribute rte key
+   * @param value device attribute value (rte or yaml)
+   * @return rte or yaml equivalent device value
+  */
+  static const std::string& GetDeviceAttribute(const std::string& key, const std::string& value);
 
 };
 

--- a/libs/rteutils/include/RteUtils.h
+++ b/libs/rteutils/include/RteUtils.h
@@ -20,14 +20,6 @@
 #include "VersionCmp.h"
 #include "WildCards.h"
 
-#include <string>
-#include <list>
-#include <map>
-#include <set>
-#include <vector>
-#include <algorithm>
-
-
 class RteUtils
 {
 private:
@@ -37,7 +29,7 @@ public:
   /**
    * @brief determine prefix of a string
    * @param s string containing the prefix
-   * @param delimiter delimiter after the prefix
+   * @param delimiter char delimiter after the prefix
    * @param withDelimiter true if returned string should contain delimiter, otherwise false
    * @return return prefix of a string with or without delimiter
   */
@@ -45,7 +37,7 @@ public:
   /**
    * @brief determine suffix of a string
    * @param s string containing the suffix
-   * @param delimiter delimiter ahead of the suffix
+   * @param delimiter char delimiter before suffix
    * @param withDelimiter true if returned string should contain delimiter, otherwise false
    * @return return suffix of a string with or without delimiter
   */
@@ -53,21 +45,21 @@ public:
   /**
    * @brief determine suffix as integer
    * @param s string containing the suffix
-   * @param delimiter delimiter ahead of the suffix
+   * @param delimiter char delimiter before suffix
    * @return return suffix as integer
   */
   static int    GetSuffixAsInt(const std::string& s, char delimiter = ':');
   /**
    * @brief determine string after a delimiter
    * @param s string containing delimiter
-   * @param delimiter delimiter to look for
+   * @param delimiter string delimiter to look for
    * @return return string after delimiter
   */
   static std::string RemovePrefixByString(const std::string& s, const char* delimiter = ":");
   /**
    * @brief determine string ahead of a delimiter
    * @param s string containing delimiter
-   * @param delimiter delimiter to look for
+   * @param delimiter string delimiter to look for
    * @return return string ahead of delimiter
   */
   static std::string RemoveSuffixByString(const std::string& s, const char* delimiter = ":");
@@ -135,6 +127,14 @@ public:
    * @return reference supplied string
    */
   static std::string& ReplaceAll(std::string& str, const std::string& toReplace, const std::string& with);
+
+  /**
+   * @brief expand string by replacing $keyword$ with corresponding values
+   * @param source string to expand
+   * @param variables string to string map with keyword values
+   * @return expanded string
+  */
+  static std::string ExpandString(const std::string& src, const StrMap& variables);
 
   /**
    * @brief replace blank(s) with underscore(s)
@@ -346,18 +346,7 @@ public:
    * @return XML specification of attributes
   */
   static std::string ToXmlString(const std::map<std::string, std::string>& attributes);
-  /**
-   * @brief remove duplicate elements from vector without changing the order of elements
-   * @param input vector to be processed
-  */
-  template <typename T>
-  static void RemoveVectorDuplicates(std::vector<T>& elemVec) {
-    auto end = elemVec.end();
-    for (auto itr = elemVec.begin(); itr != end; ++itr) {
-      end = std::remove(itr + 1, end, *itr);
-    }
-    elemVec.erase(end, elemVec.end());
-  }
+
 
   static const std::string EMPTY_STRING;
   static const std::string DASH_STRING;

--- a/libs/rteutils/src/CollectionUtils.cpp
+++ b/libs/rteutils/src/CollectionUtils.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "CollectionUtils.h"
+#include <algorithm>
+
+using namespace std;
+
+void CollectionUtils::PushBackUniquely(vector<string>& vec, const string& value) {
+  if (find(vec.cbegin(), vec.cend(), value) == vec.cend()) {
+    vec.push_back(value);
+  }
+}
+
+void CollectionUtils::PushBackUniquely(list<string>& list, const string& value) {
+  if (find(list.cbegin(), list.cend(), value) == list.cend()) {
+    list.push_back(value);
+  }
+}
+
+void CollectionUtils::PushBackUniquely(StrPairVec& vec, const StrPair& value) {
+  for (const auto& item : vec) {
+    if ((value.first == item.first) && (value.second == item.second)) {
+      return;
+    }
+  }
+  vec.push_back(value);
+}
+
+StrVecMap CollectionUtils::MergeStrVecMap(const StrVecMap& map1, const StrVecMap& map2) {
+  StrVecMap mergedMap(map1);
+  mergedMap.insert(map2.begin(), map2.end());
+  return mergedMap;
+}
+
+// end of CollectionUtils.cpp

--- a/libs/rteutils/src/RteConstants.cpp
+++ b/libs/rteutils/src/RteConstants.cpp
@@ -1,0 +1,60 @@
+/******************************************************************************/
+/* RTE  -  CMSIS Run-Time Environment				                          */
+/******************************************************************************/
+/** @file  RteConstants.cpp
+  * @brief CMSIS RTE Data Model
+*/
+/******************************************************************************/
+/*
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/******************************************************************************/
+
+#include "RteConstants.h"
+#include "RteUtils.h"
+
+using namespace std;
+
+const StrMap RteConstants::DeviceAttributesKeys = {
+  { RTE_DFPU       , YAML_FPU               },
+  { RTE_DDSP       , YAML_DSP               },
+  { RTE_DMVE       , YAML_MVE               },
+  { RTE_DENDIAN    , YAML_ENDIAN            },
+  { RTE_DSECURE    , YAML_TRUSTZONE         },
+  { RTE_DBRANCHPROT, YAML_BRANCH_PROTECTION },
+};
+
+const StrPairVecMap RteConstants::DeviceAttributesValues = {
+  { RTE_DFPU       , {{ RTE_DP_FPU       , YAML_FPU_DP         },
+                      { RTE_SP_FPU       , YAML_FPU_SP         },
+                      { RTE_NO_FPU       , YAML_OFF            }}},
+  { RTE_DDSP       , {{ RTE_DSP          , YAML_ON             },
+                      { RTE_NO_DSP       , YAML_OFF            }}},
+  { RTE_DMVE       , {{ RTE_FP_MVE       , YAML_MVE_FP         },
+                      { RTE_MVE          , YAML_MVE_INT        },
+                      { RTE_NO_MVE       , YAML_OFF            }}},
+  { RTE_DENDIAN    , {{ RTE_ENDIAN_BIG   , YAML_ENDIAN_BIG     },
+                      { RTE_ENDIAN_LITTLE, YAML_ENDIAN_LITTLE  }}},
+  { RTE_DSECURE    , {{ RTE_SECURE       , YAML_TZ_SECURE      },
+                      { RTE_NON_SECURE   , YAML_TZ_NON_SECURE  },
+                      { RTE_TZ_DISABLED  , YAML_OFF            }}},
+  { RTE_DBRANCHPROT, {{ RTE_BTI          , YAML_BP_BTI         },
+                      { RTE_BTI_SIGNRET  , YAML_BP_BTI_SIGNRET },
+                      { RTE_NO_BRANCHPROT, YAML_OFF            }}},
+};
+
+const string& RteConstants::GetDeviceAttribute(const string& key, const string& value) {
+  const auto& values = DeviceAttributesValues.at(key);
+  for (const auto& [rte, yaml] : values) {
+    if (value == rte) {
+      return yaml;
+    } else if  (value == yaml) {
+      return rte;
+    }
+  }
+  return RteUtils::EMPTY_STRING;
+}
+
+// end of RteConstants.cpp

--- a/libs/rteutils/src/RteUtils.cpp
+++ b/libs/rteutils/src/RteUtils.cpp
@@ -17,6 +17,7 @@
 
 #include <cstring>
 #include <sstream>
+#include <regex>
 
 using namespace std;
 
@@ -154,6 +155,19 @@ std::string& RteUtils::ReplaceAll(std::string& str, const string& toReplace, con
   return str;
 }
 
+string RteUtils::ExpandString(const string& src, const StrMap& variables) {
+  string ret = src;
+  if (regex_match(ret, regex(".*\\$.*\\$.*"))) {
+    for (const auto& [varName, replacement] : variables) {
+      const string var = "$" + varName + "$";
+      size_t index = 0;
+      while ((index = ret.find(var)) != string::npos) {
+        ret.replace(index, var.length(), replacement);
+      }
+    }
+  }
+  return ret;
+}
 
 string RteUtils::SpacesToUnderscore(const string& s)
 {
@@ -238,9 +252,6 @@ string RteUtils::EnsureLf(const std::string& s)
   return ReplaceAll(tmp, RteUtils::CR_STRING, RteUtils::LF_STRING);
 }
 
-
-
-
 string RteUtils::ExpandInstancePlaceholders(const string& s, int count)
 {
   static string INSTANCE = "%Instance%";
@@ -261,7 +272,6 @@ string RteUtils::ExpandInstancePlaceholders(const string& s, int count)
   }
   return result;
 }
-
 
 string RteUtils::ExtractFileName(const string& fileName)
 {

--- a/libs/rteutils/test/src/RteUtilsTest.cpp
+++ b/libs/rteutils/test/src/RteUtilsTest.cpp
@@ -27,6 +27,21 @@ TEST(RteUtilsTest, StringToFrom) {
   EXPECT_EQ(RteUtils::LongToString(32,16), "0x20");
 }
 
+TEST(RteUtilsTest, StringToInt) {
+  map<string, int> testDataVec = {
+    { "0", 0 },
+    { " ", 0 },
+    { "", 0 },
+    { "alphanum012345", 0 },
+    { "000", 0 },
+    { "123", 123 },
+    { "+456", 456 },
+  };
+  for (const auto& [input, expected] : testDataVec) {
+    EXPECT_EQ(RteUtils::StringToInt(input, 0), expected);
+  }
+}
+
 TEST(RteUtilsTest, Trim) {
   EXPECT_EQ(RteUtils::Trim("").empty(), true);
   EXPECT_EQ(RteUtils::Trim(" \t\n\r").empty(), true);
@@ -333,22 +348,22 @@ TEST(RteUtilsTest, RemoveVectorDuplicates)
 {
   vector<int> testInput = { 1,2,3,2,4,5,3,6 };
   vector<int> expected  = { 1,2,3,4,5,6 };
-  RteUtils::RemoveVectorDuplicates<int>(testInput);
+  CollectionUtils::RemoveVectorDuplicates<int>(testInput);
   EXPECT_EQ(testInput, expected);
 
   testInput = { 1,1,3,3,1,2,2 };
   expected = { 1,3,2 };
-  RteUtils::RemoveVectorDuplicates<int>(testInput);
+  CollectionUtils::RemoveVectorDuplicates<int>(testInput);
   EXPECT_EQ(testInput, expected);
 
   testInput = { 1,1,1,1,1,1,1,1,1 };
   expected = { 1 };
-  RteUtils::RemoveVectorDuplicates<int>(testInput);
+  CollectionUtils::RemoveVectorDuplicates<int>(testInput);
   EXPECT_EQ(testInput, expected);
 
   testInput = { };
   expected = { };
-  RteUtils::RemoveVectorDuplicates<int>(testInput);
+  CollectionUtils::RemoveVectorDuplicates<int>(testInput);
   EXPECT_EQ(testInput, expected);
 }
 
@@ -436,6 +451,20 @@ TEST(RteUtils, CollectionUtils)
 
   EXPECT_EQ(*get_or_default(strToPtr, "two", sDefault), '2');
   EXPECT_EQ(*get_or_default(strToPtr, "four", sDefault), 'd');
+}
+
+TEST(RteUtils, ExpandString) {
+  StrMap variables = {
+    {"Foo", "./foo"},
+    {"Bar", "./bar"},
+    {"Foo Bar", "./foo-bar"},
+  };
+  EXPECT_EQ(RteUtils::ExpandString("path1: $Foo/bar", variables), "path1: $Foo/bar");
+  EXPECT_EQ(RteUtils::ExpandString("path1: $Foo$/bar", variables), "path1: ./foo/bar");
+  EXPECT_EQ(RteUtils::ExpandString("path2: $Bar$/foo", variables), "path2: ./bar/foo");
+  EXPECT_EQ(RteUtils::ExpandString("$Foo$ $Bar$", variables), "./foo ./bar");
+  EXPECT_EQ(RteUtils::ExpandString("$Foo Bar$", variables), "./foo-bar");
+  EXPECT_EQ(RteUtils::ExpandString("$Foo$ $Foo$ $Foo$", variables), "./foo ./foo ./foo");
 }
 
 // end of RteUtilsTest.cpp

--- a/libs/xmltree/include/XmlItem.h
+++ b/libs/xmltree/include/XmlItem.h
@@ -469,14 +469,14 @@ public:
    * @param rootFileName absolute file name string
   */
   virtual void SetRootFileName(const std::string& rootFileName) {
-    // default does nothing
+    AddAttribute(".", rootFileName, false);  // default adds "." attribute
   }
 
   /**
    * @brief get absolute filename associated with the root item this instance belongs to
-   * @return file name string, empty if no file is associated (default)
+   * @return file name string, empty if no file is associated
   */
-  virtual const std::string& GetRootFileName() const { return EMPTY_STRING; }
+  virtual const std::string& GetRootFileName() const { return GetAttribute("."); }
 
   /**
    * @brief return absolute path of the file this item is read from or associated with

--- a/libs/xmltree/include/XmlTreeItem.h
+++ b/libs/xmltree/include/XmlTreeItem.h
@@ -366,9 +366,14 @@ public:
   */
   const std::string& GetRootFileName() const override
   {
-    TITEM* root = GetRoot();
-    if (root && root != this) // to protect recursion
-      return root->GetRootFileName();
+    const std::string& rootFileName = XmlItem::GetRootFileName();
+    if(!rootFileName.empty()) {
+      return rootFileName;
+    }
+    TITEM* parent = GetParent();
+    if(parent) {
+      return parent->GetRootFileName();
+    }
     return EMPTY_STRING;
   }
 

--- a/libs/xmltree/test/src/XmlTreeTest.cpp
+++ b/libs/xmltree/test/src/XmlTreeTest.cpp
@@ -71,5 +71,19 @@ TEST(XmlTreeTest, GetAttribute) {
     EXPECT_FALSE(e.HasValue(val));
   }
   EXPECT_FALSE(e.EraseAttributes("attr*"));
+
+  EXPECT_TRUE(e.GetRootFileName().empty());
+  e.SetRootFileName("e/foo.bar");
+  EXPECT_EQ(e.GetRootFileName(), "e/foo.bar");
+  EXPECT_EQ(e.GetRootFilePath(true), "e/");
+  EXPECT_EQ(e.GetRootFilePath(false), "e");
+
+  XMLTreeElement* e1 = new XMLTreeElement(e);
+  XMLTreeElement* e2 = new XMLTreeElement(e1);
+  EXPECT_EQ(e1->GetRootFileName(), "e/foo.bar");
+  EXPECT_EQ(e2->GetRootFileName(), "e/foo.bar");
+  e1->SetRootFileName("e1/foo.bar");
+  EXPECT_EQ(e1->GetRootFileName(), "e1/foo.bar");
+  EXPECT_EQ(e2->GetRootFileName(), "e1/foo.bar");
 }
 // end of XmlTreeTest.cpp

--- a/libs/ymltree/test/YmlTreeTest.cpp
+++ b/libs/ymltree/test/YmlTreeTest.cpp
@@ -217,13 +217,13 @@ TEST_F(YmlTreeTestF, ReadFileDefault) {
   EXPECT_TRUE(success);
   EXPECT_TRUE(tree.GetRoot());
   XMLTreeElement* root = tree.GetRoot() ? tree.GetRoot()->GetFirstChild() : nullptr;
-  EXPECT_TRUE(root);
+  ASSERT_TRUE(root);
+  EXPECT_EQ(root->GetRootFileName(), ymlIn);
 
   XmlFormatter xmlFormatter;
   string xmlContent = xmlFormatter.FormatElement(root);
 
   tree.Clear();
-
 }
 
 // end of YmlTreeTest.cpp

--- a/tools/buildmgr/cbuild/include/CbuildUtils.h
+++ b/tools/buildmgr/cbuild/include/CbuildUtils.h
@@ -41,7 +41,6 @@ struct CbuildPackItem
 
 class CbuildUtils {
 public:
-  typedef std::pair<std::string, int> Result;
 
   CbuildUtils();
   ~CbuildUtils();
@@ -120,13 +119,6 @@ public:
   static const std::string StrPathConv(const std::string& path);
 
   /**
-   * @brief execute shell command
-   * @param cmd string shell command to be executed
-   * @return command execution result <string, error_code>
-  */
-  static const Result ExecCommand(const std::string& cmd);
-
-  /**
    * @brief convert path to absolute if it's unambiguously recognized as relative
    *        accept toolchain flag as input (e.g. key=./relative/path)
    * @param path string relative path to concatenate to base
@@ -134,13 +126,6 @@ public:
    * @return an absolute path from a relative path and a fully qualified base path
   */
   static const std::string StrPathAbsolute(const std::string& path, const std::string& base);
-
-  /**
-   * @brief Add a value into a vector if it does not already exist in the vector
-   * @param vec The vector to add the value into
-   * @param value the value to add
-  */
-  static void PushBackUniquely(std::vector<std::string>& vec, const std::string& value);
 
   /**
    * @brief generate json packlist file

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -1478,17 +1478,17 @@ bool CbuildModel::EvalAccessSequence() {
   // remove duplicates
   for (auto& itemList : fieldList) {
     for (auto& [_, item] : *itemList) {
-      RteUtils::RemoveVectorDuplicates<string>(item);
+      CollectionUtils::RemoveVectorDuplicates<string>(item);
     }
   }
-  RteUtils::RemoveVectorDuplicates<string>(m_targetDefines);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetIncludePaths);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetCFlags);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetCxxFlags);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetAsFlags);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetLdFlags);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetLdCFlags);
-  RteUtils::RemoveVectorDuplicates<string>(m_targetLdCxxFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetDefines);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetIncludePaths);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetCFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetCxxFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetAsFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetLdFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetLdCFlags);
+  CollectionUtils::RemoveVectorDuplicates<string>(m_targetLdCxxFlags);
 
   return true;
 }

--- a/tools/buildmgr/cbuild/src/CbuildUtils.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildUtils.cpp
@@ -185,32 +185,6 @@ const string CbuildUtils::StrPathAbsolute(const string& flagText, const string& 
   return result.replace(offset, string::npos, "\"" + path + "\"");
 }
 
-
-const CbuildUtils::Result CbuildUtils::ExecCommand(const string& cmd) {
-  array<char, 128> buffer;
-  string result;
-  int ret_code = -1;
-  std::function<int(FILE*)> close = _pclose;
-  std::function<FILE*(const char*, const char*)> open = _popen;
-
-  auto deleter = [&close, &ret_code](FILE* cmd) { ret_code = close(cmd); };
-  {
-    const unique_ptr<FILE, decltype(deleter)> pipe(open(cmd.c_str(), "r"), deleter);
-    if (pipe) {
-      while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
-        result += buffer.data();
-      }
-    }
-  }
-  return make_pair(result, ret_code);
-}
-
-void CbuildUtils::PushBackUniquely(std::vector<std::string>& vec, const std::string& value) {
-  if (find(vec.cbegin(), vec.cend(), value) == vec.cend()) {
-    vec.push_back(value);
-  }
-}
-
 string CbuildUtils::GenerateJsonPackList(const std::vector<CbuildPackItem>& packList) {
   string json;
   if (!packList.empty()) {

--- a/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
@@ -396,14 +396,14 @@ bool BuildSystemGenerator::GenAuditFile(void) {
 void BuildSystemGenerator::MergeVecStr(const std::vector<std::string>& src, std::vector<std::string>& dest) {
   for (const auto& item : src)
   {
-    CbuildUtils::PushBackUniquely(dest, item);
+    CollectionUtils::PushBackUniquely(dest, item);
   }
 }
 
 void BuildSystemGenerator::MergeVecStrNorm(const std::vector<std::string>& src, std::vector<std::string>& dest) {
   for (const auto& item : src)
   {
-    CbuildUtils::PushBackUniquely(dest, StrNorm(item));
+    CollectionUtils::PushBackUniquely(dest, StrNorm(item));
   }
 }
 

--- a/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.cpp
@@ -83,7 +83,7 @@ void CBuildGenTestFixture::RunCBuildGen(const TestParam& param, string projpath,
       '/' + param.targetArg + ".cprj\" " + param.command +
       (param.options.empty() ? "" : " ") + param.options + "\"";
   }
-  const auto& ret_val = CbuildUtils::ExecCommand(cmd.c_str());
+  const auto& ret_val = CrossPlatformUtils::ExecCommand(cmd.c_str());
   stdoutStr = ret_val.first;
   ASSERT_EQ(param.expect, (ret_val.second == 0) ? true : false);
 }
@@ -209,17 +209,17 @@ void CBuildGenTestFixture::CheckDescriptionFiles(const string& filename1, const 
 }
 
 
-void CBuildGenTestFixture::GetDirectoryItems(const string& inPath, set<string> &Result, const string& ignoreDir) {
+void CBuildGenTestFixture::GetDirectoryItems(const string& inPath, set<string> &result, const string& ignoreDir) {
   string itemPath;
   for (auto& item : fs::directory_iterator(inPath)) {
     if (fs::is_directory(fs::status(item))) {
       if (item.path().filename().compare(ignoreDir) == 0) {
         continue;
       }
-      GetDirectoryItems(item.path().generic_string(), Result, ignoreDir);
+      GetDirectoryItems(item.path().generic_string(), result, ignoreDir);
     }
     itemPath = item.path().generic_string();
-    Result.insert(itemPath.substr(inPath.length() + 1, itemPath.length()));
+    result.insert(itemPath.substr(inPath.length() + 1, itemPath.length()));
   }
 }
 

--- a/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.h
+++ b/tools/buildmgr/test/integrationtests/src/CBuildGenTestFixture.h
@@ -22,7 +22,7 @@ protected:
   void CheckCMakeIntermediateDir (const TestParam& param, const std::string& intdir);
   void CheckCPInstallFile        (const TestParam& param, bool json=false);
 
-  void GetDirectoryItems         (const std::string& inPath, std::set<std::string> &Result, const std::string& ignoreDir);
+  void GetDirectoryItems         (const std::string& inPath, std::set<std::string> &result, const std::string& ignoreDir);
 
   std::string stdoutStr;
 };

--- a/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
@@ -33,14 +33,14 @@ void DebPkgTests::SetUp() {
 
 string DebPkgTests::FindPackage(const string& path) {
   string cmd = "find " + path + " -name *.deb";
-  string pkgfile = CbuildUtils::ExecCommand(cmd.c_str()).first;
+  string pkgfile = CrossPlatformUtils::ExecCommand(cmd.c_str()).first;
   pkgfile.erase(pkgfile.find_last_not_of(" \f\n\r\t\v") + 1);
   return pkgfile;
 }
 
 void DebPkgTests::ExtractPackage(const string& pkg, const string& extPath) {
   string cmd = "dpkg-deb -xv " + pkg + " " + extPath;
-  auto res = CbuildUtils::ExecCommand(cmd.c_str());
+  auto res = CrossPlatformUtils::ExecCommand(cmd.c_str());
 
   ASSERT_FALSE(res.first.empty());
   ASSERT_EQ(res.second, 0);
@@ -93,13 +93,13 @@ TEST_F(DebPkgTests, CheckMetadata) {
 
   cmd = "find " + debpkgpath + " -name *.deb";
 
-  auto result = CbuildUtils::ExecCommand(cmd.c_str());
+  auto result = CrossPlatformUtils::ExecCommand(cmd.c_str());
   ASSERT_FALSE(result.first.empty());
   ASSERT_EQ(result.second, 0);
 
   string pkgfile = result.first;
   cmd = "dpkg-deb --info " + pkgfile;
-  auto res = CbuildUtils::ExecCommand(cmd.c_str());
+  auto res = CrossPlatformUtils::ExecCommand(cmd.c_str());
   ASSERT_FALSE(res.first.empty());
   ASSERT_EQ(res.second, 0);
 

--- a/tools/buildmgr/test/unittests/src/BuildSystemGeneratorTests.cpp
+++ b/tools/buildmgr/test/unittests/src/BuildSystemGeneratorTests.cpp
@@ -54,7 +54,7 @@ void BuildSystemGeneratorTests::CreateBuildArtifacts(const string& outPath,
   RteFsUtils::CreateDirectories(outPath);
   for (const auto& fileName : testBuildArtifactNames) {
     string filePath = outPath + "/" + fileName;
-    ASSERT_TRUE(RteFsUtils::CreateFile(filePath, RteUtils::EMPTY_STRING)) <<
+    ASSERT_TRUE(RteFsUtils::CreateTextFile(filePath, RteUtils::EMPTY_STRING)) <<
       "unable to create file '" + filePath + "'";
   }
 }
@@ -186,7 +186,7 @@ TEST_F(BuildSystemGeneratorTests, GenAuditFile_With_Existing_Audit_File) {
   };
 
   CreateBuildArtifacts(testout_folder, testBuildArtifactNames);
-  RteFsUtils::CreateFile(file, RteUtils::EMPTY_STRING);
+  RteFsUtils::CreateTextFile(file, RteUtils::EMPTY_STRING);
 
   EXPECT_TRUE(GenAuditFile());
   EXPECT_TRUE(fs::exists(file, ec));

--- a/tools/buildmgr/test/unittests/src/CbuildModelTests.cpp
+++ b/tools/buildmgr/test/unittests/src/CbuildModelTests.cpp
@@ -50,9 +50,9 @@ TEST_F(CbuildModelTests, GetCompatibleToolchain_Select_Latest) {
 
   // Select latest compatible toolchain
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.6.6.4.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.6.16.0.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/GCC.6.19.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/AC6.6.6.4.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/AC6.6.16.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/GCC.6.19.0.cmake", ""));
   EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
   EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);
@@ -79,8 +79,8 @@ TEST_F(CbuildModelTests, GetCompatibleToolchain_Invalid_Files) {
 
   // No .cmake file found
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/test.info", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/AC6.info", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/test.info", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/AC6.info", ""));
   EXPECT_FALSE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, RteUtils::EMPTY_STRING);
   EXPECT_EQ(m_toolchainConfig, RteUtils::EMPTY_STRING);
@@ -97,9 +97,9 @@ TEST_F(CbuildModelTests, GetCompatibleToolchain_Select_Latest_recursively) {
 
   // Select latest compatible toolchain
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir+"/Test"));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
   EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
   EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);
@@ -124,9 +124,9 @@ TEST_F(CbuildModelTests, GetCompatibleToolchain_Registered) {
 
   // Select latest compatible toolchain
   ASSERT_TRUE(RteFsUtils::CreateDirectories(toolchainDir + "/Test"));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
-  ASSERT_TRUE(RteFsUtils::CreateFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/AC6.6.6.4.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/AC6.6.16.0.cmake", ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(toolchainDir + "/Test/GCC.6.19.0.cmake", ""));
   EXPECT_TRUE(GetCompatibleToolchain(name, versionRange, toolchainDir, envVars));
   EXPECT_EQ(m_toolchainConfigVersion, expectedToolchainVersion);
   EXPECT_EQ(m_toolchainConfig, expectedToolchainConfig);

--- a/tools/buildmgr/test/unittests/src/UtilsTests.cpp
+++ b/tools/buildmgr/test/unittests/src/UtilsTests.cpp
@@ -165,23 +165,6 @@ TEST_F(CbuildUtilsTests, StrPathAbsolute) {
   // Restore CWD
   fs::current_path(cwd, ec);
 }
-
-TEST_F(CbuildUtilsTests, ExecCommand) {
-  auto result = CbuildUtils::ExecCommand("invalid command");
-  EXPECT_EQ(false, (0 == result.second) ? true : false) << result.first;
-
-  string testdir = "mkdir_test_dir";
-  fs::current_path(testout_folder);
-  if (fs::exists(testdir)) RemoveDir(testdir);
-
-  result = CbuildUtils::ExecCommand("mkdir " + testdir);
-  EXPECT_TRUE(fs::exists(testdir));
-  EXPECT_EQ(true, (0 == result.second) ? true : false) << result.first;
-
-  fs::current_path(CBuildUnitTestEnv::workingDir);
-  RemoveDir(testdir);
-}
-
 TEST_F(CbuildUtilsTests, EscapeQuotes) {
   string result = CbuildUtils::EscapeQuotes("-DFILE=\"config.h\"");
   EXPECT_EQ(result, "-DFILE=\\\"config.h\\\"");

--- a/tools/packchk/src/PackChk.cpp
+++ b/tools/packchk/src/PackChk.cpp
@@ -75,7 +75,7 @@ bool PackChk::CreatePacknameFile(const string& filename, RtePackage* pKg)
 
   string absPath = RteFsUtils::AbsolutePath(filename).generic_string();
   string content = pdscRef + "." + pkgVendor + "." + pkgVersion + PKG_FEXT;
-  if(!RteFsUtils::CreateFile(absPath, content)) {
+  if(!RteFsUtils::CreateTextFile(absPath, content)) {
     LogMsg("M205", PATH(absPath));
     return false;
   }

--- a/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
+++ b/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
@@ -295,11 +295,11 @@ TEST_F(PackChkIntegTests, AddRefPacks) {
   refPack3 = outDir + refPack3;
   refPack4 = outDir + refPack4;
 
-  ASSERT_TRUE(RteFsUtils::CreateFile(refPackTest, contentBegin + refNameTest + contentEnd));
-  ASSERT_TRUE(RteFsUtils::CreateFile(refPack1, contentBegin + refName1 + contentEnd));
-  ASSERT_TRUE(RteFsUtils::CreateFile(refPack2, contentBegin + refName2 + contentEnd));
-  ASSERT_TRUE(RteFsUtils::CreateFile(refPack3, contentBegin + refName3 + contentEnd));
-  ASSERT_TRUE(RteFsUtils::CreateFile(refPack4, contentBegin + refName4 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(refPackTest, contentBegin + refNameTest + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(refPack1, contentBegin + refName1 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(refPack2, contentBegin + refName2 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(refPack3, contentBegin + refName3 + contentEnd));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(refPack4, contentBegin + refName4 + contentEnd));
 
   ASSERT_TRUE(RteFsUtils::Exists(refPackTest));
   ASSERT_TRUE(RteFsUtils::Exists(refPack1));

--- a/tools/packchk/test/unittests/src/TestCheckFiles.cpp
+++ b/tools/packchk/test/unittests/src/TestCheckFiles.cpp
@@ -118,7 +118,7 @@ TEST_F(TestCheckFiles, CheckFileExtension_IncludeNoSlash) {
 TEST_F(TestCheckFiles, CheckFileExtension_IncludeNotADir) {
   // GIVEN an existing header file
   const string checkFile = "CheckFileExtension/TheIncludeDir/header.h";
-  ASSERT_TRUE(RteFsUtils::CreateFile(string(BUILD_FOLDER)+checkFile, ""));
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(string(BUILD_FOLDER)+checkFile, ""));
 
   // ... AND an item refering to this file as category include
   RteItem item(NULL);
@@ -157,10 +157,10 @@ TEST_F(TestCheckFiles, CheckCaseSense)
     RteFsUtils::RemoveDir(testDataFolder);
   }
   ASSERT_TRUE(RteFsUtils::CreateDirectories(testApiFolder));
-  ASSERT_TRUE(RteFsUtils::CreateFile(
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(
     testApiFolder + "/Exclusive.h", RteUtils::EMPTY_STRING));
   ASSERT_TRUE(RteFsUtils::CreateDirectories(testDataFolder + "/.test1"));
-  ASSERT_TRUE(RteFsUtils::CreateFile(
+  ASSERT_TRUE(RteFsUtils::CreateTextFile(
     testDataFolder + "/.test1/NonExclusive.h", RteUtils::EMPTY_STRING));
   checkFiles.SetPackagePath(testDataFolder);
 

--- a/tools/packgen/include/PackGen.h
+++ b/tools/packgen/include/PackGen.h
@@ -195,7 +195,6 @@ YAML::Emitter& operator << (YAML::Emitter& out, const queryRequests& req);
 
 class PackGen {
 public:
-  typedef std::pair<std::string, int> Result;
 
   /**
    * @brief class constructor
@@ -255,13 +254,6 @@ public:
    * @return true if no errors happened, false otherwise
   */
   bool CompressPack(void);
-
-  /**
-   * @brief execute external command in the underlying shell
-   * @param cmd command to be executed
-   * @return command execution result <string, error_code>
-  */
-  static const Result ExecCommand(const std::string& cmd);
 
 protected:
   std::string m_manifest;

--- a/tools/projmgr/include/ProjMgrExtGenerator.h
+++ b/tools/projmgr/include/ProjMgrExtGenerator.h
@@ -48,19 +48,13 @@ public:
   /**
    * @brief class destructor
   */
-  ~ProjMgrExtGenerator(void);
+  ~ProjMgrExtGenerator();
 
   /**
    * @brief set check schema
    * @param boolean check schema
   */
   void SetCheckSchema(bool checkSchema);
-
-  /**
-   * @brief retrieve globally registered generators
-   * @return true if successful
-  */
-  bool RetrieveGlobalGenerators(void);
 
   /**
    * @brief verify if generator is global
@@ -122,11 +116,8 @@ public:
 
 protected:
   ProjMgrParser* m_parser = nullptr;
-  StrVec m_globalGeneratorFiles;
-  std::map<std::string, GlobalGeneratorItem> m_globalGenerators;
   GeneratorContextVecMap m_usedGenerators;
   bool m_checkSchema;
-  std::string m_compilerRoot;
 };
 
 #endif  // PROJMGREXTGENERATOR_H

--- a/tools/projmgr/include/ProjMgrUtils.h
+++ b/tools/projmgr/include/ProjMgrUtils.h
@@ -82,56 +82,6 @@ typedef std::vector<ConnectionsCollection> ConnectionsCollectionVec;
 typedef std::map<std::string, ConnectionsCollectionVec> ConnectionsCollectionMap;
 
 /**
-  * @brief string pair
- */
-typedef std::pair<std::string, std::string> StrPair;
-
-/**
- * @brief string vector
-*/
-typedef std::vector<std::string> StrVec;
-
-/**
- * @brief string set
-*/
-typedef std::set<std::string> StrSet;
-
-/**
- * @brief vector of string pair
-*/
-typedef std::vector<StrPair> StrPairVec;
-
-/**
- * @brief vector of string pair pointer
-*/
-typedef std::vector<const StrPair*> StrPairPtrVec;
-
-/**
- * @brief map of vector of string pair
-*/
-typedef std::map<std::string, StrPairVec> StrPairVecMap;
-
-/**
- * @brief map of string vector
-*/
-typedef std::map<std::string, StrVec> StrVecMap;
-
-/**
- * @brief map of int
-*/
-typedef std::map<std::string, int> IntMap;
-
-/**
- * @brief map of bool
-*/
-typedef std::map<std::string, bool> BoolMap;
-
-/**
- * @brief map of string
-*/
-typedef std::map<std::string, std::string> StrMap;
-
-/**
  * @brief project manager utility class
 */
 class ProjMgrUtils {
@@ -144,110 +94,6 @@ protected:
 
 public:
 
-  typedef std::pair<std::string, int> Result;
-
-  /**
-   * @brief output types
-  */
-  static constexpr const char* OUTPUT_TYPE_BIN = "bin";
-  static constexpr const char* OUTPUT_TYPE_ELF = "elf";
-  static constexpr const char* OUTPUT_TYPE_HEX = "hex";
-  static constexpr const char* OUTPUT_TYPE_LIB = "lib";
-  static constexpr const char* OUTPUT_TYPE_CMSE = "cmse-lib";
-
-  /**
-   * @brief access sequences
-  */
-  static constexpr const char* AS_SOLUTION = "Solution";
-  static constexpr const char* AS_PROJECT = "Project";
-  static constexpr const char* AS_COMPILER = "Compiler";
-  static constexpr const char* AS_BUILD_TYPE = "BuildType";
-  static constexpr const char* AS_TARGET_TYPE = "TargetType";
-  static constexpr const char* AS_DNAME = "Dname";
-  static constexpr const char* AS_PNAME = "Pname";
-  static constexpr const char* AS_BNAME = "Bname";
-
-  static constexpr const char* AS_SOLUTION_DIR = "SolutionDir";
-  static constexpr const char* AS_PROJECT_DIR = "ProjectDir";
-  static constexpr const char* AS_OUT_DIR = "OutDir";
-  static constexpr const char* AS_BIN = OUTPUT_TYPE_BIN;
-  static constexpr const char* AS_ELF = OUTPUT_TYPE_ELF;
-  static constexpr const char* AS_HEX = OUTPUT_TYPE_HEX;
-  static constexpr const char* AS_LIB = OUTPUT_TYPE_LIB;
-  static constexpr const char* AS_CMSE = OUTPUT_TYPE_CMSE;
-
-  /**
-   * @brief default and toolchain specific output affixes
-  */
-  static constexpr const char* DEFAULT_ELF_SUFFIX = ".elf";
-  static constexpr const char* DEFAULT_LIB_PREFIX = "";
-  static constexpr const char* DEFAULT_LIB_SUFFIX = ".a";
-
-  static constexpr const char* AC6_ELF_SUFFIX = ".axf";
-  static constexpr const char* GCC_ELF_SUFFIX = ".elf";
-  static constexpr const char* IAR_ELF_SUFFIX = ".out";
-  static constexpr const char* AC6_LIB_PREFIX = "";
-  static constexpr const char* GCC_LIB_PREFIX = "lib";
-  static constexpr const char* IAR_LIB_PREFIX = "";
-  static constexpr const char* AC6_LIB_SUFFIX = ".lib";
-  static constexpr const char* GCC_LIB_SUFFIX = ".a";
-  static constexpr const char* IAR_LIB_SUFFIX = ".a";
-
-  /**
-   * @brief device attributes maps
-  */
-  static constexpr const char* YAML_FPU = "fpu";
-  static constexpr const char* YAML_DSP = "dsp";
-  static constexpr const char* YAML_MVE = "mve";
-  static constexpr const char* YAML_ENDIAN = "endian";
-  static constexpr const char* YAML_TRUSTZONE = "trustzone";
-  static constexpr const char* YAML_BRANCH_PROTECTION = "branch-protection";
-
-  static constexpr const char* YAML_ON = "on";
-  static constexpr const char* YAML_OFF = "off";
-  static constexpr const char* YAML_FPU_DP = "dp";
-  static constexpr const char* YAML_FPU_SP = "sp";
-  static constexpr const char* YAML_MVE_FP = "fp";
-  static constexpr const char* YAML_MVE_INT = "int";
-  static constexpr const char* YAML_ENDIAN_BIG = "big";
-  static constexpr const char* YAML_ENDIAN_LITTLE = "little";
-  static constexpr const char* YAML_BP_BTI = "bti";
-  static constexpr const char* YAML_BP_BTI_SIGNRET = "bti-signret";
-  static constexpr const char* YAML_TZ_SECURE = "secure";
-  static constexpr const char* YAML_TZ_NON_SECURE = "non-secure";
-
-  static constexpr const char* RTE_DFPU = "Dfpu";
-  static constexpr const char* RTE_DDSP = "Ddsp";
-  static constexpr const char* RTE_DMVE = "Dmve";
-  static constexpr const char* RTE_DENDIAN = "Dendian";
-  static constexpr const char* RTE_DSECURE = "Dsecure";
-  static constexpr const char* RTE_DTZ = "Dtz";
-  static constexpr const char* RTE_DBRANCHPROT = "DbranchProt";
-  static constexpr const char* RTE_DPACBTI = "Dpacbti";
-
-  static constexpr const char* RTE_DP_FPU = "DP_FPU";
-  static constexpr const char* RTE_SP_FPU = "SP_FPU";
-  static constexpr const char* RTE_NO_FPU = "NO_FPU";
-  static constexpr const char* RTE_DSP = "DSP";
-  static constexpr const char* RTE_NO_DSP = "NO_DSP";
-  static constexpr const char* RTE_MVE = "MVE";
-  static constexpr const char* RTE_FP_MVE = "FP_FVE";
-  static constexpr const char* RTE_NO_MVE = "NO_MVE";
-  static constexpr const char* RTE_ENDIAN_BIG = "Big-endian";
-  static constexpr const char* RTE_ENDIAN_LITTLE = "Little-endian";
-  static constexpr const char* RTE_ENDIAN_CONFIGURABLE = "Configurable";
-  static constexpr const char* RTE_SECURE = "Secure";
-  static constexpr const char* RTE_NON_SECURE = "Non-secure";
-  static constexpr const char* RTE_TZ_DISABLED = "TZ-disabled";
-  static constexpr const char* RTE_NO_TZ = "NO_TZ";
-  static constexpr const char* RTE_BTI = "BTI";
-  static constexpr const char* RTE_BTI_SIGNRET = "BTI_SIGNRET";
-  static constexpr const char* RTE_NO_BRANCHPROT = "NO_BRANCHPROT";
-  static constexpr const char* RTE_NO_PACBTI = "NO_PACBTI";
-
-  static const StrMap DeviceAttributesKeys;
-  static const StrPairVecMap DeviceAttributesValues;
-
   /**
    * @brief read gpdsc file
    * @param path to gpdsc file
@@ -257,45 +103,7 @@ public:
   */
   static RtePackage* ReadGpdscFile(const std::string& gpdsc, bool& valid);
 
-  /**
-   * @brief execute shell command
-   * @param cmd string shell command to be executed
-   * @return command execution result <string, error_code>
-  */
-  static const Result ExecCommand(const std::string& cmd);
-
-  /**
-   * @brief get file category according to file extension
-   * @param filename with extension
-   * @return string category
-  */
-  static const std::string GetCategory(const std::string& file);
-
-  /**
-   * @brief add a value into a vector/list if it does not already exist in the vector/list
-   * @param vec/list the vector/list to add the value into
-   * @param value the value to add
-  */
-  static void PushBackUniquely(std::vector<std::string>& vec, const std::string& value);
-  static void PushBackUniquely(std::list<std::string>& lst, const std::string& value);
-  static void PushBackUniquely(StrPairVec& vec, const StrPair& value);
-
-  /**
-   * @brief merge two string vector maps
-   * @param map1 first string vector map
-   * @param map2 second string vector map
-   * @return StrVecMap merged map
-  */
- static StrVecMap MergeStrVecMap(const StrVecMap& map1, const StrVecMap& map2);
-
-  /**
-   * @brief convert string to int, return 0 if it's empty or not convertible
-   * @param string
-   * @return int
-  */
-  static int StringToInt(const std::string& value);
-
-  /**
+ /**
    * @brief expand compiler id the format <name>@[>=]<version> into name, minimum and maximum versions
    * @param compiler id
    * @param name reference to compiler name
@@ -360,14 +168,6 @@ public:
     std::vector<std::string>& selectedContexts,
     const std::vector<std::string>& allAvailableContexts,
     const std::vector<std::string>& contextFilters);
-
-  /**
-   * @brief get equivalent device attribute
-   * @param key device attribute rte key
-   * @param value device attribute value (rte or yaml)
-   * @return rte or yaml equivalent device value
-  */
-  static const std::string& GetDeviceAttribute(const std::string& key, const std::string& value);
 
   /**
    * @brief convert a pack ID to a pack info

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -745,7 +745,6 @@ protected:
     std::vector<ConnectPtrVec>& combinations);
   void PushBackUniquely(ConnectionsCollectionVec& vec, const ConnectionsCollection& value);
   void PushBackUniquely(std::vector<ToolchainItem>& vec, const ToolchainItem& value);
-  std::string ExpandString(const std::string& src, const StrMap& variables);
   void GetRegisteredToolchains(void);
   bool GetLatestToolchain(ToolchainItem& toolchain);
   bool GetToolchainConfig(const std::string& name, const std::string& version, std::string& configPath, std::string& selectedConfigVersion);

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -299,8 +299,11 @@ int ProjMgr::RunProjMgr(int argc, char** argv, char** envp) {
     }
   }
   manager.m_worker.SetEnvironmentVariables(envVars);
-
-  res = manager.ProcessCommands();
+  if(manager.m_worker.InitializeModel()) {
+    res = manager.ProcessCommands();
+  } else {
+    res = 1;
+  }
   return res;
 }
 
@@ -466,11 +469,6 @@ bool ProjMgr::PopulateContexts(void) {
   // Retrieve all context types
   m_worker.RetrieveAllContextTypes();
 
-  // Retrieve global generators
-  if (!m_extGenerator.RetrieveGlobalGenerators()) {
-    return false;
-  }
-
   return true;
 }
 
@@ -489,10 +487,6 @@ bool ProjMgr::RunConfigure(bool printConfig) {
   map<string, ContextItem>* contexts = nullptr;
   m_worker.GetContexts(contexts);
 
-  // Initialize model
-  if (!m_worker.InitializeModel()) {
-    return false;
-  }
   vector<ContextItem*> allContexts;
   vector<string> orderedContexts;
   m_worker.GetYmlOrderedContexts(orderedContexts);

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -183,11 +183,11 @@ void ProjMgrGenerator::GenerateCprjTarget(XMLTreeElement* element, const Context
     targetOutputElement->AddAttribute("rtedir", context.directories.rte);
     const auto& types = context.outputTypes;
     const vector<tuple<bool, const string, const string>> outputTypes = {
-      { types.bin.on, types.bin.filename, ProjMgrUtils::OUTPUT_TYPE_BIN },
-      { types.elf.on, types.elf.filename, ProjMgrUtils::OUTPUT_TYPE_ELF },
-      { types.hex.on, types.hex.filename, ProjMgrUtils::OUTPUT_TYPE_HEX },
-      { types.lib.on, types.lib.filename, ProjMgrUtils::OUTPUT_TYPE_LIB },
-      { types.cmse.on, types.cmse.filename, ProjMgrUtils::OUTPUT_TYPE_CMSE },
+      { types.bin.on, types.bin.filename, RteConstants::OUTPUT_TYPE_BIN },
+      { types.elf.on, types.elf.filename, RteConstants::OUTPUT_TYPE_ELF },
+      { types.hex.on, types.hex.filename, RteConstants::OUTPUT_TYPE_HEX },
+      { types.lib.on, types.lib.filename, RteConstants::OUTPUT_TYPE_LIB },
+      { types.cmse.on, types.cmse.filename, RteConstants::OUTPUT_TYPE_CMSE },
     };
     for (const auto& [on, file, type] : outputTypes) {
       if (on) {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -317,7 +317,7 @@ string ProjMgrWorker::GetPackRoot() {
 
 bool ProjMgrWorker::InitializeModel() {
   if(m_kernel) {
-    return true; // already initialized;
+    return true; // already initialized
   }
   m_packRoot = GetPackRoot();
   m_kernel = ProjMgrKernel::Get();

--- a/tools/projmgr/src/ProjMgrYamlEmitter.cpp
+++ b/tools/projmgr/src/ProjMgrYamlEmitter.cpp
@@ -351,7 +351,6 @@ void ProjMgrYamlCbuild::SetComponentsNode(YAML::Node node, const ContextItem* co
       SetNodeValue(componentNode[YAML_GENERATOR][YAML_ID], component.generator);
       const RteGenerator* rteGenerator = get_or_null(context->generators, component.generator);
       if(rteGenerator && !rteGenerator->IsExternal()) {
-        const RteGenerator* rteGenerator = context->generators.at(component.generator);
         SetNodeValue(componentNode[YAML_GENERATOR][YAML_FROM_PACK], rteGenerator->GetPackageID());
         SetGeneratorFiles(componentNode[YAML_GENERATOR], context, componentId);
       } else if (contains_key(context->extGenDir, component.generator)) {

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -701,7 +701,7 @@ bool ProjMgrYamlParser::ParseContexts(const YAML::Node& parent, CsolutionItem& c
       descriptor.cproject = RteFsUtils::RelativePath(fs::canonical(fs::path(csolution.directory).append(descriptor.cproject), ec).generic_string(), csolution.directory);
       if (!descriptor.cproject.empty()) {
         csolution.contexts.push_back(descriptor);
-        ProjMgrUtils::PushBackUniquely(csolution.cprojects, descriptor.cproject);
+        CollectionUtils::PushBackUniquely(csolution.cprojects, descriptor.cproject);
       }
     }
   }

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -99,7 +99,7 @@ TEST_F(ProjMgrGeneratorUnitTests, FailCreatingDirectories) {
 
   // Create a file with same name as parent directory where cbuild-gen.yml will be attempted to be created
   EXPECT_TRUE(RteFsUtils::CreateDirectories(folder));
-  EXPECT_TRUE(RteFsUtils::CreateFile(folder + "/TypeA", ""));
+  EXPECT_TRUE(RteFsUtils::CreateTextFile(folder + "/TypeA", ""));
 
   EXPECT_EQ(1, ProjMgr::RunProjMgr(6, argv, 0));
 

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -21,6 +21,8 @@ string testcmsispack_folder;
 string testcmsiscompiler_folder;
 string schema_folder;
 string templates_folder;
+string etc_folder;
+string bin_folder;
 
 StdStreamRedirect::StdStreamRedirect() :
   m_outbuffer(""), m_cerrbuffer(""),
@@ -56,6 +58,11 @@ void ProjMgrTestEnv::SetUp() {
   testoutput_folder    = RteFsUtils::GetCurrentFolder() + "output";
   testcmsispack_folder = string(CMAKE_SOURCE_DIR) + "test/packs";
   testcmsiscompiler_folder = testinput_folder + "/TestToolchains";
+  etc_folder = string(PROJMGRUNITTESTS_BIN_PATH) + "/../etc";
+  RteFsUtils::NormalizePath(etc_folder);
+  bin_folder = string(PROJMGRUNITTESTS_BIN_PATH) + "/../bin";
+  RteFsUtils::NormalizePath(bin_folder);
+
   if (RteFsUtils::Exists(testoutput_folder)) {
     RteFsUtils::RemoveDir(testoutput_folder);
   }
@@ -69,12 +76,11 @@ void ProjMgrTestEnv::SetUp() {
   ASSERT_FALSE(schema_folder.empty());
 
   // copy schemas
-  std::string schemaDestDir = string(PROJMGRUNITTESTS_BIN_PATH) + "/../etc";
-  if (RteFsUtils::Exists(schemaDestDir)) {
-    RteFsUtils::RemoveDir(schemaDestDir);
+  if (RteFsUtils::Exists(etc_folder)) {
+    RteFsUtils::RemoveDir(etc_folder);
   }
-  RteFsUtils::CreateDirectories(schemaDestDir);
-  fs::copy(fs::path(schema_folder), fs::path(schemaDestDir), fs::copy_options::recursive, ec);
+  RteFsUtils::CreateDirectories(etc_folder);
+  fs::copy(fs::path(schema_folder), fs::path(etc_folder), fs::copy_options::recursive, ec);
 
   //copy test input data
   if (RteFsUtils::Exists(testinput_folder)) {
@@ -82,6 +88,11 @@ void ProjMgrTestEnv::SetUp() {
   }
   RteFsUtils::CreateDirectories(testinput_folder);
   fs::copy(fs::path(testdata_folder), fs::path(testinput_folder), fs::copy_options::recursive, ec);
+
+  if (RteFsUtils::Exists(bin_folder)) {
+    RteFsUtils::RemoveDir(bin_folder);
+  }
+  RteFsUtils::CreateDirectories(bin_folder);
 
   // copy local pack
   string srcPackPath, destPackPath;
@@ -114,9 +125,9 @@ void ProjMgrTestEnv::SetUp() {
 
   // create dummy cmsis compiler root
   RteFsUtils::CreateDirectories(testcmsiscompiler_folder);
-  RteFsUtils::CreateFile(testcmsiscompiler_folder + "/AC6.6.18.0.cmake", "");
-  RteFsUtils::CreateFile(testcmsiscompiler_folder + "/GCC.11.2.1.cmake", "");
-  RteFsUtils::CreateFile(testcmsiscompiler_folder + "/IAR.8.50.6.cmake", "");
+  RteFsUtils::CreateTextFile(testcmsiscompiler_folder + "/AC6.6.18.0.cmake", "");
+  RteFsUtils::CreateTextFile(testcmsiscompiler_folder + "/GCC.11.2.1.cmake", "");
+  RteFsUtils::CreateTextFile(testcmsiscompiler_folder + "/IAR.8.50.6.cmake", "");
   CrossPlatformUtils::SetEnv("CMSIS_COMPILER_ROOT", testcmsiscompiler_folder);
 
   // copy linker script template files

--- a/tools/projmgr/test/src/ProjMgrTestEnv.h
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.h
@@ -16,7 +16,8 @@ extern std::string testinput_folder;
 extern std::string testcmsispack_folder;
 extern std::string testcmsiscompiler_folder;
 extern std::string schema_folder;
-
+extern std::string etc_folder;
+extern std::string bin_folder;
 /**
  * @brief direct console output to string
 */

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -3318,7 +3318,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_GetCdefaultFile1) {
   const string& testdir = testoutput_folder + "/FindFileRegEx";
   const string& fileName = testdir + "/cdefault.yml";
   RteFsUtils::CreateDirectories(testdir);
-  RteFsUtils::CreateFile(fileName, "");
+  RteFsUtils::CreateTextFile(fileName, "");
   m_rootDir = testdir;
   m_cdefaultFile.clear();
   EXPECT_TRUE(GetCdefaultFile());
@@ -3759,7 +3759,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_WriteCprjFail) {
   argv[9] = (char*)"_export";
 
   // Fail to write export cprj file
-  RteFsUtils::CreateFile(outputFolder + "/test2.Debug+CM0_export.cprj", "");
+  RteFsUtils::CreateTextFile(outputFolder + "/test2.Debug+CM0_export.cprj", "");
   RteFsUtils::SetTreeReadOnly(outputFolder);
   EXPECT_EQ(1, RunProjMgr(10, argv, 0));
 
@@ -3881,7 +3881,7 @@ error csolution: processing context 'outputFiles.TypeConflict\\+Target' failed\n
 
 TEST_F(ProjMgrUnitTests, SelectToolchains) {
   const string& AC6_6_6_5 = testinput_folder + "/TestToolchains/AC6.6.6.5.cmake";
-  RteFsUtils::CreateFile(AC6_6_6_5, "");
+  RteFsUtils::CreateTextFile(AC6_6_6_5, "");
   char* envp[6];
   string ac6_0 = "AC6_TOOLCHAIN_6_20_0=" + testinput_folder;
   string ac6_1 = "AC6_TOOLCHAIN_6_16_1=" + testinput_folder;
@@ -4211,8 +4211,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_UpdateRte) {
   const string& testdir = testoutput_folder + "/OutputDir";
   RteFsUtils::RemoveDir(rteDir);
   RteFsUtils::RemoveDir(testdir);
-  RteFsUtils::CreateFile(configFile, "// config file");
-  RteFsUtils::CreateFile(baseFile, "// config file@base");
+  RteFsUtils::CreateTextFile(configFile, "// config file");
+  RteFsUtils::CreateTextFile(baseFile, "// config file@base");
 
   StdStreamRedirect streamRedirect;
   string csolutionFile = testinput_folder + "/TestSolution/test.csolution.yml";
@@ -4792,12 +4792,13 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_cbuildset_file) {
 }
 
 TEST_F(ProjMgrUnitTests, ExternalGenerator) {
+
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/global.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
 
   const string& srcBridgeTool = testinput_folder + "/ExternalGenerator/bridge.sh";
-  const string& dstBridgeTool = testcmsiscompiler_folder + "/bridge.sh";
+  const string& dstBridgeTool = bin_folder + "/bridge.sh";
   RteFsUtils::CopyCheckFile(srcBridgeTool, dstBridgeTool, false);
 
   // list generators
@@ -4896,7 +4897,7 @@ error csolution: generator 'RteTestExternalGenerator' required by component 'ARM
 
 TEST_F(ProjMgrUnitTests, ExternalGenerator_WrongGenDir) {
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/wrong-gendir.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
 
   StdStreamRedirect streamRedirect;
@@ -4922,7 +4923,7 @@ warning csolution: unknown access sequence: 'UnknownAccessSequence()'\n\
 
 TEST_F(ProjMgrUnitTests, ExternalGenerator_NoGenDir) {
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/no-gendir.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
 
   StdStreamRedirect streamRedirect;
@@ -4967,7 +4968,7 @@ error csolution: a single context must be specified\n\
 
 TEST_F(ProjMgrUnitTests, ExternalGenerator_WrongGeneratedData) {
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/global.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
 
   StdStreamRedirect streamRedirect;
@@ -5003,7 +5004,7 @@ TEST_F(ProjMgrUnitTests, ExternalGenerator_WrongGeneratedData) {
 
 TEST_F(ProjMgrUnitTests, ExternalGenerator_NoCgenFile) {
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/global.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
 
   const string genDir = m_extGenerator.GetGlobalGenDir("RteTestExternalGenerator");
@@ -5027,7 +5028,7 @@ TEST_F(ProjMgrUnitTests, ExternalGenerator_NoCgenFile) {
 
 TEST_F(ProjMgrUnitTests, ExternalGeneratorListVerbose) {
   const string& srcGlobalGenerator = testinput_folder + "/ExternalGenerator/global.generator.yml";
-  const string& dstGlobalGenerator = testcmsiscompiler_folder + "/global.generator.yml";
+  const string& dstGlobalGenerator = etc_folder + "/global.generator.yml";
   RteFsUtils::CopyCheckFile(srcGlobalGenerator, dstGlobalGenerator, false);
   StdStreamRedirect streamRedirect;
 

--- a/tools/projmgr/test/src/ProjMgrUtilsUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUtilsUnitTests.cpp
@@ -72,59 +72,6 @@ TEST_F(ProjMgrUtilsUnitTests, ReadGpdscFileNoExists) {
   EXPECT_FALSE(validGpdsc);
 }
 
-TEST_F(ProjMgrUtilsUnitTests, ExecCommand) {
-  auto result = ProjMgrUtils::ExecCommand("invalid command");
-  EXPECT_EQ(false, (0 == result.second) ? true : false) << result.first;
-
-  string testdir = "mkdir_test_dir";
-  error_code ec;
-  const auto& workingDir = fs::current_path(ec);
-  fs::current_path(testoutput_folder, ec);
-  if (fs::exists(testdir)) {
-    RteFsUtils::RemoveDir(testdir);
-  }
-  result = ProjMgrUtils::ExecCommand("mkdir " + testdir);
-  EXPECT_TRUE(fs::exists(testdir));
-  EXPECT_EQ(true, (0 == result.second) ? true : false) << result.first;
-
-  fs::current_path(workingDir, ec);
-  RteFsUtils::RemoveDir(testdir);
-}
-
-TEST_F(ProjMgrUtilsUnitTests, StrToInt) {
-  map<string, int> testDataVec = {
-    { "0", 0 },
-    { " ", 0 },
-    { "", 0 },
-    { "alphanum012345", 0 },
-    { "000", 0 },
-    { "123", 123 },
-    { "+456", 456 },
-  };
-  for (const auto& [input, expected] : testDataVec) {
-    EXPECT_EQ(ProjMgrUtils::StringToInt(input), expected);
-  }
-}
-
-TEST_F(ProjMgrUtilsUnitTests, GetCategory) {
-  map<string, vector<string>> testDataVec = {
-    {"sourceC",      {"sourceFile.c", "sourceFile.C"}},
-    {"sourceCpp",    {"sourceFile.cpp", "sourceFile.c++", "sourceFile.C++", "sourceFile.cxx", "sourceFile.cc", "sourceFile.CC"}},
-    {"sourceAsm",    {"sourceFile.asm", "sourceFile.s", "sourceFile.S"}},
-    {"header",       {"headerFile.h", "headerFile.hpp"}},
-    {"library",      {"libraryFile.a", "libraryFile.lib"}},
-    {"object",       {"objectFile.o"}},
-    {"linkerScript", {"linkerFile.sct", "linkerFile.scf", "linkerFile.ld", "linkerFile.icf"}},
-    {"doc",          {"documentFile.txt", "documentFile.md", "documentFile.pdf", "documentFile.htm", "documentFile.html"}},
-  };
-  for (const auto& [expected, files] : testDataVec) {
-    for (const auto& file : files) {
-      EXPECT_EQ(ProjMgrUtils::GetCategory(file), expected);
-    }
-  }
-}
-
-
 TEST_F(ProjMgrUtilsUnitTests, CompilersIntersect) {
   string intersection;
   CompilersIntersect("AC6@6.16.0", "AC6", intersection);

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -33,7 +33,7 @@ void ProjMgrWorkerUnitTests::SetCsolutionPacks(CsolutionItem* csolution, std::ve
   }
   context.csolution = csolution;
   context.type.target = targetType;
-  ProjMgrUtils::PushBackUniquely(m_ymlOrderedContexts, targetType);
+  CollectionUtils::PushBackUniquely(m_ymlOrderedContexts, targetType);
   m_contexts.insert(std::pair<string, ContextItem>(string(targetType), context));
 }
 
@@ -1105,21 +1105,6 @@ TEST_F(ProjMgrWorkerUnitTests, CollectLayersFromPacks) {
   EXPECT_FALSE(CollectLayersFromPacks(context, clayers));
 }
 
-TEST_F(ProjMgrWorkerUnitTests, ExpandString) {
-  ContextItem context;
-  context.variables = {
-    {"Foo", "./foo"},
-    {"Bar", "./bar"},
-    {"Foo Bar", "./foo-bar"},
-  };
-
-  EXPECT_EQ(ExpandString("path1: $Foo$/bar", context.variables), "path1: ./foo/bar");
-  EXPECT_EQ(ExpandString("path2: $Bar$/foo", context.variables), "path2: ./bar/foo");
-  EXPECT_EQ(ExpandString("$Foo$ $Bar$", context.variables), "./foo ./bar");
-  EXPECT_EQ(ExpandString("$Foo Bar$", context.variables), "./foo-bar");
-  EXPECT_EQ(ExpandString("$Foo$ $Foo$ $Foo$", context.variables), "./foo ./foo ./foo");
-}
-
 TEST_F(ProjMgrWorkerUnitTests, ListToolchains) {
   const string& cmsisPackRoot = CrossPlatformUtils::GetEnv("CMSIS_COMPILER_ROOT");
 
@@ -1280,7 +1265,7 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessLinkerOptions) {
   linker.regions = linkerRegionsFile;
   cproject.linker.push_back(linker);
   context.compiler = "AC6";
-  context.variables[ProjMgrUtils::AS_COMPILER] = context.compiler;
+  context.variables[RteConstants::AS_COMPILER] = context.compiler;
   string expectedLinkerScriptFile = "path/to/linkerScript_AC6.sct";
   string expectedLinkerRegionsFile = "path/to/linkerRegions_AC6.h";
   EXPECT_TRUE(ProcessLinkerOptions(context));
@@ -1566,22 +1551,22 @@ TEST_F(ProjMgrWorkerUnitTests, CheckDeviceAttributes) {
   StrMap targetAttributes;
   StdStreamRedirect streamRedirect;
 
-  userSelection.branchProtection = ProjMgrUtils::YAML_BP_BTI;
-  userSelection.dsp = ProjMgrUtils::YAML_ON;
-  userSelection.endian = ProjMgrUtils::YAML_ENDIAN_BIG;
-  userSelection.fpu = ProjMgrUtils::YAML_FPU_DP;
-  userSelection.mve = ProjMgrUtils::YAML_MVE_FP;
-  userSelection.trustzone = ProjMgrUtils::YAML_TZ_SECURE;
-  targetAttributes[ProjMgrUtils::RTE_DPACBTI] = ProjMgrUtils::RTE_NO_PACBTI;
-  targetAttributes[ProjMgrUtils::RTE_DDSP] = ProjMgrUtils::RTE_NO_DSP;
-  targetAttributes[ProjMgrUtils::RTE_DENDIAN] = ProjMgrUtils::RTE_ENDIAN_LITTLE;
-  targetAttributes[ProjMgrUtils::RTE_DFPU] = ProjMgrUtils::RTE_SP_FPU;
-  targetAttributes[ProjMgrUtils::RTE_DMVE] = ProjMgrUtils::RTE_NO_MVE;
-  targetAttributes[ProjMgrUtils::RTE_DTZ] = ProjMgrUtils::RTE_NO_TZ;
+  userSelection.branchProtection = RteConstants::YAML_BP_BTI;
+  userSelection.dsp = RteConstants::YAML_ON;
+  userSelection.endian = RteConstants::YAML_ENDIAN_BIG;
+  userSelection.fpu = RteConstants::YAML_FPU_DP;
+  userSelection.mve = RteConstants::YAML_MVE_FP;
+  userSelection.trustzone = RteConstants::YAML_TZ_SECURE;
+  targetAttributes[RteConstants::RTE_DPACBTI] = RteConstants::RTE_NO_PACBTI;
+  targetAttributes[RteConstants::RTE_DDSP] = RteConstants::RTE_NO_DSP;
+  targetAttributes[RteConstants::RTE_DENDIAN] = RteConstants::RTE_ENDIAN_LITTLE;
+  targetAttributes[RteConstants::RTE_DFPU] = RteConstants::RTE_SP_FPU;
+  targetAttributes[RteConstants::RTE_DMVE] = RteConstants::RTE_NO_MVE;
+  targetAttributes[RteConstants::RTE_DTZ] = RteConstants::RTE_NO_TZ;
 
   CheckDeviceAttributes(device, userSelection, targetAttributes);
   auto errStr = streamRedirect.GetErrorString();
-  
+
   EXPECT_TRUE(errStr.find("warning csolution: device 'TestDevice' does not support 'endian: big'") != string::npos);
   EXPECT_TRUE(errStr.find("warning csolution: device 'TestDevice' does not support 'fpu: dp'") != string::npos);
   EXPECT_TRUE(errStr.find("warning csolution: device 'TestDevice' does not support 'dsp: on'") != string::npos);


### PR DESCRIPTION
* Support for external generators in RTE Model
read .generator.yml files
make some common code accessible from different tools
remove duplicated methods
read generators.yml  in RTE Model
move ExecCommand to CrossPlatformUtils
move constants to RteConstants
move some utility methods to CollectionUtils
rename RteFsUtils::CreateFile to RteFsUtils::CreateTextFile due to clash with Windows API
