### PR TITLE
Update and rename AC6.6.18.0.cmake to AC6.6.16.2.cmake

### DIFF
--- a/tools/buildmgr/cbuildgen/config/AC6.6.16.2.cmake
+++ b/tools/buildmgr/cbuildgen/config/AC6.6.16.2.cmake
@@ -1,11 +1,11 @@
 # This file maps the CMSIS project options to toolchain settings.
 #
-#   - Applies to toolchain: ARM Compiler 6.18 and greater
+#   - Applies to toolchain: ARM Compiler 6.16.2 and greater
 
 ############### EDIT BELOW ###############
 # Set base directory of toolchain
 set(TOOLCHAIN_ROOT)
-set(TOOLCHAIN_VERSION "6.18.0")
+set(TOOLCHAIN_VERSION "6.16.2")
 
 ############ DO NOT EDIT BELOW ###########
 

--- a/tools/buildmgr/cbuildgen/installer/install.sh
+++ b/tools/buildmgr/cbuildgen/installer/install.sh
@@ -20,7 +20,7 @@ timestamp=
 githash=
 
 # header
-echo "("$(basename "$0")"): CMSIS Build Installer $version (C) 2021-2022 ARM"
+echo "("$(basename "$0")"): CMSIS Build Installer $version (C) 2021-2024 ARM"
 
 # usage
 usage() {
@@ -332,7 +332,7 @@ if [[ $OS == "Windows" ]]
 fi
 
 # update toolchain config files
-script="${cmsis_compiler_root}/AC6.6.18.0.cmake"
+script="${cmsis_compiler_root}/AC6.6.16.2.cmake"
 sed -e "s|set(TOOLCHAIN_ROOT.*|set(TOOLCHAIN_ROOT \"${compiler6_root}\")|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 sed -e "s|set(EXT.*|set(EXT ${extension})|" "${script}" > temp.$$ && mv temp.$$ "${script}"
 

--- a/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
+++ b/tools/buildmgr/test/integrationtests/src/CBuildIntegTestEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -61,7 +61,7 @@ void CBuildIntegTestEnv::SetUp() {
   ci_installer_path = CrossPlatformUtils::GetEnv("CI_CBUILD_INSTALLER");
 
   // Read AC6 toolchain path
-  string ac6ToolchainFilePath = testout_folder + "/cbuild/etc/AC6.6.18.0.cmake";
+  string ac6ToolchainFilePath = testout_folder + "/cbuild/etc/AC6.6.16.2.cmake";
   ASSERT_TRUE(fs::exists(ac6ToolchainFilePath));
 
   ifstream file(ac6ToolchainFilePath);

--- a/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/DebPkgTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -48,7 +48,7 @@ void DebPkgTests::ExtractPackage(const string& pkg, const string& extPath) {
 
 void DebPkgTests::ValidateExtract(const string& extPath) {
   vector<string> pathVec = {
-    "./etc/cmsis-build/AC6.6.18.0.cmake",
+    "./etc/cmsis-build/AC6.6.16.2.cmake",
     "./etc/cmsis-build/CPRJ.xsd", "./etc/cmsis-build/GCC.10.3.1.cmake",
     "./etc/cmsis-build/setup",
     "./etc/cmsis-build/{{ProjectName}}.cproject.yml", "./etc/cmsis-build/{{SolutionName}}.csolution.yml",
@@ -64,7 +64,7 @@ void DebPkgTests::ValidateExtract(const string& extPath) {
     "./usr/lib/cmsis-build/bin/cbuildgen",
     "./usr/lib/cmsis-build/bin/cpackget",
     "./usr/lib/cmsis-build/bin/csolution",
-    "./usr/lib/cmsis-build/etc/AC6.6.18.0.cmake",
+    "./usr/lib/cmsis-build/etc/AC6.6.16.2.cmake",
     "./usr/lib/cmsis-build/etc/CPRJ.xsd", "./usr/lib/cmsis-build/etc/GCC.10.3.1.cmake",
     "./usr/lib/cmsis-build/etc/setup",
     "./usr/lib/cmsis-build/{{ProjectName}}.cproject.yml", "./usr/lib/cmsis-build/{{SolutionName}}.csolution.yml",

--- a/tools/buildmgr/test/integrationtests/src/InstallerTests.cpp
+++ b/tools/buildmgr/test/integrationtests/src/InstallerTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -47,7 +47,7 @@ void InstallerTests::CheckInstallationDir(const string& path, bool expect) {
     { "bin", vector<string>{ "cbuild.sh", "cbuildgen", "cpackget", "csolution"} },
 #endif
     { "doc", vector<string>{ "index.html", "html"} },
-    { "etc", vector<string>{ "AC6.6.18.0.cmake", "CPRJ.xsd",
+    { "etc", vector<string>{ "AC6.6.16.2.cmake", "CPRJ.xsd",
       "GCC.10.3.1.cmake", "IAR.9.32.1.cmake", "setup"} }
   };
 
@@ -78,7 +78,7 @@ void InstallerTests::CheckExtractedDir(const string& path, bool expect) {
     "cbuildgen.lin-arm64",
     "csolution.lin-arm64"} },
     { "doc", vector<string>{ "index.html", "html"} },
-    { "etc", vector<string>{ "AC6.6.18.0.cmake", "CPRJ.xsd",
+    { "etc", vector<string>{ "AC6.6.16.2.cmake", "CPRJ.xsd",
       "GCC.10.3.1.cmake", "IAR.9.32.1.cmake", "setup"} }
   };
 


### PR DESCRIPTION
Arm Compiler 6.16.2 is a long term maintenance version of the Arm Compiler 6 and shall be supported by CMSIS-Toolbox as well. The cmake supports CPUs that are not supported by the 6.16.2 compiler version. For these CPUs the compiler will report an error on invocation.