### PR TITLE
[projmgr] Run schema check over generated files

### DIFF
--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,11 +29,12 @@ public:
    * @param parser reference
    * @param contexts vector with pointers to contexts
    * @param outputDir directory
+   * @param boolean check schema of generated file
    * @return true if executed successfully
   */
   static bool GenerateCbuildIndex(ProjMgrParser& parser,
     const std::vector<ContextItem*>& contexts, const std::string& outputDir,
-    const std::set<std::string>& failedContexts);
+    const std::set<std::string>& failedContexts, bool checkSchema);
 
   /**
    * @brief generate cbuild-gen-idx.yml file
@@ -42,20 +43,21 @@ public:
    * @param type project type
    * @param outdir output directory
    * @param gendir generated files directory
+   * @param boolean check schema of generated file
    * @return true if executed successfully
   */
   static bool GenerateCbuildGenIndex(ProjMgrParser& parser, const std::vector<ContextItem*> siblings,
-    const std::string& type, const std::string& outdir, const std::string& gendir);
+    const std::string& type, const std::string& outdir, const std::string& gendir, bool checkSchema);
 
   /**
    * @brief generate cbuild.yml or cbuild-gen.yml file
    * @param context pointer to the context
-   * @param boolean indicates if context has conversion error(s)
+   * @param boolean check schema of generated file
    * @param reference to generator identifier
    * @param reference to generator pack
    * @return true if executed successfully
   */
-  static bool GenerateCbuild(ContextItem* context,
+  static bool GenerateCbuild(ContextItem* context, bool checkSchema,
     const std::string& generatorId = std::string(),
     const std::string& generatorPack = std::string());
 
@@ -64,19 +66,21 @@ public:
    * @param contexts vector with pointers to contexts
    * @param selectedCompiler name of the selected compiler
    * @param cbuildSetFile path to *.cbuild-set file to be generated
+   * @param boolean check schema of generated file
    * @return true if executed successfully
   */
   static bool GenerateCbuildSet(const std::vector<ContextItem*> contexts,
-    const std::string& selectedCompiler, const std::string& cbuildSetFile);
+    const std::string& selectedCompiler, const std::string& cbuildSetFile, bool checkSchema);
 
   /**
    * @brief generate cbuild pack file
    * @param contexts vector with pointers to contexts
    * @param keepExistingPackContent if true, all entries from existing cbuild-pack should be preserved
    * @param cbuildPackFrozen if true, reject updates to cbuild pack file
+   * @param boolean check schema of generated file
    * @return true if executed successfully
   */
-  static bool GenerateCbuildPack(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, bool keepExistingPackContent, bool cbuildPackFrozen);
+  static bool GenerateCbuildPack(ProjMgrParser& parser, const std::vector<ContextItem*> contexts, bool keepExistingPackContent, bool cbuildPackFrozen, bool checkSchema);
 };
 
 #endif  // PROJMGRYAMLEMITTER_H

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -13,11 +13,11 @@
     },
     "BuildContext": {
       "type": "string",
-      "pattern": "^(((^[.][^.+\\s]*)|(^[+][^.+\\s]*))|((^[.][^.+\\s]*)[+][^.+\\s]*|(^[+][^.+\\s]*)[.][^.+\\s]*))$"
+      "pattern": "^(((^[.][^.+]*)|(^[+][^.+]*))|((^[.][^.+]*)[+][^.+]*|(^[+][^.+]*)[.][^.+]*))$"
     },
     "BuildContextWithProjectName": {
       "type": "string",
-      "pattern": "^([^.+\\s]+|[^.+\\s]*\\.[^.+\\s]+(\\+[^.+\\s]+)?|[^.+\\s]*\\+[^.+\\s]+(\\.[^.+\\s]+)?)$"
+      "pattern": "^([^.+]+|[^.+]*\\.[^.+]+(\\+[^.+]+)?|[^.+]*\\+[^.+]+(\\.[^.+]+)?)$"
     },
     "ArrayOfBuildContext": {
       "type": "array",
@@ -562,6 +562,8 @@
         "file":            { "type": "string", "description": "File name along with the path." },
         "category":        { "$ref": "#/definitions/FileCategoryType" },
         "attr":            { "$ref": "#/definitions/FileAttributeType" },
+        "language":        { "$ref": "#/definitions/FileLanguageType" },
+        "scope":           { "$ref": "#/definitions/FileScopeType" },
         "version":         { "$ref": "#/definitions/VersionType" },
         "for-context":     { "$ref": "#/definitions/ForContext" },
         "not-for-context": { "$ref": "#/definitions/NotForContext" },
@@ -1005,6 +1007,8 @@
         "optimize":          { "$ref": "#/definitions/OptimizeType" },
         "debug":             { "$ref": "#/definitions/DebugType" },
         "warnings":          { "$ref": "#/definitions/WarningsType" },
+        "language-C":        { "$ref": "#/definitions/LanguageCType" },
+        "language-CPP":      { "$ref": "#/definitions/LanguageCppType" },
         "misc":              { "$ref": "#/definitions/MiscType" },
         "define":            { "$ref": "#/definitions/BuildDefinesType" },
         "add-path":          { "$ref": "#/definitions/AddpathsType" },

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -482,7 +482,7 @@ bool ProjMgr::PopulateContexts(void) {
 bool ProjMgr::GenerateYMLConfigurationFiles() {
   // Generate cbuild pack file
   const bool isUsingContexts = m_contextSet || m_context.size() != 0;
-  if (!m_emitter.GenerateCbuildPack(m_parser, m_processedContexts, isUsingContexts, m_frozenPacks)) {
+  if (!m_emitter.GenerateCbuildPack(m_parser, m_processedContexts, isUsingContexts, m_frozenPacks, m_checkSchema)) {
     return false;
   }
 
@@ -491,7 +491,7 @@ bool ProjMgr::GenerateYMLConfigurationFiles() {
 
   // Generate cbuild index file
   if (!m_allContexts.empty()) {
-    if (!m_emitter.GenerateCbuildIndex(m_parser, m_allContexts, m_outputDir, m_failedContext)) {
+    if (!m_emitter.GenerateCbuildIndex(m_parser, m_allContexts, m_outputDir, m_failedContext, m_checkSchema)) {
       return false;
     }
   }
@@ -506,20 +506,21 @@ bool ProjMgr::GenerateYMLConfigurationFiles() {
     }
     else if (!m_processedContexts.empty()) {
       // Generate cbuild-set file
-      if (!m_emitter.GenerateCbuildSet(m_processedContexts, m_selectedToolchain, cbuildSetFile)) {
+      if (!m_emitter.GenerateCbuildSet(m_processedContexts, m_selectedToolchain, cbuildSetFile, m_checkSchema)) {
         return false;
       }
     }
   }
 
   // Generate cbuild files
+  bool result = true;
   for (auto& contextItem : m_processedContexts) {
-    if (!m_emitter.GenerateCbuild(contextItem)) {
-      return false;
+    if (!m_emitter.GenerateCbuild(contextItem, m_checkSchema)) {
+      result = false;
     }
   }
 
-  return true;
+  return result;
 }
 
 bool ProjMgr::Configure() {
@@ -827,7 +828,7 @@ bool ProjMgr::RunListLayers(void) {
     }
 
     if (!m_allContexts.empty()) {
-      if (!m_emitter.GenerateCbuildIndex(m_parser, m_allContexts, m_outputDir, m_failedContext)) {
+      if (!m_emitter.GenerateCbuildIndex(m_parser, m_allContexts, m_outputDir, m_failedContext, m_checkSchema)) {
         return false;
       }
     }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3756,7 +3756,7 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
     generatorDestination += '/';
   }
 
-  if (!ProjMgrYamlEmitter::GenerateCbuild(&context, generator->GetGeneratorName(),
+  if (!ProjMgrYamlEmitter::GenerateCbuild(&context, m_checkSchema, generator->GetGeneratorName(),
     RtePackage::GetPackageIDfromAttributes(*generator->GetPackage()))) {
     return false;
   }
@@ -4356,11 +4356,11 @@ bool ProjMgrWorker::ExecuteExtGenerator(std::string& generatorId) {
   // Generate cbuild-gen files
   string cbuildgenOutput = selectedContext->directories.intdir;
   RteFsUtils::NormalizePath(cbuildgenOutput, selectedContext->directories.cprj);
-  if (!ProjMgrYamlEmitter::GenerateCbuildGenIndex(*m_parser, siblingContexts, projectType, cbuildgenOutput, genDir)) {
+  if (!ProjMgrYamlEmitter::GenerateCbuildGenIndex(*m_parser, siblingContexts, projectType, cbuildgenOutput, genDir, m_checkSchema)) {
     return false;
   }
   for (const auto& siblingContext : siblingContexts) {
-    if (!ProjMgrYamlEmitter::GenerateCbuild(siblingContext, generatorId)) {
+    if (!ProjMgrYamlEmitter::GenerateCbuild(siblingContext, m_checkSchema, generatorId)) {
       return false;
     }
   }

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -3954,7 +3954,7 @@ error csolution: processing context 'outputFiles.TypeConflict\\+Target' failed\n
 ";
 
   auto errStr = streamRedirect.GetErrorString();
-  EXPECT_TRUE(regex_match(errStr, regex(expected)));
+  EXPECT_TRUE(regex_search(errStr, regex(expected)));
 }
 
 TEST_F(ProjMgrUnitTests, SelectToolchains) {


### PR DESCRIPTION
Run schema check over generated files when it's enabled.
Add missing `language-C`, `language-CPP`, `language` and `scope` in cbuild schema.
Allow whitespaces in cbuild contexts for alignment with `build-types` and `target-types` schema requirements.
https://github.com/Open-CMSIS-Pack/devtools/issues/1397