### PR TITLE
csolution crashes with config files for generated compoinents

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -435,6 +435,9 @@ void RteProject::AddCprjComponents(const Collection<RteItem*>& selItems, RteTarg
 
   // update file versions
   for (auto [instanceName, fi] : m_files) {
+    if(fi->IsRemoved()) {
+      continue;
+    }
     string version;
     auto rteFile = fi->GetFile(target->GetName());
     auto itver = configFileVersions.find(instanceName); // file in cprj can be specified by its instance name
@@ -442,7 +445,7 @@ void RteProject::AddCprjComponents(const Collection<RteItem*>& selItems, RteTarg
       itver = configFileVersions.find(fi->GetName()); // or by original name
     if (itver != configFileVersions.end()) {
       version = itver->second;
-    } else {
+    } else if(rteFile) {
       // Fall back to the version noted in the pack
       version = rteFile->GetVersionString();
     }

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -90,6 +90,7 @@ TEST(RteModelTest, PackRegistryLoadPacks) {
   packs1.clear();
   EXPECT_TRUE(rteKernel.LoadPacks(files, packs1, &testModel, true));
   EXPECT_EQ(packs1.size(), files.size());
+  pack1 = *packs1.begin();
   EXPECT_EQ(pack1->GetFirstChild("dummy_child"), nullptr); // pack got loaded again => no added child
 
   EXPECT_EQ(packRegistry->GetLoadedPacks().size(), files.size());


### PR DESCRIPTION
csolution convert crashes when using attr=config files for generated component and the files is missing in the gpdsc file #1442

Provide nullptr guard over rteFile
tests are pending: provided by
PR [projmgr] Expose crash when running csolution convert (#1442)

Avoid tests crash