### PR TITLE
Windows: discover generator's file extension

### DIFF
--- a/libs/rtemodel/src/RteGenerator.cpp
+++ b/libs/rtemodel/src/RteGenerator.cpp
@@ -152,6 +152,17 @@ string RteGenerator::GetExecutable(RteTarget* target, const std::string& hostTyp
   if (RteFsUtils::IsRelative(cmd)) {
      cmd = RteFsUtils::MakePathCanonical(GetAbsolutePackagePath() + cmd);
   }
+
+  // check if generator executable has an extension
+  if(hostType == "win" && RteUtils::ExtractFileExtension(RteUtils::ExtractFileName(cmd)).empty()) {
+    // try to find file with correct extension
+    for(auto ext : {".com", ".exe", ".bat"}) {
+      string file = cmd + ext;
+      if(RteFsUtils::Exists(file)) {
+        return file;
+      }
+    }
+  }
   return cmd;
 }
 

--- a/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
+++ b/test/packs/ARM/RteTestGenerator/0.1.0/ARM.RteTestGenerator.pdsc
@@ -41,7 +41,7 @@
       <!-- path is specified either absolute or relative to PDSC or GPDSC file -->
       <workingDir>$PRTE/Device</workingDir>
       <exe>
-      <command host="win">Generator with spaces/script.bat</command>
+      <command host="win">Generator with spaces/script</command>
       <command host="linux">Generator with spaces/script.sh</command>
       <command host="mac">Generator with spaces/script.sh</command>
         <!-- path is specified either absolute or relative to PDSC or GPDSC file. If not specified it is the project directory configured by the environment -->


### PR DESCRIPTION
In case generator executable contains no extension,
try to append ".com", ".exe" and ".bat" to get real file name.
That is needed to launch an executable via CreateProcess() WinApi method