### PR TITLE
[projmgr] Fix compiler redefinition

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2555,6 +2555,9 @@ bool ProjMgrWorker::ProcessPrecedences(ContextItem& context, bool processDevice,
     error |= true;
   }
 
+  // clean previous compiler selection
+  context.compiler.clear();
+
   StringCollection compiler = {
    &context.compiler,
    {

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -1502,7 +1502,7 @@ TEST_F(ProjMgrWorkerUnitTests, GetGeneratorDir) {
   cproject.directory = csolution.directory + "/ProjectDirectory";
   clayer.directory = cproject.directory + "/LayerDirectory";
   context.directories.cprj = testoutput_folder;
-  context.variables["Compiler"] = context.compiler = "AC6";
+  context.variables["Compiler"] = csolution.target.build.compiler = "AC6";
   context.name = "project.Build+Target";
   cproject.target.device = "RteTest_ARMCM0";
   string genDir;


### PR DESCRIPTION
Ensure the compiler selection is clean before processing the compiler precedence to avoid unexpected redefinition if the precedences are recalculated, for example after applying a generated layer (cgen) to the context processing.

Address https://github.com/Open-CMSIS-Pack/devtools/issues/1674