### PR TITLE
[projmgr] Validate $ProjectDir()$ in output-dirs->cprjdir (#1570)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2378,8 +2378,9 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
   context.groups.clear();
 
   // Get content of build and target types
+  bool error = false;
   if (!GetTypeContent(context)) {
-    return false;
+    error |= true;
   }
 
   StringCollection board = {
@@ -2394,7 +2395,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     board.elements.push_back(&clayer.second->target.board);
   }
   if (!ProcessBoardPrecedence(board)) {
-    return false;
+    error |= true;
   }
 
   StringCollection device = {
@@ -2409,7 +2410,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     device.elements.push_back(&clayer.second->target.device);
   }
   if (!ProcessDevicePrecedence(device)) {
-    return false;
+    error |= true;
   }
 
   StringCollection compiler = {
@@ -2425,15 +2426,15 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     compiler.elements.push_back(&clayer->target.build.compiler);
   }
   if (!ProcessCompilerPrecedence(compiler)) {
-    return false;
+    error |= true;
   }
   // accept compiler redefinition in the command line
   compiler = { &context.compiler, { &m_selectedToolchain } };
   if (!ProcessCompilerPrecedence(compiler, true)) {
-    return false;
+    error |= true;
   }
   if (!ProcessToolchain(context)) {
-    return false;
+    error |= true;
   }
 
   // set context variables (static access sequences)
@@ -2452,18 +2453,18 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
 
   // Get build options content of project setup
   if (!GetProjectSetup(context)) {
-    return false;
+    error |= true;
   }
 
   // Processor options
   if (!ProcessProcessorOptions(context)) {
-    return false;
+    error |= true;
   }
 
   // Output filenames must be processed after board, device and compiler precedences
   // but before processing other access sequences
   if (!ProcessOutputFilenames(context)) {
-    return false;
+    error |= true;
   }
 
   // Access sequences and relative path references must be processed
@@ -2471,7 +2472,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
   // after output filenames (due to $Output$)
   // but before processing misc, defines and includes precedences
   if (!ProcessSequencesRelatives(context, rerun)) {
-    return false;
+    error |= true;
   }
 
   // Optimize
@@ -2491,7 +2492,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     optimize.elements.push_back(&clayer.optimize);
   }
   if (!ProcessPrecedence(optimize)) {
-    return false;
+    error |= true;
   }
 
   // Debug
@@ -2511,7 +2512,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     debug.elements.push_back(&clayer.debug);
   }
   if (!ProcessPrecedence(debug)) {
-    return false;
+    error |= true;
   }
 
   // Warnings
@@ -2531,7 +2532,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     warnings.elements.push_back(&clayer.warnings);
   }
   if (!ProcessPrecedence(warnings)) {
-    return false;
+    error |= true;
   }
 
   // Language C
@@ -2551,7 +2552,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     languageC.elements.push_back(&clayer.languageC);
   }
   if (!ProcessPrecedence(languageC)) {
-    return false;
+    error |= true;
   }
 
   // Language C++
@@ -2571,7 +2572,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     languageCpp.elements.push_back(&clayer.languageCpp);
   }
   if (!ProcessPrecedence(languageCpp)) {
-    return false;
+    error |= true;
   }
 
   // Misc
@@ -2670,7 +2671,7 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
   for (auto& setup : context.controls.setups) {
     CollectionUtils::AddStringItemsUniquely(includesAsmRef, setup.addpathsAsm);
   }
-  return true;
+  return !error;
 }
 
 bool ProjMgrWorker::ProcessProcessorOptions(ContextItem& context) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5837,10 +5837,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_CprjFilesShouldBePlacedInProjectTree) {
   char* argv[4];
   const string& app = testoutput_folder + "/app";
   const string& csolution = app + "/app.csolution.yml";
-  const string& work = testoutput_folder + "/work";
   const string& cprjdir = app + "/foo/baz";
-
-  ASSERT_TRUE(RteFsUtils::CreateDirectories(work));
 
   ASSERT_TRUE(RteFsUtils::CreateTextFile(csolution, "# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/2.4.0/tools/projmgr/schemas/csolution.schema.json\n"
     "solution:\n"
@@ -5861,14 +5858,13 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_CprjFilesShouldBePlacedInProjectTree) {
   ASSERT_TRUE(RteFsUtils::CreateTextFile(app + "/foo/test.cproject.yml", "# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/2.4.0/tools/projmgr/schemas/cproject.schema.json\n"
     "project:\n"));
 
-  ASSERT_FALSE(RteFsUtils::IsDirectory(cprjdir));
-
   argv[1] = (char*)"convert";
   argv[2] = (char*)"--solution";
   argv[3] = (char*)csolution.c_str();
-  ASSERT_EQ(1, RunProjMgr(4, argv, 0));
+  EXPECT_EQ(1, RunProjMgr(4, argv, 0));
 
-  ASSERT_TRUE(RteFsUtils::IsDirectory(cprjdir));
+  EXPECT_TRUE(RteFsUtils::Exists(cprjdir + "/test.debug+main.cprj"));
+  EXPECT_TRUE(RteFsUtils::Exists(cprjdir + "/test.debug+main.cbuild.yml"));
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_ProjectDirShouldBeExpanded) {
@@ -5876,10 +5872,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ProjectDirShouldBeExpanded) {
   StdStreamRedirect streamRedirect;
   const string& app = testoutput_folder + "/app";
   const string& csolution = app + "/app.csolution.yml";
-  const string& work = testoutput_folder + "/work";
   const string& cprjdir = app + "/foo/baz";
-
-  ASSERT_TRUE(RteFsUtils::CreateDirectories(work));
 
   ASSERT_TRUE(RteFsUtils::CreateTextFile(csolution, "# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/2.4.0/tools/projmgr/schemas/csolution.schema.json\n"
     "solution:\n"
@@ -5899,16 +5892,15 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ProjectDirShouldBeExpanded) {
   ASSERT_TRUE(RteFsUtils::CreateTextFile(app + "/foo/test.cproject.yml", "# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/2.4.0/tools/projmgr/schemas/cproject.schema.json\n"
     "project:\n"));
 
-  ASSERT_FALSE(RteFsUtils::IsDirectory(cprjdir));
-
   argv[1] = (char*)"convert";
   argv[2] = (char*)"--solution";
   argv[3] = (char*)csolution.c_str();
-  ASSERT_EQ(1, RunProjMgr(4, argv, 0));
+  EXPECT_EQ(1, RunProjMgr(4, argv, 0));
 
-  ASSERT_EQ(string::npos, streamRedirect.GetOutString().find("$ProjectDir()$"))
+  EXPECT_EQ(string::npos, streamRedirect.GetOutString().find("$ProjectDir()$"))
     << "stdout:\n" << streamRedirect.GetOutString()
     << "stderr:\n" << streamRedirect.GetErrorString();
 
-  ASSERT_TRUE(RteFsUtils::IsDirectory(cprjdir));
+  EXPECT_TRUE(RteFsUtils::Exists(cprjdir + "/test.debug+main.cprj"));
+  EXPECT_TRUE(RteFsUtils::Exists(cprjdir + "/test.debug+main.cbuild.yml"));
 }


### PR DESCRIPTION
When using the `$ProjectDir()$` access sequence, the expectation is to expand it to the path to where the cproject.yml is placed.

Contributed by STMicroelectronics