### PR TITLE
Remove redundant inheritance in IXmlItemBuilder

### DIFF
--- a/libs/rtemodel/src/RteKernel.cpp
+++ b/libs/rtemodel/src/RteKernel.cpp
@@ -617,9 +617,6 @@ unique_ptr<XMLTree> RteKernel::CreateUniqueXmlTree(IXmlItemBuilder* itemBuilder,
 unique_ptr<RteItemBuilder> RteKernel::CreateUniqueRteItemBuilder(RteItem* rootParent, PackageState packState, const RteItem& options) const
 {
   unique_ptr<RteItemBuilder> builder( new RteItemBuilder(rootParent, packState));
-  if(!options.IsEmpty()) {
-    builder->SetAttributes(options);
-  }
   return builder;
 }
 

--- a/libs/xmltree/include/IXmlItemBuilder.h
+++ b/libs/xmltree/include/IXmlItemBuilder.h
@@ -2,7 +2,7 @@
 #define IXmlItemBuilder_H
 /******************************************************************************/
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,7 +14,8 @@
 /**
  * @brief abstract factory interface class to create XmlItem derived objects
 */
-class IXmlItemBuilder : public XmlItem {
+class IXmlItemBuilder
+{
 public:
 
   /**


### PR DESCRIPTION
This reverts a change introduced by PR
Support for external generators in RTE Model (#1335)