### PR TITLE
[projmgr] Skip missing `pname` error when layer variables are not defined (#1008)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1358,18 +1358,21 @@ bool ProjMgrWorker::ProcessDevice(ContextItem& context) {
   if (!processor) {
     if (!deviceItem.pname.empty()) {
       ProjMgrLogger::Error("processor name '" + deviceItem.pname + "' was not found");
+      return false;
+    } else if (!HasVarDefineError()) {
+      string msg = "one of the following processors must be specified:";
+      const auto& processors = matchedDevice->GetProcessors();
+      for (const auto& p : processors) {
+        msg += "\n" + matchedDevice->GetDeviceName() + ":" + p.first;
+      }
+      ProjMgrLogger::Error(msg);
+      return false;
     }
-    string msg = "one of the following processors must be specified:";
-    const auto& processors = matchedDevice->GetProcessors();
-    for (const auto& p : processors) {
-      msg += "\n" + matchedDevice->GetDeviceName() + ":" + p.first;
-    }
-    ProjMgrLogger::Error(msg);
-    return false;
+  } else {
+    const auto& processorAttributes = processor->GetAttributes();
+    context.targetAttributes.insert(processorAttributes.begin(), processorAttributes.end());
   }
 
-  const auto& processorAttributes = processor->GetAttributes();
-  context.targetAttributes.insert(processorAttributes.begin(), processorAttributes.end());
   context.targetAttributes["Dvendor"] = matchedDevice->GetEffectiveAttribute("Dvendor");
   context.targetAttributes["Dname"] = matchedDevice->GetFullDeviceName();
 

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -112,6 +112,26 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessDevice) {
   EXPECT_TRUE(context.targetAttributes.find("Dendian") == context.targetAttributes.end());
 }
 
+TEST_F(ProjMgrWorkerUnitTests, ProcessDeviceUndefLayerVar) {
+  ContextItem context;
+  EXPECT_TRUE(LoadPacks(context));
+  // undefined layer variables
+  this->m_undefLayerVars.insert("Board-Layer");
+  // multi-core device with pname
+  context.device = "RteTest_ARMCM0_Dual:cm0_core0";
+  context.targetAttributes.clear();
+  EXPECT_TRUE(ProcessDevice(context));
+  EXPECT_EQ("cm0_core0", context.targetAttributes["Pname"]);
+  // multi-core device without pname
+  context.device = "RteTest_ARMCM0_Dual";
+  context.targetAttributes.clear();
+  EXPECT_TRUE(ProcessDevice(context));
+  EXPECT_TRUE(context.targetAttributes["Pname"].empty());
+  // no undefined layer variables
+  this->m_undefLayerVars.clear();
+  EXPECT_FALSE(ProcessDevice(context));
+}
+
 TEST_F(ProjMgrWorkerUnitTests, ProcessComponents) {
   set<string> expected = {
     "ARM::Device:Startup&RteTest Startup@2.0.3",


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1658