### PR TITLE
Inherit token on workflow_call

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,18 +9,23 @@ jobs:
   buildmgr:
     if: github.repository == 'Open-CMSIS-Pack/devtools'
     uses: Open-CMSIS-Pack/devtools/.github/workflows/buildmgr.yml@main
+    secrets: inherit
   packchk:
     needs: [buildmgr]
     uses: Open-CMSIS-Pack/devtools/.github/workflows/packchk.yml@main
+    secrets: inherit
   packgen:
     needs: [packchk]
     uses: Open-CMSIS-Pack/devtools/.github/workflows/packgen.yml@main
+    secrets: inherit
   projmgr:
     needs: [packgen]
     uses: Open-CMSIS-Pack/devtools/.github/workflows/projmgr.yml@main
+    secrets: inherit
   svdconv:
     needs: [projmgr]
     uses: Open-CMSIS-Pack/devtools/.github/workflows/svdconv.yml@main
+    secrets: inherit
   test_libs:
     needs: [svdconv]
     uses: Open-CMSIS-Pack/devtools/.github/workflows/test_libs.yml@main


### PR DESCRIPTION
The coverage jobs were encountering failures due to inaccessible secrets when invoked from other workflows during the nightly build. This modification improves the handling of secrets by allowing them to be inherited from the calling workflows.

LOT: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow