### PR TITLE
Restrict --context-set to one identical target-type and only one build-type per context

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -645,6 +645,13 @@ public:
   */
   void ProcessExecutesDependencies();
 
+  /**
+    * @brief validates and restrict the input contexts
+    * @param contexts list to be validated
+    * @param fromCbuildSet true is the contexts are read from cbuild-set, otherwise false
+    * @return true if validation success
+  */
+  bool ValidateContexts(const std::vector<std::string>& contexts, bool fromCbuildSet);
 protected:
   ProjMgrParser* m_parser = nullptr;
   ProjMgrKernel* m_kernel = nullptr;

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -541,6 +541,14 @@ bool ProjMgr::Configure() {
   if (!m_worker.ParseContextSelection(m_context, checkCbuildSet)) {
     return false;
   }
+
+  // validate and restrict the input contexts when used with -S option
+  if (!m_context.empty() && m_contextSet) {
+    if (!m_worker.ValidateContexts(m_context, false)){
+      return false;
+    }
+  }
+
   if (m_worker.HasVarDefineError()) {
     auto undefVars = m_worker.GetUndefLayerVars();
     string errMsg = "undefined variables in "+ fs::path(m_csolutionFile).filename().generic_string() +":\n";

--- a/tools/projmgr/test/data/ExternalGenerator/extgen.cbuild-set.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/extgen.cbuild-set.yml
@@ -2,8 +2,5 @@ cbuild-set:
   generated-by: csolution version 2.3.0
   contexts:
     - context: core0.Debug+MultiCore
-    - context: core0.Release+MultiCore
     - context: core1.Debug+MultiCore
-    - context: core1.Release+MultiCore
-    - context: boot.Debug+MultiCore
     - context: boot.Release+MultiCore

--- a/tools/projmgr/test/data/TestSolution/test_restricted_contexts.cbuild-set.yml
+++ b/tools/projmgr/test/data/TestSolution/test_restricted_contexts.cbuild-set.yml
@@ -1,0 +1,6 @@
+cbuild-set:
+  generated-by: csolution version 2.4.0
+  contexts:
+    - context: test1.Debug+CM0
+    - context: test2.Debug+CM0
+    - context: test1.Debug+CM3

--- a/tools/projmgr/test/data/TestSolution/test_restricted_contexts.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/test_restricted_contexts.csolution.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+  description: test description string
+  target-types:
+    - type: CM0
+      device: RteTest_ARMCM0
+    - type: CM3
+      device: RteTest_ARMCM3
+
+  build-types:
+    - type: Debug
+    - type: Release
+
+  packs:
+    - pack: ARM::RteTest_DFP@0.2.0
+
+  projects:
+    - project: ./TestProject2/test2.cproject.yml
+    - project: ./TestProject1/test1.cproject.yml

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5630,7 +5630,6 @@ TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed_Read_From_C
   char* argv[6];
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/TestSolution/test_restricted_contexts.csolution.yml";
-  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
   const string& expectedErrMsg = "\
 error csolution: invalid combination of contexts specified in test_restricted_contexts.cbuild-set.yml:\n\
   target-type does not match for 'test1.Debug+CM3' and 'test1.Debug+CM0'";
@@ -5650,7 +5649,6 @@ TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed1) {
   char* argv[14];
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
-  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
   const string& expectedErrMsg = "\
 error csolution: invalid combination of contexts specified in command line:\n\
   target-type does not match for 'test2.Debug+CM3' and 'test1.Debug+CM0'";
@@ -5678,7 +5676,6 @@ TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed2) {
   char* argv[12];
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
-  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
   const string& expectedErrMsg = "\
 error csolution: invalid combination of contexts specified in command line:\n\
   build-type is not unique for project 'test1' in 'test1.Release+CM0' and 'test1.Debug+CM0'";
@@ -5703,7 +5700,6 @@ error csolution: invalid combination of contexts specified in command line:\n\
 TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Pass) {
   char* argv[10];
   const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
-  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
 
   argv[1] = (char*)"convert";
   argv[2] = (char*)csolution.c_str();

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5625,3 +5625,95 @@ TEST_F(ProjMgrUnitTests, TestRelativeOutputOption) {
   ProjMgrTestEnv::CompareFile(outputFolder + "/solution.cbuild-idx.yml",
     testinput_folder + "/TestSolution/Executes/ref/solution.cbuild-idx.yml");
 }
+
+TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed_Read_From_CbuildSet) {
+  char* argv[6];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestSolution/test_restricted_contexts.csolution.yml";
+  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
+  const string& expectedErrMsg = "\
+error csolution: invalid combination of contexts specified in test_restricted_contexts.cbuild-set.yml:\n\
+  target-type does not match for 'test1.Debug+CM3' and 'test1.Debug+CM0'";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"--output";
+  argv[4] = (char*)testoutput_folder.c_str();
+  argv[5] = (char*)"-S";
+
+  EXPECT_EQ(1, RunProjMgr(6, argv, 0));
+  auto errMsg = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errMsg.find(expectedErrMsg));
+}
+
+TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed1) {
+  char* argv[14];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
+  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
+  const string& expectedErrMsg = "\
+error csolution: invalid combination of contexts specified in command line:\n\
+  target-type does not match for 'test2.Debug+CM3' and 'test1.Debug+CM0'";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"-c";
+  argv[4] = (char*)"test1.Debug+CM0";
+  argv[5] = (char*)"-c";
+  argv[6] = (char*)"test1.Release+CM0";
+  argv[7] = (char*)"-c";
+  argv[8] = (char*)"test2.Debug+CM0";
+  argv[9] = (char*)"-c";
+  argv[10] = (char*)"test2.Debug+CM3";
+  argv[11] = (char*)"--output";
+  argv[12] = (char*)testoutput_folder.c_str();
+  argv[13] = (char*)"-S";
+
+  EXPECT_EQ(1, RunProjMgr(14, argv, 0));
+  auto errMsg = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errMsg.find(expectedErrMsg));
+}
+
+TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Failed2) {
+  char* argv[12];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
+  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
+  const string& expectedErrMsg = "\
+error csolution: invalid combination of contexts specified in command line:\n\
+  build-type is not unique for project 'test1' in 'test1.Release+CM0' and 'test1.Debug+CM0'";
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"-c";
+  argv[4] = (char*)"test1.Debug+CM0";
+  argv[5] = (char*)"-c";
+  argv[6] = (char*)"test1.Release+CM0";
+  argv[7] = (char*)"-c";
+  argv[8] = (char*)"test2.Debug+CM0";
+  argv[9] = (char*)"--output";
+  argv[10] = (char*)testoutput_folder.c_str();
+  argv[11] = (char*)"-S";
+
+  EXPECT_EQ(1, RunProjMgr(12, argv, 0));
+  auto errMsg = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errMsg.find(expectedErrMsg));
+}
+
+TEST_F(ProjMgrUnitTests, TestRestrictedContextsWithContextSet_Pass) {
+  char* argv[10];
+  const string& csolution = testinput_folder + "/TestSolution/test.csolution.yml";
+  const string& testFolder = RteFsUtils::ParentPath(testoutput_folder);
+
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"-c";
+  argv[4] = (char*)"test1.Debug+CM0";
+  argv[5] = (char*)"-c";
+  argv[6] = (char*)"test2.Debug+CM0";
+  argv[7] = (char*)"--output";
+  argv[8] = (char*)testoutput_folder.c_str();
+  argv[9] = (char*)"-S";
+
+  EXPECT_EQ(0, RunProjMgr(10, argv, 0));
+}


### PR DESCRIPTION
Addressing : https://github.com/Open-CMSIS-Pack/devtools/issues/1203