### PR TITLE
Update cdefault.yml

### DIFF
--- a/tools/projmgr/templates/cdefault.yml
+++ b/tools/projmgr/templates/cdefault.yml
@@ -40,8 +40,7 @@ default:
       C:
         - -std=gnu11
       Link:
-        - -lcrt0-semihost
-        - -lsemihost
+        - -lcrt0
         - -Wl,-Map=$elf()$.map
         - -Wl,--gc-sections
 
@@ -49,5 +48,4 @@ default:
       C-CPP: 
         - --dlib_config DLib_Config_Full.h
       Link:
-        - --semihosting
         - --map=$elf()$.map

--- a/tools/projmgr/templates/cdefault.yml
+++ b/tools/projmgr/templates/cdefault.yml
@@ -28,9 +28,10 @@ default:
         - -std=gnu11
       Link:
         - --specs=nano.specs
+        - --specs=nosys.specs
         - -Wl,-Map=$elf()$.map
         - -Wl,--gc-sections
-        - -Wl,--no-warn-rwx-segments
+        - -Wl,--no-warn-rwx-segments   # suppress incorrect linker warning
 
     - for-compiler: CLANG
       C-CPP:


### PR DESCRIPTION
remove semihosting for CLANG and IAR as well.

@JonatanAntoni could you please validate that this works correctly for CLANG and IAR.