### PR TITLE
[rtemodel] Align implementation with specification

### DIFF
--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -40,10 +40,9 @@ void RteReleaseContainer::Construct()
 {
   string version;
   for (auto release : GetChildren()) {
-    const string& releaseVersion = release->GetVersionString();
-    if (version.empty() || VersionCmp::Compare(releaseVersion, version) > 0) {
-      version = releaseVersion;
-    }
+    // First release XML node is the version of the package
+    version = release->GetVersionString();
+    break;
   }
   AddAttribute("version", version);
 }

--- a/test/packs/ARM/RteTest_DFP/0.1.1/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.1.1/ARM.RteTest_DFP.pdsc
@@ -8,11 +8,11 @@
   <url>http://www.keil.com/pack/</url>
 
   <releases>
-    <release version="0.1.0" date="2021-02-16">
-      Tag to check that the latest release item version is picked up even if it is below
-    </release>
     <release version="0.1.1+metadata" date="2021-02-17">
       Initial copy from ARM.CMSIS pack
+    </release>
+    <release version="0.1.0" date="2021-02-16">
+      Tag to check that the latest release item version is picked up even if it is below
     </release>
   </releases>
 

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -8,14 +8,14 @@
   <url>http://www.keil.com/pack/</url>
 
   <releases>
-    <release version="0.1.0" date="2021-02-16">
-      Tag to check that the latest release item version is picked up even if it is below
+    <release version="0.2.0" date="2022-02-19">
+      Added a new device 'RteTest_ARMCM0_Dual'
     </release>
     <release version="0.1.1" date="2021-02-17">
       Initial copy from ARM.CMSIS pack
     </release>
-    <release version="0.2.0" date="2022-02-19">
-      Added a new device 'RteTest_ARMCM0_Dual'
+    <release version="0.1.0" date="2021-02-16">
+      Tag to check that the latest release item version is picked up even if it is below
     </release>
   </releases>
   <taxonomy>


### PR DESCRIPTION
See https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/issues/307

**Note**: This changes both the RtePackage.cpp file, but also the pdsc files used for testing, including something that looks like it was done to ensure that the releases were sorted.

Contributed by STMicroelectronics