### PR TITLE
[devtools] Extend `language-C` and `language-CPP` supported values

### DIFF
--- a/tools/buildmgr/cbuildgen/config/AC6.6.16.2.cmake
+++ b/tools/buildmgr/cbuildgen/config/AC6.6.16.2.cmake
@@ -81,9 +81,9 @@ set(WARNINGS_AS_ARM_FLAGS ""   "-w"                      "")
 set(WARNINGS_AS_GNU_FLAGS ""   "-w"                      "-Wall")
 set(WARNINGS_ASM_FLAGS    ""   "-w"                      "-Wall")
 
-set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "c23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"     )
-set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=c23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""            )
-set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""         "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++17" "-std=gnu++17")
+set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "gnu17"      "c23"      "gnu23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"      "c++23"      "gnu++23")
+set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=gnu17" "-std=c23" "-std=gnu23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           "")
+set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""           ""         ""           "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++20" "-std=gnu++20" "-std=c++23" "-std=gnu++23")
 
 function(cbuild_set_option_flags lang option value flags)
   if(NOT DEFINED ${option}_${lang}_FLAGS)

--- a/tools/buildmgr/cbuildgen/config/CLANG.17.0.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/CLANG.17.0.1.cmake
@@ -57,9 +57,9 @@ set(WARNINGS_ASM_FLAGS    ""   "-w"  "-Wall")
 set(WARNINGS_CXX_FLAGS    ""   "-w"  "-Wall")
 set(WARNINGS_LD_FLAGS     ""   "-w"  "-Wall")
 
-set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "c23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"     )
-set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=c23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""            )
-set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""         "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++20" "-std=gnu++20")
+set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "gnu17"      "c23"      "gnu23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"      "c++23"      "gnu++23")
+set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=gnu17" "-std=c23" "-std=gnu23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           "")
+set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""           ""         ""           "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++20" "-std=gnu++20" "-std=c++23" "-std=gnu++23")
 
 function(cbuild_set_option_flags lang option value flags)
   if(NOT DEFINED ${option}_${lang}_FLAGS)

--- a/tools/buildmgr/cbuildgen/config/GCC.10.3.1.cmake
+++ b/tools/buildmgr/cbuildgen/config/GCC.10.3.1.cmake
@@ -66,9 +66,9 @@ set(WARNINGS_AS_GNU_FLAGS ""       "-w"        "-Wall")
 set(WARNINGS_CXX_FLAGS    ""       "-w"        "-Wall")
 set(WARNINGS_LD_FLAGS     ""       "-w"        "-Wall")
 
-set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "c23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"     )
-set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=c23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""            )
-set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""         "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++20" "-std=gnu++20")
+set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"      "c17"      "gnu17"      "c23"      "gnu23"      "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"      "c++20"      "gnu++20"      "c++23"      "gnu++23")
+set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11" "-std=c17" "-std=gnu17" "-std=c23" "-std=gnu23" ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           ""             ""           "")
+set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""           ""         ""           ""         ""           "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17" "-std=c++20" "-std=gnu++20" "-std=c++23" "-std=gnu++23")
 
 function(cbuild_set_option_flags lang option value flags)
   if(NOT DEFINED ${option}_${lang}_FLAGS)

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -181,12 +181,12 @@
       "description": "Control warnings (on, off, all)."
     },
     "LanguageCType": {
-      "enum": [ "c90", "gnu90", "c99", "gnu99", "c11", "gnu11", "c17", "c23" ],
-      "description": "Language standard for C (c90, gnu90, c99, gnu99, c11, gnu11, c17, c23)."
+      "enum": [ "c90", "gnu90", "c99", "gnu99", "c11", "gnu11", "c17", "gnu17", "c23", "gnu23" ],
+      "description": "Language standard for C (c90, gnu90, c99, gnu99, c11, gnu11, c17, gnu17, c23, gnu23)."
     },
     "LanguageCppType": {
-      "enum": [ "c++98", "gnu++98", "c++03", "gnu++03", "c++11", "gnu++11", "c++14", "gnu++14", "c++17", "gnu++17", "c++20", "gnu++20" ],
-      "description": "Language standard for C++ (c++98, gnu++98, c++03, gnu++03, c++11, gnu++11, c++14, gnu++14, c++17, gnu++17, c++20, gnu++20)."
+      "enum": [ "c++98", "gnu++98", "c++03", "gnu++03", "c++11", "gnu++11", "c++14", "gnu++14", "c++17", "gnu++17", "c++20", "gnu++20", "c++23", "gnu++23" ],
+      "description": "Language standard for C++ (c++98, gnu++98, c++03, gnu++03, c++11, gnu++11, c++14, gnu++14, c++17, gnu++17, c++20, gnu++20, c++23, gnu++23)."
     },
     "PLMStatusType": {
       "enum": [ "missing file", "missing base", "update suggested", "update recommended", "update required" ],


### PR DESCRIPTION
This PR adds the remaining missing C and C++ language standards to AC6, GCC, and CLANG.

- add C standards gnu17 and gnu23
- add C++ standards c++23 and gnu++23
- fix C++ standards c++20 and gnu++20 incorrectly setting `-std=c++17` and `-std=gnu++17` on AC6

Fixes #1785