### PR TITLE
Avoid creation of files when dry-running generator

### DIFF
--- a/tools/projmgr/include/ProjMgrYamlEmitter.h
+++ b/tools/projmgr/include/ProjMgrYamlEmitter.h
@@ -63,7 +63,8 @@ public:
   */
   static bool GenerateCbuild(ContextItem* context, bool checkSchema,
     const std::string& generatorId = std::string(),
-    const std::string& generatorPack = std::string());
+    const std::string& generatorPack = std::string(),
+    bool ignoreRteFileMissing = false);
 
   /**
    * @brief generate cbuild set file
@@ -74,7 +75,7 @@ public:
    * @return true if executed successfully
   */
   static bool GenerateCbuildSet(const std::vector<std::string> selectedContexts,
-    const std::string& selectedCompiler, const std::string& cbuildSetFile, bool checkSchema);
+    const std::string& selectedCompiler, const std::string& cbuildSetFile, bool checkSchema, bool ignoreRteFileMissing = false);
 
   /**
    * @brief generate cbuild pack file

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4117,7 +4117,7 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
   }
   const string& selectedContext = m_selectedContexts.front();
   ContextItem& context = m_contexts[selectedContext];
-  if (!ProcessContext(context, false)) {
+  if (!ProcessContext(context, false, true, !m_dryRun)) {
     return false;
   }
   const auto& generators = context.generators;
@@ -4146,7 +4146,7 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
   }
 
   if (!ProjMgrYamlEmitter::GenerateCbuild(&context, m_checkSchema, generator->GetGeneratorName(),
-    RtePackage::GetPackageIDfromAttributes(*generator->GetPackage()))) {
+    RtePackage::GetPackageIDfromAttributes(*generator->GetPackage()), m_dryRun)) {
     return false;
   }
 
@@ -4176,7 +4176,9 @@ bool ProjMgrWorker::ExecuteGenerator(std::string& generatorId) {
 
   error_code ec;
   const auto& workingDir = fs::current_path(ec);
-  RteFsUtils::CreateDirectories(generatorDestination);
+  if (!m_dryRun) {
+    RteFsUtils::CreateDirectories(generatorDestination);
+  }
   fs::current_path(generatorDestination, ec);
   StrIntPair result = CrossPlatformUtils::ExecCommand(generatorCommand);
   fs::current_path(workingDir, ec);

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -184,9 +184,12 @@ TEST_F(ProjMgrGeneratorUnitTests, DryRun) {
   argv[6] = (char*)"--dry-run";
 
   const string generatorInputFile = testinput_folder + "/TestSolution/tmp/TestProject3_1/TypeA/Debug/TestProject3_1.Debug+TypeA.cbuild-gen.yml";
-  const string targetGPDSC = testinput_folder + "/TestSolution/TestProject3_1/gendir/RteTestGen_ARMCM0/RteTest.gpdsc";
+  const string generatorDestination = testinput_folder + "/TestSolution/TestProject3_1/gendir";
+  const string targetGPDSC = generatorDestination + "/RteTestGen_ARMCM0/RteTest.gpdsc";
+  const string rteDir = testinput_folder + "/TestSolution/TestProject3_1/RTE";
 
-  RteFsUtils::RemoveFile(targetGPDSC);
+  RteFsUtils::RemoveDir(generatorDestination);
+  RteFsUtils::RemoveDir(rteDir);
 
   EXPECT_EQ(0, ProjMgr::RunProjMgr(7, argv, envp));
 
@@ -200,7 +203,9 @@ TEST_F(ProjMgrGeneratorUnitTests, DryRun) {
   ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, stripAbsoluteFunc);
 
   EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));
+  EXPECT_EQ(false, std::filesystem::exists(rteDir));
   EXPECT_EQ(false, std::filesystem::exists(targetGPDSC));
+  EXPECT_EQ(false, std::filesystem::exists(generatorDestination));
 
   // Expect that the GPDSC content was printed to stdout, enclosed within the begin and end marks
   auto outStr = streamRedirect.GetOutString();


### PR DESCRIPTION
Both generator output directory and RTE were created (in the latter case also with contents) when running a generator with the `--dry-run` flag. The idea of dry run was to only return the contents of the GPDSC without unnecessary work or file system access.

When the RTE directory is no longer updated when dry-running a generator, creation of the cbuild and cbuild-gen files need to ignore that files may be missing when adding the `constructed-files` node.

Contributed by STMicroelectronics