### PR TITLE
Update cdefault.yml

### DIFF
--- a/tools/projmgr/templates/cdefault.yml
+++ b/tools/projmgr/templates/cdefault.yml
@@ -1,7 +1,5 @@
 default:
 
-  compiler: GCC
-
   misc:
     - for-compiler: AC6
       C-CPP:
@@ -30,7 +28,6 @@ default:
         - -std=gnu11
       Link:
         - --specs=nano.specs
-        - --specs=rdimon.specs
         - -Wl,-Map=$elf()$.map
         - -Wl,--gc-sections
 


### PR DESCRIPTION
#1641 do not enable semihosting by default, as this will not work for hardware. #1576 Do not set `compiler:` node in cdefault to trigger compiler detection for solutions without selected compiler when cdefault from etc is used.