### PR TITLE
[projmgr] Fix `context-set` handling

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4218,10 +4218,6 @@ bool ProjMgrWorker::ParseContextSelection(
         if (m_selectedToolchain.empty()) {
           m_selectedToolchain = cbuildSetItem.compiler;
         }
-
-        if (!ValidateContexts(m_selectedContexts, true)) {
-          return false;
-        }
       }
       else {
         m_selectedContexts.clear();
@@ -4237,6 +4233,10 @@ bool ProjMgrWorker::ParseContextSelection(
         ProjMgrLogger::Error(filterError.m_errMsg);
         return false;
       }
+    }
+    // validate context selection
+    if (!ValidateContexts(m_selectedContexts, contextSelection.empty())) {
+      return false;
     }
   }
 

--- a/tools/projmgr/test/data/TestLayers/ref/variables-notdefined.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestLayers/ref/variables-notdefined.cbuild-idx.yml
@@ -16,3 +16,8 @@ build-idx:
       project: variables-notdefined
       configuration: .BuildType+TargetType
       errors: true
+    - cbuild: testlayers.BuildType+TargetType.cbuild.yml
+      project: testlayers
+      configuration: .BuildType+TargetType
+      clayers:
+        - clayer: ../data/TestLayers/Layer1/layer1.clayer.yml

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6160,7 +6160,7 @@ TEST_F(ProjMgrUnitTests, ConvertEmptyLayer) {
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_conflict_cbuild_set) {
-  char* argv[9];
+  char* argv[7];
   StdStreamRedirect streamRedirect;
 
   // convert --solution solution.yml
@@ -6169,12 +6169,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_conflict_cbuild_set) {
   argv[2] = (char*)"--solution";
   argv[3] = (char*)csolution.c_str();
   argv[4] = (char*)"-c";
-  argv[5] = (char*)".Debug";
-  argv[6] = (char*)"-c";
-  argv[7] = (char*)".Release";
-  argv[8] = (char*)"-S";
-  EXPECT_EQ(1, RunProjMgr(9, argv, 0));
+  argv[5] = (char*)"test1+CM0";
+  argv[6] = (char*)"-S";
+  EXPECT_EQ(1, RunProjMgr(7, argv, 0));
 
   auto errStr = streamRedirect.GetErrorString();
-  EXPECT_NE(errStr.find("build-type is not unique in '.Release' and '.Debug'"), string::npos);
+  EXPECT_NE(errStr.find("build-type is not unique in 'test1.Release+CM0' and 'test1.Debug+CM0'"), string::npos);
 }


### PR DESCRIPTION
1. Validate `context-set` selection with and without `--context` options. Consider each `--context` option can be partially specified and must be expanded before validation.
2. Remove left-over `cbuild-set.yml` reading in list layers. Its reading/writing is already done in `ProjMgr::ParseAndValidateContexts` for all commands.