### PR TITLE
[projmgr] Add a hint in missing component error message

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -842,7 +842,7 @@ protected:
   bool ProcessToolchain(ContextItem& context);
   bool ProcessPackages(ContextItem& context, const std::string& packRoot);
   bool ProcessComponents(ContextItem& context);
-  RteComponent* ProcessComponent(ContextItem& context, ComponentItem& item, RteComponentMap& componentMap);
+  RteComponent* ProcessComponent(ContextItem& context, ComponentItem& item, RteComponentMap& componentMap, std::string& hint);
   bool ProcessGpdsc(ContextItem& context);
   bool ProcessConfigFiles(ContextItem& context);
   bool ProcessComponentFiles(ContextItem& context);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1772,10 +1772,12 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
     if (item.component.empty()) {
       continue;
     }
-    RteComponent* matchedComponent = ProcessComponent(context, item, componentMap);
+    string hint;
+    RteComponent* matchedComponent = ProcessComponent(context, item, componentMap, hint);
     if (!matchedComponent) {
       // No match
-      ProjMgrLogger::Get().Error("no component was found with identifier '" + item.component + "'", context.name);
+      ProjMgrLogger::Get().Error("no component was found with identifier '" + item.component + "'" +
+        (!hint.empty() ? "\n  did you mean '" + hint + "'?" : ""), context.name);
       error = true;
       continue;
     }
@@ -1901,7 +1903,7 @@ bool ProjMgrWorker::ProcessComponents(ContextItem& context) {
   return !error;
 }
 
-RteComponent* ProjMgrWorker::ProcessComponent(ContextItem& context, ComponentItem& item, RteComponentMap& componentMap)
+RteComponent* ProjMgrWorker::ProcessComponent(ContextItem& context, ComponentItem& item, RteComponentMap& componentMap, string& hint)
 {
   if (!item.condition.empty()) {
     RteComponentInstance ci(nullptr);
@@ -1987,6 +1989,9 @@ RteComponent* ProjMgrWorker::ProcessComponent(ContextItem& context, ComponentIte
       }
     }
     // No match
+    if (filteredComponents.size() == 1) {
+      hint = filteredComponents.cbegin()->second->GetPartialComponentID(true);
+    }
     return nullptr;
   } else {
     // One or multiple matches

--- a/tools/projmgr/test/data/TestProject/test_component_csub.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_csub.cproject.yml
@@ -6,3 +6,4 @@ project:
   components:
     - component: Board:Test:Rev1
     - component: Board:Test
+    - component: Device:Startup

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -469,7 +469,9 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessComponents_Csub) {
   EXPECT_FALSE(ProcessComponents(context));
   EXPECT_TRUE(context.components.find("ARM::Board:Test:Rev1@1.1.1") != context.components.end());
   EXPECT_EQ("no component was found with identifier 'Board:Test'", ProjMgrLogger::Get().GetErrors()["test_component_csub"][0]);
-}
+  EXPECT_EQ("no component was found with identifier 'Device:Startup'\n  did you mean 'Device:Startup&RteTest Startup'?",
+    ProjMgrLogger::Get().GetErrors()["test_component_csub"][1]);
+ }
 
 TEST_F(ProjMgrWorkerUnitTests, ProcessComponentsApi) {
   set<string> expectedComponents = {


### PR DESCRIPTION
Mitigate potential disruption due to stricter component resolution introduced in https://github.com/Open-CMSIS-Pack/devtools/pull/1861 addressing https://github.com/Open-CMSIS-Pack/devtools/issues/1650.
Extend missing component error message with a hint when a single match is found but it is not automatically resolved.
For example for a partial identifier `Device:Startup` aiming a component without default variant:
```
error csolution: no component was found with identifier 'Device:Startup'
  did you mean 'Device:Startup&C Startup'?
```