### PR TITLE
[projmgr] Add pack related access sequences handling

### DIFF
--- a/libs/rteutils/include/RteConstants.h
+++ b/libs/rteutils/include/RteConstants.h
@@ -104,12 +104,16 @@ public:
   static constexpr const char* AS_DNAME = "Dname";
   static constexpr const char* AS_PNAME = "Pname";
   static constexpr const char* AS_BNAME = "Bname";
+  static constexpr const char* AS_DPACK = "Dpack";
+  static constexpr const char* AS_BPACK = "Bpack";
+  
 
   static constexpr const char* AS_SOLUTION_DIR = "SolutionDir";
   static constexpr const char* AS_PROJECT_DIR = "ProjectDir";
   static constexpr const char* AS_SOLUTION_DIR_BR = "SolutionDir()";
   static constexpr const char* AS_PROJECT_DIR_BR = "ProjectDir()";
   static constexpr const char* AS_OUT_DIR = "OutDir";
+  static constexpr const char* AS_PACK_DIR = "Pack";
   static constexpr const char* AS_BIN = OUTPUT_TYPE_BIN;
   static constexpr const char* AS_ELF = OUTPUT_TYPE_ELF;
   static constexpr const char* AS_HEX = OUTPUT_TYPE_HEX;

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -731,7 +731,7 @@ protected:
   bool GetProjectSetup(ContextItem& context);
   bool InitializeTarget(ContextItem& context);
   bool SetTargetAttributes(ContextItem& context, std::map<std::string, std::string>& attributes);
-  bool ProcessPrecedences(ContextItem& context, bool rerun = false);
+  bool ProcessPrecedences(ContextItem& context, bool processDevice = false, bool rerun = false);
   bool ProcessPrecedence(StringCollection& item);
   bool ProcessCompilerPrecedence(StringCollection& item, bool acceptRedefinition = false);
   bool ProcessDevice(ContextItem& context);
@@ -803,6 +803,7 @@ protected:
   void CheckAndGenerateRegionsHeader(ContextItem& context);
   bool GenerateRegionsHeader(ContextItem& context, std::string& generatedRegionsFile);
   void ExpandAccessSequence(const ContextItem& context, const ContextItem& refContext, const std::string& sequence, const std::string& outdir, std::string& item, bool withHeadingDot);
+  void ExpandPackDir(ContextItem& context, const std::string& pack, std::string& item);
   bool GetGeneratorDir(const RteGenerator* generator, ContextItem& context, const std::string& layer, std::string& genDir);
   bool GetGeneratorOptions(ContextItem& context, const std::string& layer, GeneratorOptionsItem& options);
   bool GetExtGeneratorOptions(ContextItem& context, const std::string& layer, GeneratorOptionsItem& options);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -29,6 +29,8 @@ static const regex accessSequencesRegEx = regex(string("^(") +
   "\\((.*)\\)$"
 );
 
+static const regex packDirRegEx = regex(string("^(") + RteConstants::AS_PACK_DIR + ")\\((.*)\\)$");
+
 static const map<const string, tuple<const string, const string, const string>> affixesMap = {
   { ""   ,   {RteConstants::DEFAULT_ELF_SUFFIX, RteConstants::DEFAULT_LIB_PREFIX, RteConstants::DEFAULT_LIB_SUFFIX }},
   { "AC6",   {RteConstants::AC6_ELF_SUFFIX    , RteConstants::AC6_LIB_PREFIX    , RteConstants::AC6_LIB_SUFFIX     }},
@@ -1264,6 +1266,7 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
     context.boardPack = matchedBoard->GetPackage();
     if (context.boardPack) {
       context.packages.insert({ context.boardPack->GetID(), context.boardPack });
+      context.variables[RteConstants::AS_BPACK] = context.boardPack->GetAbsolutePackagePath();
     }
     context.targetAttributes["Bname"]    = matchedBoard->GetName();
     context.targetAttributes["Bvendor"]  = matchedBoard->GetVendorName();
@@ -1398,6 +1401,7 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
   context.devicePack = matchedDevice->GetPackage();
   if (context.devicePack) {
     context.packages.insert({ context.devicePack->GetID(), context.devicePack });
+    context.variables[RteConstants::AS_DPACK] = context.devicePack->GetAbsolutePackagePath();
   }
   GetDeviceItem(context.device, context.deviceItem);
   context.variables[RteConstants::AS_DNAME] = context.deviceItem.name;
@@ -2500,7 +2504,7 @@ bool ProjMgrWorker::ProcessCompilerPrecedence(StringCollection& item, bool accep
 }
 
 
-bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
+bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool processDevice, bool rerun) {
   // Notes: defines, includes and misc are additive. All other keywords overwrite previous settings.
   // The target-type and build-type definitions are additive, but an attempt to
   // redefine an already existing type results in an error.
@@ -2605,8 +2609,15 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool rerun) {
     error |= true;
   }
 
+  // Process device and board
+  if (processDevice && !ProcessDevice(context)) {
+    CheckMissingPackRequirements(context.name);
+    error |= true;
+  }
+
   // Access sequences and relative path references must be processed
   // after board, device and compiler precedences (due to $Bname$, $Dname$ and $Compiler$)
+  // after board and device processing (due to $Bpack$ and $Dpack$)
   // after output filenames (due to $Output$)
   // but before processing misc, defines and includes precedences
   if (!ProcessSequencesRelatives(context, rerun)) {
@@ -3103,6 +3114,31 @@ void ProjMgrWorker::ExpandAccessSequence(const ContextItem& context, const Conte
   item = regex_replace(item, regEx, replacement);
 }
 
+void ProjMgrWorker::ExpandPackDir(ContextItem& context, const string& pack, string& item) {
+  PackInfo packInfo;
+  ProjMgrUtils::ConvertToPackInfo(pack, packInfo);
+  if (packInfo.vendor.empty() || packInfo.name.empty()) {
+    ProjMgrLogger::Warn("access sequence '$Pack(" + pack + ")' must have the format '$Pack(vendor::name)$'");
+    return;
+  }
+  string replacement = RteUtils::EMPTY_STRING;
+  for (const auto& rtePackage : m_loadedPacks) {
+    // find first match in loaded packs
+    PackInfo loadedPackInfo;
+    ProjMgrUtils::ConvertToPackInfo(rtePackage->GetPackageID(), loadedPackInfo);
+    if (ProjMgrUtils::IsMatchingPackInfo(loadedPackInfo, packInfo)) {
+      replacement = rtePackage->GetAbsolutePackagePath();
+      break;
+    }
+  }
+  if (replacement.empty()) {
+    ProjMgrLogger::Warn("access sequence pack was not loaded: '$Pack(" + pack + ")$'");
+    return;
+  }
+  regex regEx = regex(string("\\$") + RteConstants::AS_PACK_DIR + "\\(.*\\)\\$");
+  item = regex_replace(item, regEx, replacement);
+}
+
 bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, const string& ref, string outDir, bool withHeadingDot, bool solutionLevel) {
   size_t offset = 0;
   bool pathReplace = false;
@@ -3119,7 +3155,10 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
     }
     if (offset != string::npos) {
       smatch asMatches;
-      if (regex_match(sequence, asMatches, accessSequencesRegEx) && asMatches.size() == 3) {
+      if (regex_match(sequence, asMatches, packDirRegEx) && asMatches.size() == 3) {
+        // pack dir access sequence
+        ExpandPackDir(context, asMatches[2], item);
+      } else if (regex_match(sequence, asMatches, accessSequencesRegEx) && asMatches.size() == 3) {
         // get capture groups, see regex accessSequencesRegEx
         const string sequenceName = asMatches[1];
         string contextName = asMatches[2];
@@ -3150,7 +3189,10 @@ bool ProjMgrWorker::ProcessSequenceRelative(ContextItem& context, string& item, 
             if (!ParseContextLayers(refContext)) {
               return false;
             }
-            if (!ProcessPrecedences(refContext)) {
+            if (!refContext.rteActiveTarget && !LoadPacks(refContext)) {
+              return false;
+            }
+            if (!ProcessPrecedences(refContext, true)) {
               return false;
             }
           }
@@ -3475,11 +3517,7 @@ bool ProjMgrWorker::ProcessContext(ContextItem& context, bool loadGenFiles, bool
     return false;
   }
   context.rteActiveProject->SetAttribute("update-rte-files", updateRteFiles ? "1" : "0");
-  if (!ProcessPrecedences(context)) {
-    return false;
-  }
-  if (!ProcessDevice(context)) {
-    CheckMissingPackRequirements(context.name);
+  if (!ProcessPrecedences(context, true)) {
     return false;
   }
   if (!SetTargetAttributes(context, context.targetAttributes)) {
@@ -3709,10 +3747,7 @@ bool ProjMgrWorker::ListComponents(vector<string>& components, const string& fil
       return false;
     }
     if (!selectedContext.empty()) {
-      if (!ProcessPrecedences(context)) {
-        return false;
-      }
-      if (!ProcessDevice(context)) {
+      if (!ProcessPrecedences(context, true)) {
         return false;
       }
     }
@@ -4800,10 +4835,7 @@ bool ProjMgrWorker::ProcessGeneratedLayers(ContextItem& context) {
         return false;
       }
     }
-    if (!ProcessPrecedences(context, true)) {
-      return false;
-    }
-    if (!ProcessDevice(context)) {
+    if (!ProcessPrecedences(context, true, true)) {
       return false;
     }
     if (!ProcessGroups(context)) {

--- a/tools/projmgr/test/data/TestAccessSequences/pack-access-sequences.cproject.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/pack-access-sequences.cproject.yml
@@ -1,0 +1,3 @@
+project:
+  components:
+    - component: CORE

--- a/tools/projmgr/test/data/TestAccessSequences/pack-access-sequences.csolution.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/pack-access-sequences.csolution.yml
@@ -1,0 +1,29 @@
+solution:
+  compiler: AC6
+  
+  target-types:
+    - type: CM4-Board
+      board: RteTest CM4 board
+      add-path:
+        - $Dpack$
+        - $Bpack$
+        - $Pack(ARM::RteTest)$
+      add-path-asm:
+        - $Pack(ARM::NotLoaded)$
+        - $Pack(Wrong.Format)$ 
+
+  projects:
+    - project: ./pack-access-sequences.cproject.yml
+
+  packs:
+    - pack: ARM::RteTest_DFP@0.1.1
+    - pack: ARM::RteTestBoard
+    - pack: ARM::RteTest
+
+  executes:
+    - execute: fcarm
+      run: $input(0)$
+      input:
+        - $Pack(ARM::RteTest_DFP)$/fcarm
+      output:
+        - $ProjectDir()$/source.c

--- a/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
@@ -1,0 +1,67 @@
+build:
+  generated-by: csolution version 2.5.0
+  solution: ../data/TestAccessSequences/pack-access-sequences.csolution.yml
+  project: ../data/TestAccessSequences/pack-access-sequences.cproject.yml
+  context: pack-access-sequences+CM4-Board
+  compiler: AC6
+  board: RteTest CM4 board
+  board-pack: ARM::RteTestBoard@0.1.0
+  device: RteTest_ARMCM4_FP
+  device-pack: ARM::RteTest_DFP@0.1.1
+  processor:
+    fpu: sp
+    core: Cortex-M4
+  packs:
+    - pack: ARM::RteTestBoard@0.1.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTestBoard/0.1.0
+    - pack: ARM::RteTest_DFP@0.1.1
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1
+  define:
+    - ARMCM4_FP
+    - _RTE_
+  define-asm:
+    - ARMCM4_FP
+    - _RTE_
+  add-path:
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1
+    - ${CMSIS_PACK_ROOT}/ARM/RteTestBoard/0.1.0
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0
+    - ../data/TestAccessSequences/RTE/_CM4-Board
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Device/ARM/ARMCM4/Include
+  add-path-asm:
+    - ../data/TestAccessSequences/$Pack(ARM::NotLoaded)$
+    - ../data/TestAccessSequences/$Pack(Wrong.Format)$
+    - ../data/TestAccessSequences/RTE/_CM4-Board
+    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Device/ARM/ARMCM4/Include
+  output-dirs:
+    intdir: tmp/pack-access-sequences/CM4-Board
+    outdir: out/pack-access-sequences/CM4-Board
+    rtedir: ../data/TestAccessSequences/RTE
+  output:
+    - type: elf
+      file: pack-access-sequences.axf
+  components:
+    - component: ARM::RteTest:CORE@0.1.1
+      condition: Cortex-M Device
+      from-pack: ARM::RteTest_DFP@0.1.1
+      selected-by: CORE
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/Doc/html/index.html
+          category: doc
+          version: 0.1.1
+  linker:
+    script: ../data/TestAccessSequences/RTE/Device/RteTest_ARMCM4_FP/ac6_linker_script.sct.src
+    regions: ../data/TestAccessSequences/RTE/Device/RteTest_ARMCM4_FP/regions_RteTest_CM4_board.h
+  constructed-files:
+    - file: ../data/TestAccessSequences/RTE/_CM4-Board/RTE_Components.h
+      category: header
+  licenses:
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTestBoard@0.1.0
+    - license: <unknown>
+      packs:
+        - pack: ARM::RteTest_DFP@0.1.1
+      components:
+        - component: ::RteTest:CORE(API)
+        - component: ARM::RteTest:CORE@0.1.1

--- a/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences.cbuild-idx.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences.cbuild-idx.yml
@@ -1,0 +1,17 @@
+build-idx:
+  generated-by: csolution version 2.5.0
+  csolution: ../data/TestAccessSequences/pack-access-sequences.csolution.yml
+  tmpdir: tmp
+  cprojects:
+    - cproject: ../data/TestAccessSequences/pack-access-sequences.cproject.yml
+  cbuilds:
+    - cbuild: pack-access-sequences+CM4-Board.cbuild.yml
+      project: pack-access-sequences
+      configuration: +CM4-Board
+  executes:
+    - execute: fcarm
+      run: ${INPUT_0}
+      input:
+        - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.1.1/fcarm
+      output:
+        - ../data/TestAccessSequences/source.c

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -2300,6 +2300,33 @@ TEST_F(ProjMgrUnitTests, AccessSequences2) {
    testinput_folder + "/TestAccessSequences/ref/test-access-sequences2.cbuild-idx.yml");
 }
 
+TEST_F(ProjMgrUnitTests, PackAccessSequences) {
+  char* argv[5];
+  StdStreamRedirect streamRedirect;
+  const string& csolution = testinput_folder + "/TestAccessSequences/pack-access-sequences.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"-o";
+  argv[4] = (char*)testoutput_folder.c_str();
+  EXPECT_EQ(0, RunProjMgr(5, argv, m_envp));
+
+  // Check generated cbuild files
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/pack-access-sequences.cbuild-idx.yml",
+    testinput_folder + "/TestAccessSequences/ref/pack-access-sequences.cbuild-idx.yml");
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/pack-access-sequences+CM4-Board.cbuild.yml",
+    testinput_folder + "/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml");
+
+  // Check warnings
+  const vector<string> expectedVec = {
+    {"warning csolution: access sequence pack was not loaded: '$Pack(ARM::NotLoaded)$'"},
+    {"warning csolution: access sequence '$Pack(Wrong.Format)' must have the format '$Pack(vendor::name)$'"}
+  };
+  const string& errStr = streamRedirect.GetErrorString();
+  for (const auto& expected : expectedVec) {
+    EXPECT_TRUE(errStr.find(expected) != string::npos) << "Missing Expected: " + expected;
+  }
+}
+
 TEST_F(ProjMgrUnitTests, RunProjMgr_MalformedAccessSequences1) {
   char* argv[6];
   const string& csolution = testinput_folder + "/TestAccessSequences/test-malformed-access-sequences1.csolution.yml";

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -1504,6 +1504,7 @@ TEST_F(ProjMgrWorkerUnitTests, GetGeneratorDir) {
   context.directories.cprj = testoutput_folder;
   context.variables["Compiler"] = context.compiler = "AC6";
   context.name = "project.Build+Target";
+  cproject.target.device = "RteTest_ARMCM0";
   string genDir;
 
   // base directory


### PR DESCRIPTION
Handle `$Dpack$`, `$Bpack$` and `$Pack(vendor::name)$` access sequences as documented in:
https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#access-sequences

Note: use `::` as delimiter instead of `.`, as established by [pack name conventions](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/YML-Input-Format.md#pack-name-conventions).
