### PR TITLE
[cbuildgen] Implement project-level executes for compatibility with cbuild2cmake

### DIFF
--- a/tools/buildmgr/cbuild/include/CbuildModel.h
+++ b/tools/buildmgr/cbuild/include/CbuildModel.h
@@ -551,6 +551,26 @@ public:
   */
   const RteTarget* GetTarget() const;
 
+  const std::map<std::string, std::string>& GetExecuteRun() const {
+    return m_executeRun;
+  }
+
+  const std::map<std::string, bool>& GetExecuteAlways() const {
+    return m_executeAlways;
+  }
+
+  const std::map<std::string, std::vector<std::string>>& GetExecuteInputs() const {
+    return m_executeInputs;
+  }
+
+  const std::map<std::string, std::vector<std::string>>& GetExecuteOutputs() const {
+    return m_executeOutputs;
+  }
+
+  const std::map<std::string, std::vector<std::string>>& GetExecuteDependencies() const {
+    return m_executeDependencies;
+  }
+
 protected:
   /**
    * @brief Kind of Translation Controls
@@ -582,6 +602,12 @@ protected:
   std::map<std::string, std::list<std::string>>     m_cSourceFiles;
   std::map<std::string, std::list<std::string>>     m_cxxSourceFiles;
   std::map<std::string, std::list<std::string>>     m_asmSourceFiles;
+  std::map<std::string, std::string>                m_executeRun;
+  std::map<std::string, bool>                       m_executeAlways;
+  std::map<std::string, std::vector<std::string>>   m_executeInputs;
+  std::map<std::string, std::vector<std::string>>   m_executeOutputs;
+  std::map<std::string, std::vector<std::string>>   m_executeDependencies;
+  std::set<std::string>                             m_executeGeneratedFiles;
   std::set<std::string>                             m_packs;
   std::string                                       m_linkerScript;
   std::string                                       m_linkerRegionsFile;
@@ -634,6 +660,10 @@ protected:
   bool EvaluateResult();
   bool EvalConfigFiles();
   bool EvalPreIncludeFiles();
+  bool EvalExecutes();
+  bool EvalExecute(RteItem* execute, const std::string& base);
+  bool EvalExecuteInputOutput();
+  void EvalExecuteReplaceMarker(std::string& run, const std::string& marker, const std::vector<std::string>& values);
   bool EvalSourceFiles();
   bool EvalNonRteSourceFiles();
   bool EvalGeneratedSourceFiles();

--- a/tools/buildmgr/cbuildgen/config/CPRJ.xsd
+++ b/tools/buildmgr/cbuildgen/config/CPRJ.xsd
@@ -545,6 +545,24 @@
     </xs:choice>
   </xs:complexType>
 
+  <!-- Executes section within the project section -->
+  <xs:complexType name="ExecuteType">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element name="input"        type="xs:string" />
+      <xs:element name="output"       type="xs:string" />
+      <xs:element name="dependency"   type="xs:string" />
+    </xs:choice>
+    <xs:attribute name="name"         type="xs:string"         use="required" />
+    <xs:attribute name="run"          type="xs:string"         use="required" />
+    <xs:attribute name="always"       type="xs:boolean"        use="optional" default="false" />
+  </xs:complexType>
+
+  <xs:complexType name="ExecutesType">
+    <xs:sequence maxOccurs="unbounded">
+      <xs:element name="execute" type="ExecuteType" />
+    </xs:sequence>
+  </xs:complexType>
+
   <!-- Component selection section -->
   <xs:complexType name="ComponentsType">
     <xs:sequence>
@@ -666,7 +684,8 @@
             <xs:field xpath="@name"/>
           </xs:unique>
         </xs:element>
-        </xs:all>
+        <xs:element name="executes"       type="ExecutesType"     minOccurs="0" />
+      </xs:all>
       <!-- schema version used by writer -->
       <xs:attribute name="schemaVersion"  type="SchemaVersionType" use="required" />
     </xs:complexType>

--- a/tools/buildmgr/cbuildgen/include/BuildSystemGenerator.h
+++ b/tools/buildmgr/cbuildgen/include/BuildSystemGenerator.h
@@ -71,6 +71,15 @@ struct module
   std::string excludes;
 };
 
+struct Execute
+{
+    std::string run;
+    std::vector<std::string> inputs;
+    std::vector<std::string> outputs;
+    std::vector<std::string> dependencies;
+    bool always;
+};
+
 /**
  * @brief cfg struct:
  *        prj: config file from project (user file)
@@ -121,6 +130,7 @@ protected:
   std::map<std::string, module> m_ccFilesList;
   std::map<std::string, module> m_cxxFilesList;
   std::map<std::string, TranslationControls> m_groupsList;
+  std::map<std::string, Execute> m_executes;
   std::vector<std::string> m_incPathsList;
   std::vector<std::string> m_libFilesList;
   std::vector<std::string> m_definesList;

--- a/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/BuildSystemGenerator.cpp
@@ -143,6 +143,16 @@ bool BuildSystemGenerator::Collect(const string& inputFile, const CbuildModel *m
     m_cfgFilesList.insert({ StrNorm(cfg.first), StrNorm(cfg.second) });
   }
 
+  for (const auto& [name, run] : model->GetExecuteRun()) {
+    m_executes[name] = Execute {
+        .run = run,
+        .inputs = model->GetExecuteInputs().at(name),
+        .outputs = model->GetExecuteOutputs().at(name),
+        .dependencies = model->GetExecuteDependencies().at(name),
+        .always = model->GetExecuteAlways().at(name)
+    };
+  }
+
   // Audit data
   m_auditData = model->GetAuditData();
 

--- a/tools/buildmgr/cbuildgen/src/CMakeListsGenerator.cpp
+++ b/tools/buildmgr/cbuildgen/src/CMakeListsGenerator.cpp
@@ -651,7 +651,7 @@ bool CMakeListsGenerator::GenBuildCMakeLists(void) {
   // Compilation Database
   cmakelists << "# Compilation Database" << EOL << EOL;
   cmakelists << "set(CMAKE_EXPORT_COMPILE_COMMANDS ON)" << EOL;
-  cmakelists << "add_custom_target(database COMMAND ${CMAKE_COMMAND} -E copy_if_different \"${INT_DIR}/compile_commands.json\" \"${OUT_DIR}\")" << EOL << EOL;
+  cmakelists << "add_custom_target(database ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different \"${INT_DIR}/compile_commands.json\" \"${OUT_DIR}\")" << EOL << EOL;
 
   // Setup Target
   cmakelists << "# Setup Target" << EOL << EOL;

--- a/tools/projmgr/include/ProjMgrGenerator.h
+++ b/tools/projmgr/include/ProjMgrGenerator.h
@@ -42,6 +42,7 @@ protected:
   void GenerateCprjTarget(XMLTreeElement* element, const ContextItem& context);
   void GenerateCprjComponents(XMLTreeElement* element, const ContextItem& context, bool nonLocked = false);
   void GenerateCprjGroups(XMLTreeElement* element, const std::vector<GroupNode>& groups, const std::string& compiler);
+  void GenerateCprjExecutes(XMLTreeElement* element, const std::vector<ExecutesItem>& executes);
   void GenerateCprjOptions(XMLTreeElement* element, const BuildType& buildType);
   void GenerateCprjMisc(XMLTreeElement* element, const std::vector<MiscItem>& miscVec);
   void GenerateCprjMisc(XMLTreeElement* element, const MiscItem& misc);

--- a/tools/projmgr/src/ProjMgrGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrGenerator.cpp
@@ -52,6 +52,7 @@ bool ProjMgrGenerator::GenerateCprj(ContextItem& context, const string& filename
   XMLTreeElement* targetElement = rootElement->CreateElement("target");
   XMLTreeElement* componentsElement = rootElement->CreateElement("components");
   XMLTreeElement* filesElement = rootElement->CreateElement("files");
+  XMLTreeElement* executesElement = rootElement->CreateElement("executes");
 
   // Packages
   if (packagesElement) {
@@ -85,6 +86,15 @@ bool ProjMgrGenerator::GenerateCprj(ContextItem& context, const string& filename
     // Remove empty files element
     if (!filesElement->HasChildren()) {
       rootElement->RemoveChild("files", true);
+    }
+  }
+
+  if (executesElement) {
+    GenerateCprjExecutes(executesElement, context.cproject->executes);
+
+    // Remove empty executes element
+    if (!executesElement->HasChildren()) {
+      rootElement->RemoveChild("executes", true);
     }
   }
 
@@ -386,6 +396,34 @@ void ProjMgrGenerator::GenerateCprjGroups(XMLTreeElement* element, const vector<
 
       }
       GenerateCprjGroups(groupElement, groupNode.groups, compiler);
+    }
+  }
+}
+
+void ProjMgrGenerator::GenerateCprjExecutes(XMLTreeElement* element, const vector<ExecutesItem>& executes) {
+  for (const auto& executesItem : executes) {
+    XMLTreeElement* executeElement = element->CreateElement("execute");
+    if (executeElement) {
+      executeElement->AddAttribute("name", executesItem.execute);
+      executeElement->AddAttribute("run", executesItem.run);
+      if (executesItem.always) {
+        executeElement->AddAttribute("always", "true");
+      }
+
+      for (const auto& input : executesItem.input) {
+        XMLTreeElement* inputElement = executeElement->CreateElement("input");
+        inputElement->SetText(input);
+      }
+
+      for (const auto& output : executesItem.output) {
+        XMLTreeElement* outputElement = executeElement->CreateElement("output");
+        outputElement->SetText(output);
+      }
+
+      for (const auto& dependency : executesItem.dependsOn) {
+        XMLTreeElement* dependencyElement = executeElement->CreateElement("dependency");
+        dependencyElement->SetText(dependency);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR implements project-level executes for `cbuildgen` (in addition to it already being implemented for `cbuild2cmake`) since otherwise some projects would depend on users passing `--cbuild2cmake` to compile properly.

The main difference to the implementation in `cbuild2cmake` is the working directory in which the run command is invoked (the project directory instead of the intermediate directory), since the directory would necessarily be different from `cbuild2cmake` (`tmp/project/context` vs `tmp/`) and since the project directory is IMO the correct directory for these commands to be invoked in. For more discussion on that that, see [cmsis-toolbox#132](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/132).

This implementation does not implement access sequences yet, but implements `$input$` and `$output$` for executes nodes.