### PR TITLE
[rtemodel, projmgr] Recreate constructed files unconditionally (#1147)

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -6,7 +6,7 @@
 */
 /******************************************************************************/
 /*
- * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1090,9 +1090,6 @@ void RteProject::UpdateRte() {
 }
 
 void RteProject::GenerateRteHeaders() {
-  if (!ShouldUpdateRte())
-    return;
-
   // generate header files for all targets
   for (auto itt : m_targets) {
     RteTarget* target = itt.second;

--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -6,7 +6,7 @@
 */
 /******************************************************************************/
 /*
- * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1991,12 +1991,11 @@ bool RteTarget::GenerateRteHeaderFile(const string& headerName, const string& co
   }
   // construct head comment
   ostringstream  oss;
+  RteCallback* callback = GetCallback();
+  if (!callback) {
+    return false;
+  }
   if (!bRegionsHeader) {
-    RteCallback* callback = GetCallback();
-    if (!callback) {
-      return false;
-    }
-
     bool foundToolInfo = false;
     auto kernel = callback->GetRteKernel();
     if (kernel) {
@@ -2050,8 +2049,10 @@ bool RteTarget::GenerateRteHeaderFile(const string& headerName, const string& co
   }
 
   // file does not exist or its content is different
-  RteFsUtils::CopyBufferToFile(headerFile, oss.str(), false); // write file
-
+  if (RteFsUtils::CopyBufferToFile(headerFile, oss.str(), false) // write file
+    && !GetProject()->ShouldUpdateRte() && !bRegionsHeader) {
+    callback->OutputMessage("Constructed file " + headerFile + " was recreated");
+  }
   return true;
 }
 // End of RteTarget.cpp

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -782,6 +782,12 @@ public:
   */
   void CollectUnusedPacks();
 
+  /**
+   * @brief check rte errors
+   * @return true if there is no error
+  */
+  bool CheckRteErrors(void);
+
 protected:
   ProjMgrParser* m_parser = nullptr;
   ProjMgrKernel* m_kernel = nullptr;
@@ -824,7 +830,6 @@ protected:
   bool LoadPacks(ContextItem& context);
   bool CheckMissingPackRequirements(const std::string& contextName);
   bool CollectRequiredPdscFiles(ContextItem& context, const std::string& packRoot);
-  bool CheckRteErrors(void);
   bool CheckBoardDeviceInLayer(const ContextItem& context, const ClayerItem& clayer);
   bool CheckCompiler(const std::vector<std::string>& forCompiler, const std::string& selectedCompiler);
   bool CheckType(const TypeFilter& typeFilter, const std::vector<TypePair>& typeVec);

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -655,15 +655,19 @@ bool ProjMgr::Configure() {
 
 bool ProjMgr::UpdateRte() {
   // Update the RTE files
-  if (m_updateRteFiles) {
-    for (auto& contextItem : m_processedContexts) {
-      if (contextItem->rteActiveProject != nullptr) {
+  for (auto& contextItem : m_processedContexts) {
+    if (contextItem->rteActiveProject != nullptr) {
+      if (m_updateRteFiles) {
         contextItem->rteActiveProject->SetAttribute("update-rte-files", "1");
         contextItem->rteActiveProject->UpdateRte();
+      } else {
+        contextItem->rteActiveProject->GenerateRteHeaders();
       }
     }
   }
-  bool result = true;
+
+  bool result = m_worker.CheckRteErrors();
+
   for (auto& contextItem : m_processedContexts) {
     // Check PLM files
     if (!m_worker.CheckConfigPLMFiles(*contextItem)) {

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -200,7 +200,7 @@ TEST_F(ProjMgrGeneratorUnitTests, DryRun) {
   ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, stripAbsoluteFunc);
 
   EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));
-  EXPECT_EQ(false, std::filesystem::exists(rteDir));
+  EXPECT_EQ(false, std::filesystem::exists(rteDir + "/Device"));
   EXPECT_EQ(false, std::filesystem::exists(targetGPDSC));
   EXPECT_EQ(false, std::filesystem::exists(generatorDestination));
 


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1894

From [comment](https://github.com/Open-CMSIS-Pack/devtools/issues/1894#issuecomment-2616013012):
>Without option --update-rte: when constructed files are missing, csolution recreates the files, but issues a warning indicated which file was recreated.
With option --update-rte: the constructed files are updated.