### PR TITLE
[projmgr] Remove `configurable` endianness from target attributes

### DIFF
--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -165,9 +165,6 @@ void ProjMgrGenerator::GenerateCprjCompilers(XMLTreeElement* element, const Cont
 void ProjMgrGenerator::GenerateCprjTarget(XMLTreeElement* element, const ContextItem& context) {
   constexpr const char* DEVICE_ATTRIBUTES[] = { "Ddsp", "Dendian", "Dfpu", "Dmve", "Dname", "Pname", "Dsecure", "Dtz", "Dvendor", "DbranchProt"};
   map<string, string> attributes = context.targetAttributes;
-  if (attributes["Dendian"] == "Configurable") {
-    attributes["Dendian"].erase();
-  }
   for (const auto& name : DEVICE_ATTRIBUTES) {
     const string& value = attributes[name];
     SetAttribute(element, name, value);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1306,6 +1306,12 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
   // Check attributes support compatibility
   CheckDeviceAttributes(context.device, attr, context.targetAttributes);
 
+  // Remove 'configurable' endianness from target attributes for RteModel conditions compliance
+  if (context.targetAttributes.find(RteConstants::RTE_DENDIAN) != context.targetAttributes.end() &&
+    context.targetAttributes.at(RteConstants::RTE_DENDIAN) == RteConstants::RTE_ENDIAN_CONFIGURABLE) {
+    context.targetAttributes.erase(RteConstants::RTE_DENDIAN);
+  }
+
   // Set or update target attributes
   const StrMap attrMap = {
     { RteConstants::RTE_DFPU       , attr.fpu              },

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -86,7 +86,6 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessDevice) {
     {"Dclock", "10000000"},
     {"Dcore", "Cortex-M0"},
     {"DcoreVersion", "r0p0"},
-    {"Dendian", "Configurable"},
     {"Dfpu", "NO_FPU"},
     {"Dmpu", "NO_MPU"},
     {"Dname", "RteTest_ARMCM0"},
@@ -107,6 +106,10 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessDevice) {
   for (const auto& expectedAttribute : expected) {
     EXPECT_EQ(expectedAttribute.second, context.targetAttributes[expectedAttribute.first]);
   }
+  // Device 'configurable' endianess must not be set among target attributes
+  const auto& processor = context.rteFilteredModel->GetDevice(context.deviceItem.name, context.deviceItem.vendor)->GetProcessor(context.deviceItem.pname);
+  EXPECT_EQ(processor->GetAttribute("Dendian"), "Configurable");
+  EXPECT_TRUE(context.targetAttributes.find("Dendian") == context.targetAttributes.end());
 }
 
 TEST_F(ProjMgrWorkerUnitTests, ProcessComponents) {


### PR DESCRIPTION
Remove `configurable` endianness from target attributes for RteModel conditions compliance.
The attribute was being removed before CPRJ generation but not before the model processing leading to a misaligned cbuild.yml.