### PR TITLE
Fix for issue #1356 (#849)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -440,6 +440,10 @@ bool ProjMgrWorker::LoadPacks(ContextItem& context) {
 
 bool ProjMgrWorker::CheckMissingPackRequirements(const std::string& contextName)
 {
+  if(!m_debug) {
+    // perform check only in debug mode
+    return true;
+  }
   bool bRequiredPacksLoaded = true;
   // check if all pack requirements are fulfilled
   for(auto pack : m_loadedPacks) {


### PR DESCRIPTION
unclear warning csolution: required pack 'ARM::CMSIS-Compiler@2.0.0' is not loaded #1356

The warnings are now printed only if -d (debug) switch is specified