### PR TITLE
[devtools] Omit leading Cvendor delimiter `::` in API identifier

### DIFF
--- a/libs/rtemodel/src/RteItem.cpp
+++ b/libs/rtemodel/src/RteItem.cpp
@@ -209,7 +209,7 @@ string RteItem::GetPartialComponentID(bool bWithBundle) const {
 
 string RteItem::GetApiID(bool withVersion) const
 {
-  string id = RteConstants::SUFFIX_CVENDOR;
+  string id;
   id += GetCclassName();
   id += RteConstants::PREFIX_CGROUP;
   id += GetCgroupName();

--- a/libs/rtemodel/test/src/RteItemTest.cpp
+++ b/libs/rtemodel/test/src/RteItemTest.cpp
@@ -28,8 +28,8 @@ TEST(RteItemTest, GetComponentID_all_attributes) {
   RteItem item(attributes);
   item.SetTag("require");
 
-  EXPECT_EQ("::Class:Group(API)@1.1.1", item.GetApiID(true));
-  EXPECT_EQ("::Class:Group(API)", item.GetApiID(false));
+  EXPECT_EQ("Class:Group(API)@1.1.1", item.GetApiID(true));
+  EXPECT_EQ("Class:Group(API)", item.GetApiID(false));
 
   EXPECT_EQ("Vendor::Class&Bundle:Group:Sub&Variant@9.9.9", item.GetComponentID(true));
   EXPECT_EQ("Vendor::Class&Bundle:Group:Sub&Variant", item.GetComponentID(false));

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -243,10 +243,10 @@ TEST(RteModelTest, LoadPacks) {
   EXPECT_FALSE(c != nullptr);
 
   // get API
-  const string& apiId = "::RteTest:CORE(API)";
+  const string& apiId = "RteTest:CORE(API)";
   RteApi* api = rteModel->GetLatestApi(apiId);
   ASSERT_TRUE(api);
-  EXPECT_EQ(api->GetID(),  "::RteTest:CORE(API)@1.1.2");
+  EXPECT_EQ(api->GetID(),  "RteTest:CORE(API)@1.1.2");
   EXPECT_EQ(api->GetPackageID(), "ARM::RteTest_DFP@0.2.0");
 
   // make pack "dominant"
@@ -257,7 +257,7 @@ TEST(RteModelTest, LoadPacks) {
   pack->Construct(); // refresh internal state
   api = rteModel->GetLatestApi(apiId);
   ASSERT_TRUE(api);
-  EXPECT_EQ(api->GetID(),  "::RteTest:CORE(API)@1.1.1");
+  EXPECT_EQ(api->GetID(),  "RteTest:CORE(API)@1.1.1");
   EXPECT_EQ(api->GetPackageID(), "ARM::RteTest_DFP@0.1.1");
 }
 

--- a/test/projects/RteTestM3/license_info_ref.txt
+++ b/test/projects/RteTestM3/license_info_ref.txt
@@ -11,9 +11,9 @@ licenses:
     packs:
     - pack: ARM::RteTest_DFP@0.2.0
     components:
-    - component: ::RteTest:CORE(API)
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
     - component: ARM::RteTest:CORE@0.1.1
+    - component: RteTest:CORE(API)
 
   - license: BSD-3-Clause
     packs:

--- a/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
@@ -71,5 +71,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.1.1
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
@@ -68,5 +68,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.1.1
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
@@ -68,5 +68,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.1.1
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -119,5 +119,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -107,5 +107,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -145,5 +145,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-project-files.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-project-files.Debug+CM0.cbuild.yml
@@ -113,5 +113,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -107,5 +107,5 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ComponentSources/ref/components.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ComponentSources/ref/components.Debug+RteTest_ARMCM3.cbuild.yml
@@ -85,7 +85,7 @@ build:
       packs:
         - pack: ARM::RteTest@0.1.0
       components:
-        - component: ::RteTest:TemplateFile(API)
+        - component: RteTest:TemplateFile(API)
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
       packs:

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti-signret.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti-signret.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+no-bp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+no-bp.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+dsp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+dsp.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+no-dsp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+no-dsp.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+big.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+big.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+little.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+little.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-dp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-dp.cbuild.yml
@@ -83,6 +83,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-sp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-sp.cbuild.yml
@@ -83,6 +83,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+no-fpu.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+no-fpu.cbuild.yml
@@ -83,6 +83,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-fp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-fp.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-int.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-int.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+no-mve.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+no-mve.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+non-secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+non-secure.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure-only.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure-only.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure.cbuild.yml
@@ -86,6 +86,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+tz-disabled.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+tz-disabled.cbuild.yml
@@ -84,6 +84,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Fail+secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Fail+secure.cbuild.yml
@@ -86,6 +86,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
@@ -101,7 +101,7 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
@@ -99,7 +99,7 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
@@ -82,6 +82,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.1.1
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
@@ -89,6 +89,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/TemplateAndApi/ref/template_api.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TemplateAndApi/ref/template_api.Debug+RteTest_ARMCM3.cbuild.yml
@@ -78,7 +78,7 @@ build:
       packs:
         - pack: ARM::RteTest@0.1.0
       components:
-        - component: ::RteTest:TemplateFile(API)
+        - component: RteTest:TemplateFile(API)
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
       packs:

--- a/tools/projmgr/test/data/TestSolution/TestBaseUpdate/ref/project.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TestBaseUpdate/ref/project.Debug+CM0.cbuild.yml
@@ -91,6 +91,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/TestProject4/test_board_and_device+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TestProject4/test_board_and_device+TEST_TARGET.cbuild.yml
@@ -91,6 +91,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
@@ -158,6 +158,6 @@ build-gen:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -119,6 +119,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
@@ -197,6 +197,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
@@ -190,6 +190,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
@@ -128,6 +128,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
@@ -125,6 +125,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
@@ -89,6 +89,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
@@ -81,6 +81,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
@@ -148,9 +148,9 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ::RteTest:CORE(API)
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
+        - component: RteTest:CORE(API)
     - license: BSD-3-Clause
       packs:
         - pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -3925,7 +3925,7 @@ TEST_F(ProjMgrUnitTests, Convert_ValidationResults_Dependencies) {
   argv[5] = (char*)"-c";
 
   map<string, string> testData = {
-    {"conflict+CM0",             "warning csolution: dependency validation for context 'conflict+CM0' failed:\nCONFLICT ::RteTest:ApiExclusive(API)\n  ARM::RteTest:ApiExclusive:S1\n  ARM::RteTest:ApiExclusive:S2" },
+    {"conflict+CM0",             "warning csolution: dependency validation for context 'conflict+CM0' failed:\nCONFLICT RteTest:ApiExclusive(API)\n  ARM::RteTest:ApiExclusive:S1\n  ARM::RteTest:ApiExclusive:S2" },
     {"incompatible+CM0",         "warning csolution: dependency validation for context 'incompatible+CM0' failed:\nINCOMPATIBLE ARM::RteTest:Check:Incompatible@0.9.9\n  deny RteTest:Dependency:Incompatible_component" },
     {"incompatible-variant+CM0", "warning csolution: dependency validation for context 'incompatible-variant+CM0' failed:\nINCOMPATIBLE_VARIANT ARM::RteTest:Check:IncompatibleVariant@0.9.9\n  require RteTest:Dependency:Variant&Compatible" },
     {"missing+CM0",              "warning csolution: dependency validation for context 'missing+CM0' failed:\nMISSING ARM::RteTest:Check:Missing@0.9.9\n  require RteTest:Dependency:Missing" },


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1821