### PR TITLE
Remove include file category type

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -540,7 +540,7 @@
       "items": { "$ref": "#/definitions/FileType" }
     },
     "FileCategoryType": {
-      "enum": [ "api", "doc", "header", "headerAsm", "headerC", "headerCpp", "headerLd", "include", "includeAsm", "includeC", "includeCpp", "includeLd", "library", "object", "source", "sourceC", "sourceCpp", "sourceAsm", "linkerScript", "utility", "image", "preIncludeGlobal", "preIncludeLocal","genSource", "genHeader", "genParams", "genAsset", "other" ],
+      "enum": [ "api", "doc", "header", "headerAsm", "headerC", "headerCpp", "headerLd", "includeAsm", "includeC", "includeCpp", "includeLd", "library", "object", "source", "sourceC", "sourceCpp", "sourceAsm", "linkerScript", "utility", "image", "preIncludeGlobal", "preIncludeLocal","genSource", "genHeader", "genParams", "genAsset", "other" ],
       "description": "File category types define the use of component files within the application. Typically, these files are added to the project and processed by the build tools."
     },
     "FileAttributeType": {


### PR DESCRIPTION
A potential solution to https://github.com/Open-CMSIS-Pack/devtools/issues/1300.

This PR removes `"include"` from the `FileCategoryType` enum in the schema. The documentation does not refer to this, so it can be argued this is not a breaking change.

Questions:
1. Should the other `"includeX"` values be removed too?
2. Is there any code to remove in the implementation of `csolution`?
3. Should we remove the `category` entirely, and rely on file extension instead? This is consistent with the documentation here: https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#filename-extensions