### PR TITLE
[projmgr] Relax project provided `connections` validation

### DIFF
--- a/tools/projmgr/include/ProjMgrUtils.h
+++ b/tools/projmgr/include/ProjMgrUtils.h
@@ -19,8 +19,8 @@ typedef std::vector<const ConnectItem*> ConnectPtrVec;
 
 /**
  * @brief connections collection item containing
- *        filename pointer
- *        layer type pointer
+ *        filename reference
+ *        layer type
  *        vector of ConnectItem pointers
  *        copy assignment operator
  *        default copy constructor

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1131,10 +1131,12 @@ ConnectionsValidationResult ProjMgrWorker::ValidateConnections(ConnectionsCollec
       incompatibles.push_back({ consumedKey, consumed->second });
     }
   }
-  // validate provided connections of each combination match at least one consumed
+  // validate layer provided connections of each combination match at least one consumed
   for (const auto& collection : combination) {
-    if (!ProvidedConnectionsMatch(collection, connections)) {
-      missedCollections.push_back(collection);
+    if (!regex_match(collection.filename, regex(".*\\.cproject\\.(yml|yaml)"))) {
+      if (!ProvidedConnectionsMatch(collection, connections)) {
+        missedCollections.push_back(collection);
+      }
     }
   }
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1980,20 +1980,12 @@ TEST_F(ProjMgrUnitTests, ListLayersOptionalLayerType) {
 check combined connections:\n\
   .*/TestLayers/genericlayers.cproject.yml\n\
     \\(Project Connections\\)\n\
-provided combined connections not consumed:\n\
-  .*/TestLayers/genericlayers.cproject.yml\n\
-    ExactMatch\n\
-    EmptyConsumedValue\n\
-    EmptyValues\n\
-    AddedValueLessThanProvided\n\
-    AddedValueEqualToProvided\n\
-    MultipleProvided\n\
-    MultipleProvidedNonIdentical0\n\
-    MultipleProvidedNonIdentical1\n\
-    ProvidedDontMatch\n\
-    ProvidedEmpty\n\
-    AddedValueHigherThanProvided\n\
-connections are invalid\n\
+connections are valid\n\
+\n\
+multiple clayers match type 'Board':\n\
+  .*/ARM/RteTest_DFP/0.2.0/Layers/board1.clayer.yml\n\
+  .*/ARM/RteTest_DFP/0.2.0/Layers/board2.clayer.yml\n\
+  .*/ARM/RteTest_DFP/0.2.0/Layers/board3.clayer.yml\n\
 ";
 
   const string& errStr = streamRedirect.GetErrorString();


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1529:
> -	Project is valid even when no connections from the project are being consumed