### PR TITLE
[projmgr] Generate RTE directory in project tree

### DIFF
--- a/libs/rtefsutils/include/RteFsUtils.h
+++ b/libs/rtefsutils/include/RteFsUtils.h
@@ -245,6 +245,13 @@ public:
    * @return absolute path of the current working directory
   */
   static std::string GetCurrentFolder(bool withTrailingSlash = true);
+
+  /**
+   * @brief change current working directory to path
+   * @param path path to use as current working directory
+  */
+  static void SetCurrentFolder(const std::string &path);
+
   /**
    * @brief determine first file owning the given extension in given folder
    * @param folder name of path where first file with given extension is to be found

--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -594,6 +594,11 @@ string RteFsUtils::GetCurrentFolder(bool withTrailingSlash) {
   return f;
 }
 
+void RteFsUtils::SetCurrentFolder(const string& path) {
+  error_code ec;
+  fs::current_path(path, ec);
+}
+
 bool RteFsUtils::MakeSureFilePath(const string &filePath) {
   fs::path path(filePath);
   path.remove_filename();

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -50,6 +50,15 @@ StdStreamRedirect::~StdStreamRedirect() {
   std::cerr.rdbuf(m_stdcerrStreamBuf);
 }
 
+TempSwitchCwd::TempSwitchCwd(const string& path) {
+  m_oldPath = RteFsUtils::GetCurrentFolder();
+  RteFsUtils::SetCurrentFolder(path);
+}
+
+TempSwitchCwd::~TempSwitchCwd() {
+  RteFsUtils::SetCurrentFolder(m_oldPath);
+}
+
 void ProjMgrTestEnv::SetUp() {
   error_code ec;
   schema_folder        = string(TEST_FOLDER) + "../schemas";

--- a/tools/projmgr/test/src/ProjMgrTestEnv.h
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.h
@@ -39,6 +39,14 @@ private:
   std::streambuf*   m_stdcerrStreamBuf;
 };
 
+class TempSwitchCwd {
+public:
+  TempSwitchCwd(const std::string &path);
+  ~TempSwitchCwd();
+private:
+  std::string m_oldPath;
+};
+
 typedef std::string (*LineReplaceFunc_t)(const std::string&);
 
 /**


### PR DESCRIPTION
When running `csolution convert -s /absolute/path/to/foo.csolution.yml`, the "RTE" directory should be placed within that structure and not where the csolution process happens to be executed from.

This is a regression in csolution 2.3.0 compared to 2.2.1 and was introduced by [this change](https://github.com/Open-CMSIS-Pack/devtools/commit/27678e9e3e631fd4e60ee2bf85fd818b8ae328ac#diff-2f6999444987cfc670f1760728ffcdcce7274b4493b1f3b159b1a5719e4409e3L511-L513). In the commit, the RTE directory is now generated without initializing the project, so the path to the project will be the empty string rather than the actual location on disk and as a result, it's created in the working directory rather than in the project tree.

I've added a test case to demonstrate the problem, but I don't know how to fix it.
@jkrech | @edriouk: Can please you take a look?

Contributed by STMicroelectronics