### PR TITLE
[projmgr] Add support for pack version operators `^` (compatible) and `~` (equivalent) (#1016)

### DIFF
--- a/tools/projmgr/include/ProjMgrUtils.h
+++ b/tools/projmgr/include/ProjMgrUtils.h
@@ -80,6 +80,18 @@ struct PackInfo {
 };
 
 /**
+ * @brief semantic version with unsigned integer elements
+ *        major,
+ *        minor,
+ *        patch,
+*/
+struct SemVer {
+  unsigned int major;
+  unsigned int minor;
+  unsigned int patch;
+};
+
+/**
  * @brief vector of ConnectionsCollection
 */
 typedef std::vector<ConnectionsCollection> ConnectionsCollectionVec;
@@ -234,6 +246,13 @@ public:
    * @return true on success
   */
   static bool HasAccessSequence(const std::string value);
+
+  /**
+   * @brief get semantic version elements
+   * @param string version
+   * @return structured semantic version
+  */
+  static SemVer GetSemVer(const std::string version);
 
 protected:
   static std::string ConstructID(const std::vector<std::pair<const char*, const std::string&>>& elements);

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -1224,8 +1224,8 @@
     },
     "PackID": {
       "type": "string",
-      "pattern": "^([a-zA-Z0-9_ \\.-]+)((::[a-zA-Z0-9_ \\.\\*-]+)(@(>=)?([0-9]+\\.[0-9]+\\.[0-9]+((\\+|\\-)[a-zA-Z0-9_\\.\\+-]+)?))?)?$",
-      "description": "Name of a required Software Pack in the format Vendor [:: Pack [@[>=] version]]"
+      "pattern": "^([a-zA-Z0-9_ \\.-]+)((::[a-zA-Z0-9_ \\.\\*-]+)(@(>=|\\~|\\^)?([0-9]+\\.[0-9]+\\.[0-9]+((\\+|\\-)[a-zA-Z0-9_\\.\\+-]+)?))?)?$",
+      "description": "Name of a required Software Pack in the format Vendor [:: Pack [@[>=|~|^] version]]"
     },
     "VersionlessPackID": {
       "type": "string",

--- a/tools/projmgr/test/data/TestSolution/ref/test_pack_selection.cbuild-pack.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/test_pack_selection.cbuild-pack.yml
@@ -6,3 +6,5 @@ cbuild-pack:
     - resolved-pack: ARM::RteTest_DFP@0.2.0
       selected-by-pack:
         - ARM::RteTest_DFP@>=0.2.0
+        - ARM::RteTest_DFP@^0.1.0
+        - ARM::RteTest_DFP@~0.2.0

--- a/tools/projmgr/test/data/TestSolution/test_pack_selection.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/test_pack_selection.csolution.yml
@@ -40,6 +40,12 @@ solution:
       del-path:
         - ./path/solution/to-be-removed
 
+    - type: Compatible
+      device: RteTest_ARMCM0
+
+    - type: Equivalent
+      device: RteTest_ARMCM0
+
   build-types:
     - type: Debug
       compiler: AC6
@@ -77,7 +83,11 @@ solution:
     - pack: ARM::RteTest_DFP@>=0.2.0
       for-context: [+CM0, +TestGen]
     - pack: ARM::RteTest_INVALID@1.2.3
-      not-for-context: [.Debug+CM0,.Debug+TestGen,.Release+CM0, .Release+TestGen]
+      not-for-context: [.Debug+CM0,.Debug+TestGen,.Release+CM0, .Release+TestGen, +Compatible, +Equivalent]
+    - pack: ARM::RteTest_DFP@^0.1.0
+      for-context: +Compatible
+    - pack: ARM::RteTest_DFP@~0.2.0
+      for-context: +Equivalent
 
   projects:
     - project: ./TestProject2/test2.cproject.yml

--- a/tools/projmgr/test/src/ProjMgrUtilsUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUtilsUnitTests.cpp
@@ -445,6 +445,9 @@ TEST_F(ProjMgrUtilsUnitTests, ConvertToVersionRange) {
   EXPECT_EQ("", ProjMgrUtils::ConvertToVersionRange(""));
   EXPECT_EQ("1.2.3:1.2.3", ProjMgrUtils::ConvertToVersionRange("1.2.3"));
   EXPECT_EQ("1.2.3", ProjMgrUtils::ConvertToVersionRange(">=1.2.3"));
+  EXPECT_EQ("1.2.3-build4", ProjMgrUtils::ConvertToVersionRange(">=1.2.3-build4"));
+  EXPECT_EQ("1.2.3:1.3.0-0", ProjMgrUtils::ConvertToVersionRange("~1.2.3"));
+  EXPECT_EQ("1.2.3:2.0.0-0", ProjMgrUtils::ConvertToVersionRange("^1.2.3"));
 }
 
 TEST_F(ProjMgrUtilsUnitTests, ReplaceDelimiters) {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1687