### PR TITLE
[svdconv] add protection handling to SvdItem::CopyItem and add SvdItem::SetProtection

### DIFF
--- a/tools/svdconv/SVDModel/include/SvdItem.h
+++ b/tools/svdconv/SVDModel/include/SvdItem.h
@@ -183,6 +183,7 @@ public:
   std::string                           GetHierarchicalNameResulting        ();
   std::string                           TryGetHeaderStructName              (SvdItem *item);
   const std::string&                    GetPeripheralName                   ();
+  bool                                  SetProtection                       (SvdTypes::ProtectionType protection) { m_protection = protection; return true; }
   SvdTypes::ProtectionType              GetProtection                       ()                    { return m_protection; }
   std::string                           GetDeriveName                       ();
   SvdItem*                              GetParent                           ()                    { return m_parent; }

--- a/tools/svdconv/SVDModel/src/SvdItem.cpp
+++ b/tools/svdconv/SVDModel/src/SvdItem.cpp
@@ -895,6 +895,7 @@ bool SvdItem::CopyItem(SvdItem *from)
   const auto  lineNo          = GetLineNumber  ();
   const auto  bitWidth        = GetBitWidth    ();
   const auto  dimElementIndex = GetDimElementIndex();
+  const auto  protection      = GetProtection  ();
 
   if(name     == "")                                { SetName        (from->GetName              ()); }
   if(dispName == "")                                { SetDisplayName (from->GetDisplayName       ()); }
@@ -902,6 +903,7 @@ bool SvdItem::CopyItem(SvdItem *from)
   if(lineNo   == -1)                                { SetLineNumber  (from->GetLineNumber        ()); }
   if(bitWidth == (int32_t)SvdItem::VALUE32_NOT_INIT){ SetBitWidth    (from->GetBitWidth          ()); }
   if(dimElementIndex == SvdItem::VALUE32_NOT_INIT)  { SetDimElementIndex(from->GetDimElementIndex()); }
+  if(protection == SvdTypes::ProtectionType::UNDEF) { SetProtection  (from->GetProtection        ()); }
 
   string tag = "Copied ";
   const string &oldTag = GetTag();


### PR DESCRIPTION
This PR adds protection handling to `SvdItem::CopyItem`. Currently, if an `SvdItem` is copied (e.g., `dim` or `derivedFrom`), its protection is not being copied (different from the other register properties `size`, `access`, `resetValue`, and `resetMask`). As a result, `SvdItem::GetEffectiveProtection` always returns `UNDEF` for inherited (`derivedFrom`) or dimensioned (`dim`) `SvdItems`. In my opinion, there is no reason for that, but please let me know if there is a specific reason (@thorstendb-ARM ?).

I'm currently working on SVD test cases for [cmsis-svd](https://github.com/cmsis-svd/cmsis-svd) and [SVDSuite](https://github.com/ARMify-Project/SVDSuite) and am trying to figure out how the inheritance of the protection rights should be handled. I'm aware that the protection is currently not really used in `svdconv`, but I believe it should be handled correctly if already implemented.