### PR TITLE
Update/Get context specific pack missing info (#809)

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -623,6 +623,7 @@ protected:
   std::vector<std::string> m_ymlOrderedContexts;
   std::map<std::string, ContextItem> m_contexts;
   std::map<std::string, ContextItem>* m_contextsPtr;
+  std::map<std::string, std::set<std::string>> m_contextErrMap;
   std::vector<std::string> m_selectedContexts;
   std::string m_outputDir;
   std::string m_packRoot;
@@ -638,7 +639,7 @@ protected:
   bool m_relativePaths;
 
   bool LoadPacks(ContextItem& context);
-  bool CollectRequiredPdscFiles(ContextItem& context, const std::string& packRoot, std::set<std::string>& errMsgs);
+  bool CollectRequiredPdscFiles(ContextItem& context, const std::string& packRoot);
   bool CheckRteErrors(void);
   bool CheckBoardDeviceInLayer(const ContextItem& context, const ClayerItem& clayer);
   bool CheckCompiler(const std::vector<std::string>& forCompiler, const std::string& selectedCompiler);
@@ -731,6 +732,7 @@ protected:
   void CheckDeviceAttributes(const std::string& device, const ProcessorItem& userSelection, const StrMap& targetAttributes);
   std::string GetContextRteFolder(ContextItem& context);
   std::vector<std::string> FindMatchingPackIdsInCbuildPack(const PackItem& needle, const std::vector<ResolvedPackItem>& resolvedPacks);
+  void PrintContextErrors(const std::string& contextName);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/test/data/TestSolution/pack_missing.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/pack_missing.csolution.yml
@@ -4,9 +4,14 @@ solution:
   target-types:
     - type: CM0
       device: RteTest_ARMCM0
-
+    - type: Gen
+      device: RteTestGen_ARMCM0
   packs:
     - pack: ARM::Missing_DFP@0.0.9
+      for-context: +CM0
+    - pack: ARM::Missing_PACK@0.0.1
+      for-context: +Gen
+
 
   projects:
     - project: ./TestProject1/test1.cproject.yml

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -287,6 +287,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListPacksMissing) {
   EXPECT_EQ(0, RunProjMgr(8, argv, 0)); // code should return success because of "-m" option
 
   auto outStr = streamRedirect.GetOutString();
+  auto errStr = streamRedirect.GetErrorString();
   EXPECT_STREQ(outStr.c_str(), "ARM::Missing_DFP@0.0.9\n");
 }
 
@@ -5139,4 +5140,21 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_GpdscWithoutComponents) {
   argv[4] = (char*)"-o";
   argv[5] = (char*)testoutput_folder.c_str();
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+}
+
+TEST_F(ProjMgrUnitTests, RunProjMgr_ValidateContextSpecificPacksMissing) {
+  char* argv[8];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestSolution/pack_missing.csolution.yml";
+  string expectedErr = "\
+error csolution: required pack: ARM::Missing_DFP@0.0.9 not installed\n\
+error csolution: processing context 'test1+CM0' failed\n\
+error csolution: required pack: ARM::Missing_PACK@0.0.1 not installed\n\
+error csolution: processing context 'test1+Gen' failed\n";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"--solution";
+  argv[3] = (char*)csolution.c_str();
+  EXPECT_EQ(1, RunProjMgr(4, argv, 0));
+  EXPECT_NE(string::npos, streamRedirect.GetErrorString().find(expectedErr));
 }

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -1596,3 +1596,25 @@ TEST_F(ProjMgrWorkerUnitTests, FindMatchingPacksInCbuildPack) {
   EXPECT_EQ(matches[0], pack5.pack);
   EXPECT_EQ(matches[1], pack6.pack);
 }
+
+TEST_F(ProjMgrWorkerUnitTests, PrintContextErrors) {
+  StdStreamRedirect streamRedirect;
+  string context1("project.build+target1"), context2("project.build+target2");
+
+  // print errors message specific to context
+  m_contextErrMap["project.build+target1"].insert("error test pack 1 missing");
+  m_contextErrMap["project.build+target1"].insert("error test pack 1.1 missing");
+  m_contextErrMap["project.build+target2"].insert("error test pack 2 missing");
+  PrintContextErrors(context1);
+  PrintContextErrors(context2);
+  auto errMsg = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errMsg.find("error test pack 1 missing"));
+  EXPECT_NE(string::npos, errMsg.find("error test pack 1.1 missing"));
+  EXPECT_NE(string::npos, errMsg.find("error test pack 2 missing"));
+
+  // when no errors occur, print no error messages
+  streamRedirect.ClearStringStreams();
+  m_contextErrMap.clear();
+  PrintContextErrors(context1);
+  EXPECT_TRUE(streamRedirect.GetErrorString().empty());
+}


### PR DESCRIPTION
This change request addresses updating the context-specific missing pack information within the individual context data structure, as well as printing the relevant missing packs information for each context.

for the same example for conversion:
Earlier
```
error csolution: required pack: ARM::Missing_DFP@0.0.9 not installed
error csolution: processing context 'test1+CM0' failed
error csolution: required pack: ARM::Missing_DFP@0.0.9 not installed
error csolution: processing context 'test1+Gen' failed
```

After this change
```
error csolution : required pack : ARM::Missing_DFP@0.0.9 not installed
error csolution : processing context 'test1+CM0' failed
error csolution : required pack : ARM::Missing_PACK@0.0.1 not installed
error csolution : processing context 'test1+Gen' failed
```