### PR TITLE
[projmgr] Improve regions file existence check

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -901,7 +901,7 @@ protected:
   bool ProvidedConnectionsMatch(ConnectionsCollection collection, ConnectionsList connections);
   StrSet GetValidSets(ContextItem& context, const std::string& clayer);
   void SetDefaultLinkerScript(ContextItem& context);
-  bool CheckAndGenerateRegionsHeader(ContextItem& context);
+  void CheckAndGenerateRegionsHeader(ContextItem& context);
   bool GenerateRegionsHeader(ContextItem& context, std::string& generatedRegionsFile);
   void ExpandAccessSequence(const ContextItem& context, const ContextItem& refContext, const std::string& sequence, const std::string& outdir, std::string& item, bool withHeadingDot);
   void ExpandPackDir(ContextItem& context, const std::string& pack, std::string& item);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -2034,7 +2034,7 @@ bool ProjMgrWorker::AddRequiredComponents(ContextItem& context) {
   return true;
 }
 
-bool ProjMgrWorker::CheckAndGenerateRegionsHeader(ContextItem& context) {
+void ProjMgrWorker::CheckAndGenerateRegionsHeader(ContextItem& context) {
   const string regionsHeader = RteFsUtils::MakePathCanonical(fs::path(context.directories.cprj).append(context.linker.regions).generic_string());
   if (!RteFsUtils::Exists(regionsHeader)) {
     string generatedRegionsFile;
@@ -2043,10 +2043,8 @@ bool ProjMgrWorker::CheckAndGenerateRegionsHeader(ContextItem& context) {
     }
   }
   if (!RteFsUtils::Exists(regionsHeader)) {
-    ProjMgrLogger::Get().Error("specified regions header was not found", context.name, regionsHeader);
-    return false;
+    m_missingFiles.insert({ regionsHeader, FileNode() });
   }
-  return true;
 }
 
 string ProjMgrWorker::GetContextRteFolder(ContextItem& context) {
@@ -3689,7 +3687,7 @@ bool ProjMgrWorker::ProcessContext(ContextItem& context, bool loadGenFiles, bool
   }
   // Check regions header, generate it if needed
   if (!context.linker.regions.empty()) {
-    ret &= CheckAndGenerateRegionsHeader(context);
+    CheckAndGenerateRegionsHeader(context);
   }
   ret &= ProcessConfigFiles(context);
   ret &= ProcessComponentFiles(context);

--- a/tools/projmgr/test/data/TestSolution/missing.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/missing.cproject.yml
@@ -5,3 +5,15 @@ project:
     - group: Sources
       files:
         - file: missing.c
+        - file: generated.c
+
+  linker:
+    - regions: regions.h
+    - regions: generated.h
+
+  executes:
+    - execute: dummy
+      run: dummy
+      output:
+        - $ProjectDir()$/generated.c
+        - $ProjectDir()$/generated.h

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6486,8 +6486,11 @@ TEST_F(ProjMgrUnitTests, MissingFile) {
   argv[1] = (char*)"convert";
   argv[2] = (char*)csolution.c_str();
   EXPECT_EQ(1, RunProjMgr(3, argv, m_envp));
-  const string expectedOutStr = ".*/missing.cproject.yml:7:11 - error csolution: file '.*/TestSolution/missing.c' was not found";
-  EXPECT_TRUE(regex_search(streamRedirect.GetErrorString(), regex(expectedOutStr)));
+  const auto& errStr = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errStr.find("missing.c' was not found"));
+  EXPECT_NE(string::npos, errStr.find("regions.h' was not found"));
+  EXPECT_EQ(string::npos, errStr.find("generated.h' was not found"));
+  EXPECT_EQ(string::npos, errStr.find("generated.c' was not found"));
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgrSolution_pack_version_not_available) {

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -1520,10 +1520,9 @@ TEST_F(ProjMgrWorkerUnitTests, CheckAndGenerateRegionsHeader) {
   // Generation fails
   context.directories.cprj = testoutput_folder;
   context.linker.regions = "regions_RteTest_ARMCM0.h";
-  EXPECT_FALSE(CheckAndGenerateRegionsHeader(context));
+  CheckAndGenerateRegionsHeader(context);
   expectedErrStr = "\
 warning csolution: regions header file generation failed\n\
-.*/regions_RteTest_ARMCM0.h - error csolution: specified regions header was not found\n\
 ";
   errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(regex_match(errStr, regex(expectedErrStr)));
@@ -1533,20 +1532,17 @@ warning csolution: regions header file generation failed\n\
   context.targetAttributes["Dname"] = "RteTest_ARMCM0";
   EXPECT_TRUE(SetTargetAttributes(context, context.targetAttributes));
   streamRedirect.ClearStringStreams();
-  EXPECT_FALSE(CheckAndGenerateRegionsHeader(context));
+  CheckAndGenerateRegionsHeader(context);
   expectedOutStr = ".*/Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h - info csolution: regions header generated successfully\n";
-  expectedErrStr = ".*/regions_RteTest_ARMCM0.h - error csolution: specified regions header was not found\n";
   outStr = streamRedirect.GetOutString();
-  errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(regex_match(outStr, regex(expectedOutStr)));
-  EXPECT_TRUE(regex_match(errStr, regex(expectedErrStr)));
+  EXPECT_NE(string::npos, m_missingFiles.begin()->first.find(context.linker.regions));
 
   // Region header already exists, does nothing
   streamRedirect.ClearStringStreams();
   context.linker.regions = "./Device/RteTest_ARMCM0/regions_RteTest_ARMCM0.h";
   CheckAndGenerateRegionsHeader(context);
   EXPECT_TRUE(streamRedirect.GetOutString().empty());
-  EXPECT_TRUE(streamRedirect.GetErrorString().empty());
 };
 
 TEST_F(ProjMgrWorkerUnitTests, GetGeneratorDir) {


### PR DESCRIPTION
Apply to regions file the logic already in place for user files: skip throwing an error when the file does not exist if it's expected to be generated by an `execute` node.
Address https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/245 