### PR TITLE
[csolution] Rework `select-compiler`: store required version ranges

### DIFF
--- a/tools/projmgr/test/data/TestSolution/SelectableToolchains/cdefault.yml
+++ b/tools/projmgr/test/data/TestSolution/SelectableToolchains/cdefault.yml
@@ -3,3 +3,5 @@ default:
   select-compiler:
     - compiler: GCC@>=8.0.0
     - compiler: IAR@1.1.1
+    - compiler: AC6@>=5.6.7
+    - compiler: CLANG@>=12.0.0

--- a/tools/projmgr/test/data/TestSolution/SelectableToolchains/ref/select-compiler.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestSolution/SelectableToolchains/ref/select-compiler.cbuild-idx.yml
@@ -3,8 +3,8 @@ build-idx:
   cdefault: ../data/TestSolution/SelectableToolchains/cdefault.yml
   csolution: ../data/TestSolution/SelectableToolchains/select-compiler.csolution.yml
   select-compiler:
-    - compiler: GCC@11.2.1
-    - compiler: AC6@6.18.0
+    - compiler: AC6@>=6.0.0
+    - compiler: GCC@>=8.0.0
   cprojects:
     - cproject: ../data/TestSolution/SelectableToolchains/select-compiler.cproject.yml
   cbuilds:

--- a/tools/projmgr/test/data/TestSolution/SelectableToolchains/select-compiler.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/SelectableToolchains/select-compiler.csolution.yml
@@ -5,7 +5,8 @@ solution:
   cdefault:
 
   select-compiler:
-    - compiler: "AC6@>=6.0.0"
+    - compiler: AC6@>=6.0.0
+    - compiler: CLANG@1.1.1
 
   build-types:
     - type: Debug


### PR DESCRIPTION
Rework `select-compiler`: store intersection of required version ranges instead of registered one
Requested in Open-CMSIS-Pack meeting from [2024-06-25](https://linaro.atlassian.net/wiki/spaces/CMSIS/pages/29358948421/Open-CMSIS-Pack+Technical+Meeting+2024-06-25)
Related to https://github.com/Open-CMSIS-Pack/devtools/pull/1581