### PR TITLE
Remove generated component when a bootstrap component is deselected

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -986,6 +986,7 @@ void RteProject::Update()
 
   if (gpdscRemoved) {
     t_bGpdscListModified = true;
+    RemoveGeneratedComponents();
     FilterComponents();
   }
 


### PR DESCRIPTION
Fixes crash when deselecting a generated component