### PR TITLE
[projmgr] Fix `Bvendor` handling (#995)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1227,7 +1227,7 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
     list<RteBoard*> partialMatchedBoards;
     for (const auto& [_, board] : availableBoards) {
       if (board->GetName() == boardItem.name) {
-        if (boardItem.vendor.empty() || (boardItem.vendor == DeviceVendor::GetCanonicalVendorName(board->GetVendorName()))) {
+        if (boardItem.vendor.empty() || (boardItem.vendor == board->GetVendorString())) {
           partialMatchedBoards.push_back(board);
         }
       }
@@ -3633,7 +3633,7 @@ bool ProjMgrWorker::ListBoards(vector<string>& boards, const string& filter) {
     }
     const RteBoardMap& availableBoards = context.rteFilteredModel->GetBoards();
     for (const auto& [_, board] : availableBoards) {
-      const string& boardVendor = board->GetVendorName();
+      const string& boardVendor = board->GetVendorString();
       const string& boardName = board->GetName();
       const string& boardRevision = board->GetRevision();
       const string& boardPack = board->GetPackageID(true);


### PR DESCRIPTION
`Bvendor` is an [unrestricted string](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_boards_pg.html#element_board) and must be handled accordingly.
It should not be confused with `Dvendor` that uses predefined values listed in [Device Vendor Enum](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#DeviceVendorEnum) and may have [alternate names remapping](https://github.com/Open-CMSIS-Pack/devtools/blob/tools/projmgr/2.5.0/libs/rteutils/src/DeviceVendor.cpp#L70).

Address https://github.com/Open-CMSIS-Pack/devtools/issues/1671