### PR TITLE
Rename one of RteProject::GetFileInstances()

### DIFF
--- a/libs/rtemodel/include/RteProject.h
+++ b/libs/rtemodel/include/RteProject.h
@@ -317,13 +317,12 @@ public:
   const std::map<std::string, RteFileInstance*>& GetFileInstances() const { return m_files; }
 
   /**
-   * @brief get collection of file paths mapped to associated RteFileInstance objects
-   * determined by target name and associated RteComponentInstance object
+   * @brief get collection of file instances for a given component instance and target
    * @param ci given RteComponentInstance object
    * @param targetName given target name
-   * @param configFiles collection of file paths mapped to associated RteFileInstance objects to fill
+   * @param configFiles collection to fill: the original file path to RteFileInstance (one entry per multi-instance component),
   */
-  void GetFileInstances(RteComponentInstance* ci, const std::string& targetName, std::map<std::string, RteFileInstance*>& configFiles) const;
+  void GetFileInstancesForComponent(RteComponentInstance* ci, const std::string& targetName, std::map<std::string, RteFileInstance*>& configFiles) const;
 
   /**
    * @brief get RteComponentInstanceGroup object

--- a/libs/rtemodel/src/RteCprjProject.cpp
+++ b/libs/rtemodel/src/RteCprjProject.cpp
@@ -254,7 +254,7 @@ void RteCprjProject::ApplySelectedComponentsToCprjFile() {
 
 void RteCprjProject::ApplyComponentFilesToCprjFile(RteComponentInstance* ci, RteItem* cprjComponent) {
   map<string, RteFileInstance*> files;
-  GetFileInstances(ci, GetActiveTargetName(), files);
+  GetFileInstancesForComponent(ci, GetActiveTargetName(), files);
   for (auto [id, fi] : files) {
     if (fi->GetAttribute("attr") == "config") {
       RteItem* item = new RteItem(cprjComponent);

--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -340,7 +340,7 @@ RteFileInstance* RteProject::GetFileInstance(const string& id) const
   return NULL;
 }
 
-void RteProject::GetFileInstances(RteComponentInstance* ci, const string& targetName, map<string, RteFileInstance*>& configFiles) const
+void RteProject::GetFileInstancesForComponent(RteComponentInstance* ci, const string& targetName, map<string, RteFileInstance*>& configFiles) const
 {
   for (auto [id, fi] : m_files) {
     if (!fi->IsUsedByTarget(targetName))

--- a/tools/buildmgr/cbuild/src/CbuildModel.cpp
+++ b/tools/buildmgr/cbuild/src/CbuildModel.cpp
@@ -562,7 +562,7 @@ bool CbuildModel::EvalConfigFiles() {
       continue;
 
     map<string, RteFileInstance*> compConfigFiles;
-    m_cprjProject->GetFileInstances(ci, m_targetName, compConfigFiles);
+    m_cprjProject->GetFileInstancesForComponent(ci, m_targetName, compConfigFiles);
     const string& layer = ci->GetAttribute("layer");
     if (!ci->IsGenerated()) m_layerPackages[layer].insert(ci->GetPackage()->GetID());
     const RteComponentInstance* api = ci->GetApiInstance();


### PR DESCRIPTION
rename one of RteProject::GetFileInstances() methods
to RteProject::GetFileInstancesForComponent() to avoid confusion