### PR TITLE
[projmgr] Strip build metadata when handling pack versions

### DIFF
--- a/test/packs/ARM/RteTest_DFP/0.1.1/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.1.1/ARM.RteTest_DFP.pdsc
@@ -11,7 +11,7 @@
     <release version="0.1.0" date="2021-02-16">
       Tag to check that the latest release item version is picked up even if it is below
     </release>
-    <release version="0.1.1" date="2021-02-17">
+    <release version="0.1.1+metadata" date="2021-02-17">
       Initial copy from ARM.CMSIS pack
     </release>
   </releases>

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -639,6 +639,7 @@ protected:
   bool m_debug;
   bool m_dryRun;
   bool m_relativePaths;
+  StrMap m_packMetadata;
 
   bool LoadPacks(ContextItem& context);
   bool CheckMissingPackRequirements(const std::string& contextName);

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -126,8 +126,8 @@ void ProjMgrGenerator::GenerateCprjPackages(XMLTreeElement* element, const Conte
       packageElement->AddAttribute("vendor", package.second->GetVendorString());
       const string& pdscFile = package.second->GetPackageFileName();
       if (!nonLocked) {
-        const string& version = package.second->GetVersionString() + ":" + package.second->GetVersionString();
-        packageElement->AddAttribute("version", version);
+        const string& version = VersionCmp::RemoveVersionMeta(package.second->GetVersionString());
+        packageElement->AddAttribute("version", version + ":" + version);
       }
       if (context.pdscFiles.find(pdscFile) != context.pdscFiles.end()) {
         if (nonLocked) {

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/metadata.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/metadata.cproject.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+  components:
+    - component: Device:Startup
+    - component: CORE

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/metadata.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/metadata.csolution.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  build-types:
+    - type: Debug
+
+  target-types:
+    - type: RteTest_ARMCM3
+      device: RteTest_ARMCM3
+
+  compiler: AC6
+
+  projects:
+    - project: metadata.cproject.yml
+
+  packs:
+    - pack: ARM::RteTest_DFP@0.1.1+user_metadata

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
@@ -1,0 +1,62 @@
+build:
+  generated-by: csolution version 0.0.0+gd3ed8151
+  solution: ../data/TestSolution/PackMetadata/metadata.csolution.yml
+  project: ../data/TestSolution/PackMetadata/metadata.cproject.yml
+  context: metadata.Debug+RteTest_ARMCM3
+  compiler: AC6
+  device: RteTest_ARMCM3
+  device-pack: ARM::RteTest_DFP@0.1.1
+  processor:
+    fpu: off
+    core: Cortex-M3
+  packs:
+    - pack: ARM::RteTest_DFP@0.1.1
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1
+  define:
+    - ARMCM3
+    - _RTE_
+  add-path:
+    - ../data/TestSolution/PackMetadata/RTE/_Debug_RteTest_ARMCM3
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Device/ARM/ARMCM3/Include
+  output-dirs:
+    intdir: tmp/metadata/RteTest_ARMCM3/Debug
+    outdir: out/metadata/RteTest_ARMCM3/Debug
+    rtedir: ../data/TestSolution/PackMetadata/RTE
+  output:
+    - type: elf
+      file: metadata.axf
+  components:
+    - component: ARM::Device:Startup&RteTest Startup@2.0.3
+      condition: ARMCM3 RteTest
+      from-pack: ARM::RteTest_DFP@0.1.1
+      selected-by: Device:Startup
+      files:
+        - file: ../data/TestSolution/PackMetadata/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct
+          category: linkerScript
+          attr: config
+          version: 1.0.0
+        - file: ../data/TestSolution/PackMetadata/RTE/Device/RteTest_ARMCM3/startup_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 2.0.3
+        - file: ../data/TestSolution/PackMetadata/RTE/Device/RteTest_ARMCM3/system_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 1.0.1
+    - component: ARM::RteTest:CORE@0.1.1
+      condition: Cortex-M Device
+      from-pack: ARM::RteTest_DFP@0.1.1
+      selected-by: CORE
+  linker:
+    script: ../data/TestSolution/PackMetadata/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct
+  constructed-files:
+    - file: ../data/TestSolution/PackMetadata/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
+      category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTest_DFP@0.1.1
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cprj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2024-03-18T17:59:27" tool="csolution 0.0.0+gd3ed8151"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.1.1:0.1.1"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dvendor="ARM:82">
+    <output elf="metadata.axf" intdir="tmp/metadata/RteTest_ARMCM3/Debug" name="metadata" outdir="out/metadata/RteTest_ARMCM3/Debug" rtedir="../data/TestSolution/PackMetadata/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestSolution/PackMetadata/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct"/>
+  </target>
+
+  <components>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.0.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/system_ARMCM3.c" version="1.0.1"/>
+    </component>
+    <component Cclass="RteTest" Cgroup="CORE" Cvendor="ARM" Cversion="0.1.1"/>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.cbuild-pack.yml
@@ -1,0 +1,5 @@
+cbuild-pack:
+  resolved-packs:
+    - resolved-pack: ARM::RteTest_DFP@0.1.1
+      selected-by-pack:
+        - ARM::RteTest_DFP@0.1.1+user_metadata

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5298,3 +5298,27 @@ TEST_F(ProjMgrUnitTests, RunProjMgrSolution_Config_Base_Update_File) {
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/project.Debug+CM0.cbuild.yml",
     testinput_folder + "/TestSolution/TestBaseUpdate/ref/project.Debug+CM0.cbuild.yml");
 }
+
+TEST_F(ProjMgrUnitTests, CheckPackMetadata) {
+  char* argv[6];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestSolution/PackMetadata/metadata.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)"--solution";
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"-o";
+  argv[5] = (char*)testoutput_folder.c_str();
+  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+
+  // Check generated files
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/metadata.Debug+RteTest_ARMCM3.cprj",
+    testinput_folder + "/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cprj");
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/metadata.Debug+RteTest_ARMCM3.cbuild.yml",
+    testinput_folder + "/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml");
+  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/PackMetadata/metadata.cbuild-pack.yml",
+    testinput_folder + "/TestSolution/PackMetadata/ref/metadata.cbuild-pack.yml");
+
+  // Check warning message
+  auto errStr = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errStr.find("warning csolution: loaded pack 'ARM::RteTest_DFP0.1.1+metadata' does not match specified metadata 'user_metadata'"));
+}


### PR DESCRIPTION
Strip build metadata when handling pack versions.
Throw a warning when specified metadata does not match the one from the loaded pack.
Addresses https://github.com/Open-CMSIS-Pack/devtools/issues/1339#issuecomment-1987962578