### PR TITLE
Do not create RTE_Components.h if no component is selected (#926)

### DIFF
--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -1885,6 +1885,9 @@ bool RteTarget::GenerateRteHeaders() {
 
 bool RteTarget::GenerateRTEComponentsH() {
 
+  if(GetSelectedComponentAggregates().empty()) {
+    return true;  // no components selected
+  }
   string content;
   const string& devheader = GetDeviceHeader();
   if (!devheader.empty()) {            // found device header file.

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -845,6 +845,22 @@ TEST_F(RteModelPrjTest, GenerateHeadersTest_Update_Header)
   GenerateHeadersTest(RteTestM3_UpdateHeader_cprj, "RTE_Update_Header", false, true);
 }
 
+TEST_F(RteModelPrjTest, RteNoComponents)
+{
+  RteKernelSlim rteKernel;
+  rteKernel.SetCmsisPackRoot(RteModelTestConfig::CMSIS_PACK_ROOT);
+  RteCprjProject* loadedCprjProject = rteKernel.LoadCprj(RteTestM3NoComponents_cprj);
+  ASSERT_NE(loadedCprjProject, nullptr);
+  // check if neither RTE directory is created, nor RTE_Ceomponents.h
+  const string& rteFolder = loadedCprjProject->GetRteFolder();
+  EXPECT_EQ("RTE_NO_DIR", rteFolder);
+  const string rteDir = RteUtils::ExtractFilePath(RteTestM3NoComponents_cprj, true) + rteFolder;
+  const string targetFolder = "/_Target_1/";
+  const string rteComp = rteDir + targetFolder + "RTE_Components.h";
+  EXPECT_FALSE(RteFsUtils::Exists(rteDir));
+  EXPECT_FALSE(RteFsUtils::Exists(rteComp));
+}
+
 TEST_F(RteModelPrjTest, LoadCprjCompDep) {
 
   RteKernelSlim rteKernel;

--- a/libs/rtemodel/test/src/RteModelTestConfig.cpp
+++ b/libs/rtemodel/test/src/RteModelTestConfig.cpp
@@ -24,6 +24,7 @@ const std::string RteModelTestConfig::packsDir = "RteModelTestPacks";
 const std::string RteModelTestConfig::localPacks = "local_packs";
 const std::string RteModelTestConfig::RteTestM3 = "/RteTestM3";
 const std::string RteModelTestConfig::RteTestM3_cprj = prjsDir + RteTestM3 + "/RteTestM3.cprj";
+const std::string RteModelTestConfig::RteTestM3NoComponents_cprj = prjsDir + RteTestM3 + "/RteTestM3NoComponents.cprj";
 const std::string RteModelTestConfig::RteTestM3PackReq_cprj = prjsDir + RteTestM3 + "/RteTestM3_PackReq.cprj";
 const std::string RteModelTestConfig::RteTestM3_ConfigFolder_cprj = prjsDir + RteTestM3 + "/RteTestM3_ConfigFolder.cprj";
 const std::string RteModelTestConfig::RteTestM3_PackPath_cprj = prjsDir + RteTestM3 + "/RteTestM3_PackPath.cprj";

--- a/libs/rtemodel/test/src/RteModelTestConfig.h
+++ b/libs/rtemodel/test/src/RteModelTestConfig.h
@@ -42,6 +42,7 @@ public:
   static const std::string localPacks;
   static const std::string RteTestM3;
   static const std::string RteTestM3_cprj;
+  static const std::string RteTestM3NoComponents_cprj;
   static const std::string RteTestM3PackReq_cprj;
   static const std::string RteTestM3_ConfigFolder_cprj;
   static const std::string RteTestM3_PackPath_cprj;

--- a/test/projects/RteTestM3/RteTestM3NoComponents.cprj
+++ b/test/projects/RteTestM3/RteTestM3NoComponents.cprj
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<cprj schemaVersion="0.0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
+
+  <created timestamp="2021-05-11T15:53:46" tool="uVision V5.34.0.5"/>
+
+  <info>
+    <name>RteTestM3</name>
+    <doc>https://arm-software.github.io/CMSIS_5/General/html/index.html</doc>
+    <category>CI testing</category>
+    <license>Test project license</license>
+    <description>RteTestM3 no components</description>
+  </info>
+
+
+  <packages>
+    <package name="RteTest" vendor="ARM"/>
+    <package name="RteTest_DFP" vendor="ARM"/>
+  </packages>
+
+  <compilers>
+    <compiler name="AC6" version="6.0.0:6.99.99"/>
+  </compilers>
+
+  <target Bname="RteTest Test board" Bvendor="Keil" Bversion="1.1.1" Ddsp="NO_DSP" Dendian="Little-endian" Dfpu="NO_FPU" Dmve="NO_MVE" Dname="RteTest_ARMCM3" Dsecure="Non-secure" Dtz="NO_TZ" Dvendor="ARM:82">
+    <output intdir="./" name="RteTestM3" outdir="./" rtedir="RTE_NO_DIR" type="exe"/>
+  </target>
+ 
+  <files>
+    <group name="Source Group">
+      <file category="sourceC" name="./main.c"/>
+    </group>
+    <group layer="LayerOne" name="Text Group">
+      <file category="doc" name="./SubDir/SubDir.txt"/>
+      <file category="doc" layer="LayerTwo" name="./Abstract.txt"/>
+    </group>
+    <group name="Sub Dir Group">
+      <file category="sourceC" name="./SubDir/SubDir.c"/>
+    </group>
+  </files>
+
+</cprj>

--- a/tools/projmgr/src/ProjMgrYamlEmitter.cpp
+++ b/tools/projmgr/src/ProjMgrYamlEmitter.cpp
@@ -658,10 +658,12 @@ void ProjMgrYamlCbuild::SetConstructedFilesNode(YAML::Node node, const ContextIt
     // constructed RTE_Components.h
     const auto& rteComponents = context->rteActiveProject->GetProjectPath() +
       context->rteActiveProject->GetRteComponentsH(context->rteActiveTarget->GetName(), "");
-    YAML::Node rteComponentsNode;
-    SetNodeValue(rteComponentsNode[YAML_FILE], FormatPath(rteComponents, context->directories.cbuild));
-    SetNodeValue(rteComponentsNode[YAML_CATEGORY], "header");
-    node.push_back(rteComponentsNode);
+    if (RteFsUtils::Exists(rteComponents)) {
+      YAML::Node rteComponentsNode;
+      SetNodeValue(rteComponentsNode[YAML_FILE], FormatPath(rteComponents, context->directories.cbuild));
+      SetNodeValue(rteComponentsNode[YAML_CATEGORY], "header");
+      node.push_back(rteComponentsNode);
+    }
   }
 }
 

--- a/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core0.Debug+MultiCore.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core0.Debug+MultiCore.cbuild-gen.yml
@@ -42,9 +42,6 @@ build-gen:
   linker:
     script: ${DEVTOOLS(data)}/ExternalGenerator/multi_0/RTE/Device/RteTest_ARMCM0_Dual_cm0_core0/ac6_linker_script.sct.src
     regions: ${DEVTOOLS(data)}/ExternalGenerator/multi_0/RTE/Device/RteTest_ARMCM0_Dual_cm0_core0/regions_RteTest_ARMCM0_Dual_cm0_core0.h
-  constructed-files:
-    - file: ${DEVTOOLS(data)}/ExternalGenerator/multi_0/RTE/_Debug_MultiCore/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       packs:

--- a/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core1.Debug+MultiCore.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core1.Debug+MultiCore.cbuild-gen.yml
@@ -42,9 +42,6 @@ build-gen:
   linker:
     script: ${DEVTOOLS(data)}/ExternalGenerator/multi_1/RTE/Device/RteTest_ARMCM0_Dual_cm0_core1/ac6_linker_script.sct.src
     regions: ${DEVTOOLS(data)}/ExternalGenerator/multi_1/RTE/Device/RteTest_ARMCM0_Dual_cm0_core1/regions_RteTest_ARMCM0_Dual_cm0_core1.h
-  constructed-files:
-    - file: ${DEVTOOLS(data)}/ExternalGenerator/multi_1/RTE/_Debug_MultiCore/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       packs:

--- a/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild-gen.yml
@@ -41,9 +41,6 @@ build-gen:
       files:
         - file: ${DEVTOOLS(data)}/ExternalGenerator/single/main.c
           category: sourceC
-  constructed-files:
-    - file: ${DEVTOOLS(data)}/ExternalGenerator/single/RTE/_Debug_CM0/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       packs:

--- a/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/ns.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/ns.Debug+CM0.cbuild-gen.yml
@@ -37,9 +37,6 @@ build-gen:
   linker:
     script: ${DEVTOOLS(data)}/ExternalGenerator/tz_ns/RTE/Device/RteTestGen_ARMCM0/ac6_linker_script.sct.src
     regions: ${DEVTOOLS(data)}/ExternalGenerator/tz_ns/RTE/Device/RteTestGen_ARMCM0/regions_RteTestGen_ARMCM0.h
-  constructed-files:
-    - file: ${DEVTOOLS(data)}/ExternalGenerator/tz_ns/RTE/_Debug_CM0/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       packs:

--- a/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/s.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/s.Debug+CM0.cbuild-gen.yml
@@ -39,9 +39,6 @@ build-gen:
   linker:
     script: ${DEVTOOLS(data)}/ExternalGenerator/tz_s/RTE/Device/RteTestGen_ARMCM0/ac6_linker_script.sct.src
     regions: ${DEVTOOLS(data)}/ExternalGenerator/tz_s/RTE/Device/RteTestGen_ARMCM0/regions_RteTestGen_ARMCM0.h
-  constructed-files:
-    - file: ${DEVTOOLS(data)}/ExternalGenerator/tz_s/RTE/_Debug_CM0/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       packs:

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
@@ -35,9 +35,6 @@ build:
           category: sourceC
         - file: ../data/TestSolution/ContextMap/MappedTarget1.c
           category: sourceC
-  constructed-files:
-    - file: ../data/TestSolution/ContextMap/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
@@ -35,9 +35,6 @@ build:
           category: sourceC
         - file: ../data/TestSolution/ContextMap/MappedRelease1.c
           category: sourceC
-  constructed-files:
-    - file: ../data/TestSolution/ContextMap/RTE/_Release_RteTest_ARMCM3/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
@@ -35,9 +35,6 @@ build:
           category: sourceC
         - file: ../data/TestSolution/ContextMap/MappedTarget2.c
           category: sourceC
-  constructed-files:
-    - file: ../data/TestSolution/ContextMap/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
@@ -35,9 +35,6 @@ build:
           category: sourceC
         - file: ../data/TestSolution/ContextMap/StandardRelease2.c
           category: sourceC
-  constructed-files:
-    - file: ../data/TestSolution/ContextMap/RTE/_Release_RteTest_ARMCM3/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt


### PR DESCRIPTION
* Do not create RTE_Components.h if no component is selected

* [projmgr] Do not emit reference to `RTE_Components.h` when it does not exist

---------

Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>