### PR TITLE
Resolve board in RteTarget (#888)

### DIFF
--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -588,8 +588,14 @@ void RteTarget::ProcessAttributes() // called from SetAttributes(), AddAttribute
     }
   }
   // resolve board
-  // RteBoard* board = model->FindBoard();
-
+  string bname = GetAttribute("Bname");
+  if (!bname.empty()) {
+    const string &rev = HasAttribute("Bversion") ? GetAttribute("Bversion") : GetAttribute("Brevision");
+    if (!rev.empty()) {
+      bname += " (" + rev + ")";
+    }
+    SetBoard(model->FindBoard(bname));
+  }
 };
 
 void RteTarget::AddBoadProperties(RteDeviceItem* device, const string& processorName) {
@@ -1716,8 +1722,8 @@ std::string RteTarget::GetDeviceFolder() const
 
 std::string RteTarget::GetRegionsHeader() const
 {
-  string deviceName = WildCards::ToX(GetFullDeviceName(), false);
-  string boardName = WildCards::ToX(GetAttribute("Bname"), false);
+  string deviceName = WildCards::ToX(GetFullDeviceName());
+  string boardName = WildCards::ToX(GetAttribute("Bname"));
   string filename = boardName.empty() ? deviceName : boardName;
   return GetDeviceFolder() + "/regions_" + filename + ".h";
 }
@@ -1725,8 +1731,8 @@ std::string RteTarget::GetRegionsHeader() const
 std::string RteTarget::GenerateMemoryRegionContent(RteItem* memory, const std::string& id, bool bBoardMemory) const
 {
   bool bRam = memory->IsWriteAccess();
- string name = memory->GetName();
-  if (bBoardMemory) {
+  string name = memory->GetName();
+  if(bBoardMemory) {
     name += " (board memory)";
   }
   ostringstream oss;

--- a/libs/rtemodel/test/src/RteChkTest.cpp
+++ b/libs/rtemodel/test/src/RteChkTest.cpp
@@ -36,7 +36,7 @@ From DFP: 22\n\
 From BSP: 0\n\
 \n\
 Devices: 10\n\
-Boards: 13\n\
+Boards: 14\n\
 \n\
 completed\n";
 
@@ -53,7 +53,7 @@ completed\n";
   EXPECT_EQ(rteChk.GetPackCount(), 8);
   EXPECT_EQ(rteChk.GetComponentCount(), 57);
   EXPECT_EQ(rteChk.GetDeviceCount(), 10);
-  EXPECT_EQ(rteChk.GetBoardCount(), 13);
+  EXPECT_EQ(rteChk.GetBoardCount(), 14);
 
   string s = RteUtils::EnsureLf(ss.str());
   EXPECT_EQ(s, summary);

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -259,7 +259,7 @@
      <condition id="BoardTest1">
       <description>Test component filtering on selected board 1</description>
       <require Dvendor="ARM:82" Dname="*ARMCM*"/>
-      <require Bname="RteTest Test board*" Bvendor="Keil" Brevision="1.1.1"/>
+      <require Bname="RteTest*Test*board*" Bvendor="Keil" Brevision="1.1.1"/>
     </condition>
 
     <condition id="BoardTest2">
@@ -441,6 +441,13 @@
       <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM3"/>
       <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM4_NOFP"/>
       <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM4_FP"/>
+    </board>
+    <board name="RteTest-Test-board With.Memory" vendor="Keil" revision="1.1.1">
+      <description>TestBoard with dots in the name and memory</description>
+      <mountedDevice    deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM3"/>
+      <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM3"/>
+      <memory name="RAM-External"   access="rwx" start="0x90000000" size="0x00800000"/>
+      <memory name="Flash-External" access="rx"  start="0x70000000" size="0x04000000"/>
     </board>
     <board name="RteTest Test board no mounted device" vendor="Keil" revision="2.2.2">
       <description>uVision Simulator</description>

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/linker.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/linker.csolution.yml
@@ -23,7 +23,9 @@ solution:
   target-types:
     - type: RteTest_ARMCM3
       device: RteTest_ARMCM3
-
+    - type: RteTest_Board
+      board: RteTest-Test-board With.Memory
+      
   projects:
     - project: linker.cproject.yml
 

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cbuild.yml
@@ -1,0 +1,76 @@
+build:
+  generated-by: csolution version 0.0.0+gab7ac463
+  solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
+  project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
+  context: linker.AutoGen+RteTest_Board
+  compiler: AC6
+  board: RteTest-Test-board With.Memory
+  board-pack: ARM::RteTest_DFP@0.2.0
+  device: RteTest_ARMCM3
+  device-pack: ARM::RteTest_DFP@0.2.0
+  processor:
+    fpu: off
+    core: Cortex-M3
+  packs:
+    - pack: ARM::RteTest_DFP@0.2.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
+  define:
+    - ARMCM3
+    - _RTE_
+  add-path:
+    - ../data/TestSolution/LinkerOptions/RTE/_AutoGen_RteTest_Board
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
+  output-dirs:
+    intdir: tmp/linker/RteTest_Board/AutoGen
+    outdir: out/linker/RteTest_Board/AutoGen
+    rtedir: ../data/TestSolution/LinkerOptions/RTE
+  output:
+    - type: elf
+      file: linker.axf
+  components:
+    - component: ARM::Board:Test:Rev1@1.1.1
+      condition: BoardTest1
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: Board:Test:Rev1
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
+          category: header
+          version: 1.1.1
+    - component: ARM::Device:Startup&RteTest Startup@2.0.3
+      condition: ARMCM3 RteTest
+      from-pack: ARM::RteTest_DFP@0.2.0
+      selected-by: Device:Startup
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include/ARMCM3.h
+          category: header
+          version: 2.0.3
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/https:/arm-software.github.io/CMSIS_5/Core_A/html/startup_c_pg.html
+          category: doc
+          version: 2.0.3
+        - file: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct
+          category: linkerScript
+          attr: config
+          version: 1.2.0
+        - file: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/startup_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 2.0.3
+        - file: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/system_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 1.2.2
+  linker:
+    script: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src
+    regions: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest-Test-board_With.Memory.h
+  constructed-files:
+    - file: ../data/TestSolution/LinkerOptions/RTE/_AutoGen_RteTest_Board/RTE_Components.h
+      category: header
+  licenses:
+    - license: <unknown>
+      license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
+      packs:
+        - pack: ARM::RteTest_DFP@0.2.0
+      components:
+        - component: ARM::Board:Test:Rev1@1.1.1
+        - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cprj
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cprj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+  <created timestamp="2023-11-15T14:22:43" tool="csolution 0.0.0+gab7ac463"/>
+
+  <info isLayer="false">
+    <description>Automatically generated project</description>
+  </info>
+
+  <packages>
+    <package name="RteTest_DFP" vendor="ARM" version="0.2.0:0.2.0"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.18.0"/>
+  </compilers>
+
+  <target Bname="RteTest-Test-board With.Memory" Brevision="1.1.1" Bvendor="Keil" Bversion="1.1.1" Dfpu="NO_FPU" Dname="RteTest_ARMCM3" Dvendor="ARM:82">
+    <output elf="linker.axf" intdir="tmp/linker/RteTest_Board/AutoGen" name="linker" outdir="out/linker/RteTest_Board/AutoGen" rtedir="../data/TestSolution/LinkerOptions/RTE" type="exe"/>
+    <ldflags compiler="AC6" file="../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src" regions="../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest-Test-board_With.Memory.h"/>
+  </target>
+
+  <components>
+    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
+    <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
+      <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.2.0"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>
+      <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/system_ARMCM3.c" version="1.2.2"/>
+    </component>
+  </components>
+</cprj>
+

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/regions_RteTest-Test-board_With.Memory.h
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/regions_RteTest-Test-board_With.Memory.h
@@ -1,0 +1,97 @@
+#ifndef REGIONS_RTETEST_TEST_BOARD_WITH_MEMORY_H
+#define REGIONS_RTETEST_TEST_BOARD_WITH_MEMORY_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Board pack:    ARM::RteTest_DFP@0.2.0
+// <i>Board pack used to generate this file
+
+// <n>Device pack:   ARM::RteTest_DFP@0.2.0
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> IROM1=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// <h> Flash-External (board memory)=<__ROM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x70000000
+#define __ROM1_BASE 0x70000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x04000000
+#define __ROM1_SIZE 0x04000000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM1_DEFAULT 0
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM1_STARTUP 0
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> IRAM1=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 1
+// </h>
+
+// <h> RAM-External (board memory)=<__RAM1>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x90000000
+#define __RAM1_BASE 0x90000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00800000
+#define __RAM1_SIZE 0x00800000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM1_DEFAULT 0
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM1_NOINIT 0
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000200
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_RTETEST_TEST_BOARD_WITH_MEMORY_H */

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/regions_RteTest_ARMCM3.h
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/regions_RteTest_ARMCM3.h
@@ -1,0 +1,60 @@
+#ifndef REGIONS_RTETEST_ARMCM3_H
+#define REGIONS_RTETEST_ARMCM3_H
+
+
+//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
+
+// <n>Device pack:   ARM::RteTest_DFP@0.2.0
+// <i>Device pack used to generate this file
+
+// <h>ROM Configuration
+// =======================
+// <h> IROM1=<__ROM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x00000000
+#define __ROM0_BASE 0x00000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00040000
+#define __ROM0_SIZE 0x00040000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __ROM0_DEFAULT 1
+//   <q>Startup
+//   <i> Selects region to be used for startup code.
+#define __ROM0_STARTUP 1
+// </h>
+
+// </h>
+
+// <h>RAM Configuration
+// =======================
+// <h> IRAM1=<__RAM0>
+//   <o> Base address <0x0-0xFFFFFFFF:8>
+//   <i> Defines base address of memory region.
+//   <i> Default: 0x20000000
+#define __RAM0_BASE 0x20000000
+//   <o> Region size [bytes] <0x0-0xFFFFFFFF:8>
+//   <i> Defines size of memory region.
+//   <i> Default: 0x00020000
+#define __RAM0_SIZE 0x00020000
+//   <q>Default region
+//   <i> Enables memory region globally for the application.
+#define __RAM0_DEFAULT 1
+//   <q>No zero initialize
+//   <i> Excludes region from zero initialization.
+#define __RAM0_NOINIT 1
+// </h>
+
+// </h>
+
+// <h>Stack / Heap Configuration
+//   <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+//   <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+#define __STACK_SIZE 0x00000200
+#define __HEAP_SIZE 0x00000C00
+// </h>
+
+
+#endif /* REGIONS_RTETEST_ARMCM3_H */

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4078,6 +4078,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_LinkerOptions_Auto) {
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/linker.FromComponent+RteTest_ARMCM3.cbuild.yml",
     testinput_folder + "/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cbuild.yml");
 
+  RteFsUtils::RemoveDir(testinput_folder + "/TestSolution/LinkerOptions/RTE");
   // 'auto' enabled
   argv[4] = (char*)"linker.AutoGen+RteTest_ARMCM3";
   EXPECT_EQ(0, RunProjMgr(7, argv, 0));
@@ -4087,7 +4088,23 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_LinkerOptions_Auto) {
     testinput_folder + "/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cprj");
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/linker.AutoGen+RteTest_ARMCM3.cbuild.yml",
     testinput_folder + "/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cbuild.yml");
+  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h",
+    testinput_folder + "/TestSolution/LinkerOptions/ref/regions_RteTest_ARMCM3.h");
 
+  RteFsUtils::RemoveDir(testinput_folder + "/TestSolution/LinkerOptions/RTE");
+  // 'auto' enabled for board
+  argv[4] = (char*)"linker.AutoGen+RteTest_Board";
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
+
+  // check generated files
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/linker.AutoGen+RteTest_Board.cprj",
+    testinput_folder + "/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cprj");
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/linker.AutoGen+RteTest_Board.cbuild.yml",
+    testinput_folder + "/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cbuild.yml");
+  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest-Test-board_With.Memory.h",
+    testinput_folder + "/TestSolution/LinkerOptions/ref/regions_RteTest-Test-board_With.Memory.h");
+
+  RteFsUtils::RemoveDir(testinput_folder + "/TestSolution/LinkerOptions/RTE");
   // 'auto' enabled warning
   StdStreamRedirect streamRedirect;
   argv[4] = (char*)"linker.AutoGenWarning+RteTest_ARMCM3";


### PR DESCRIPTION
* Resolve board in RteTarget
fixes: Regions header file not processing information from <boards> #1468
Use consistent directory names with dots and dashes
