### PR TITLE
Updated googletest version to v1.6.0

### DIFF
--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -196,7 +196,7 @@ jobs:
   create_installer:
     needs: [ setup, build, docs ]
     # Debian package generation in ubuntu 22.04 produces incompatible metadata
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - name: Harden Runner

--- a/external/json-schema-validator.patch
+++ b/external/json-schema-validator.patch
@@ -1,7 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e6aff61..fa90bc0 100644
+index e6aff61..8826dae 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.10)
+ 
+ option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ON)
+ option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ON)
 @@ -132,9 +132,9 @@ set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
  set(INSTALL_CMAKEDIR_ROOT share/cmake)
  
@@ -16,7 +22,7 @@ index e6aff61..fa90bc0 100644
  include(CMakePackageConfigHelpers)
  write_basic_package_version_file(
 diff --git a/src/json-validator.cpp b/src/json-validator.cpp
-index 0beb613..0a9122b 100644
+index 0beb613..4f3213f 100644
 --- a/src/json-validator.cpp
 +++ b/src/json-validator.cpp
 @@ -218,12 +218,16 @@ public:

--- a/external/json.patch
+++ b/external/json.patch
@@ -1,5 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b93c6e47..11448a52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.10)
+ 
+ ##
+ ## PROJECT
 diff --git a/include/nlohmann/detail/exceptions.hpp b/include/nlohmann/detail/exceptions.hpp
-index b4b180496..597f835d8 100644
+index b4b18049..597f835d 100644
 --- a/include/nlohmann/detail/exceptions.hpp
 +++ b/include/nlohmann/detail/exceptions.hpp
 @@ -127,9 +127,8 @@ class parse_error : public exception
@@ -41,7 +51,7 @@ index b4b180496..597f835d8 100644
  
  /// @brief exception indicating errors with iterators
 diff --git a/single_include/nlohmann/json.hpp b/single_include/nlohmann/json.hpp
-index 92308c557..479aad4a5 100644
+index 92308c55..479aad4a 100644
 --- a/single_include/nlohmann/json.hpp
 +++ b/single_include/nlohmann/json.hpp
 @@ -2912,9 +2912,8 @@ class parse_error : public exception

--- a/external/yaml-cpp.patch
+++ b/external/yaml-cpp.patch
@@ -1,3 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46dc180..b746ac1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # 3.5 is actually available almost everywhere, but this a good minimum
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # enable MSVC_RUNTIME_LIBRARY target property
+ # see https://cmake.org/cmake/help/latest/policy/CMP0091.html
 diff --git a/include/yaml-cpp/emittermanip.h b/include/yaml-cpp/emittermanip.h
 index 976d149..ba73a48 100644
 --- a/include/yaml-cpp/emittermanip.h
@@ -66,7 +77,7 @@ index 07cf81a..ed7d9cd 100644
    void convert_sequence_to_map(const shared_memory_holder& pMemory);
  
 diff --git a/src/emitter.cpp b/src/emitter.cpp
-index 4d48307..d4485be 100644
+index 4d48307..a188cca 100644
 --- a/src/emitter.cpp
 +++ b/src/emitter.cpp
 @@ -721,7 +721,7 @@ Emitter& Emitter::Write(const std::string& str) {
@@ -167,6 +178,3 @@ index 9d0c790..37355aa 100644
 +
  }  // namespace
  }  // namespace YAML
--- 
-2.34.1.windows.1
-

--- a/external/yaml-cpp.patch
+++ b/external/yaml-cpp.patch
@@ -5,7 +5,7 @@ index 46dc180..b746ac1 100644
 @@ -1,5 +1,5 @@
  # 3.5 is actually available almost everywhere, but this a good minimum
 -cmake_minimum_required(VERSION 3.4)
-+cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.4...3.14)
  
  # enable MSVC_RUNTIME_LIBRARY target property
  # see https://cmake.org/cmake/help/latest/policy/CMP0091.html

--- a/external/yaml-cpp.patch
+++ b/external/yaml-cpp.patch
@@ -5,7 +5,7 @@ index 46dc180..b746ac1 100644
 @@ -1,5 +1,5 @@
  # 3.5 is actually available almost everywhere, but this a good minimum
 -cmake_minimum_required(VERSION 3.4)
-+cmake_minimum_required(VERSION 3.4...3.14)
++cmake_minimum_required(VERSION 3.10)
  
  # enable MSVC_RUNTIME_LIBRARY target property
  # see https://cmake.org/cmake/help/latest/policy/CMP0091.html

--- a/libs/rtemodel/test/src/RteExampleTest.cpp
+++ b/libs/rtemodel/test/src/RteExampleTest.cpp
@@ -86,6 +86,7 @@ TEST_F(RteExampleTest, TestExamplePaths) {
 
   RteExample *preIncludeExample = nullptr;
   RteExample *preIncludeEnvFolderExample = nullptr;
+
   for (auto exampleIt = exampleList.begin(); exampleIt != exampleList.end(); exampleIt++) {
     RteExample *example = dynamic_cast<RteExample*>(*exampleIt);
     if (example == nullptr) {


### PR DESCRIPTION
Failure occurred due to the deprecation of support for CMake versions earlier than 3.10. Since the Ubuntu GitHub runner uses CMake 3.31.6, which no longer supports versions prior to 3.10 in many cases, our pinned version of GoogleTest needed an update. Additionally, other dependencies, such as JSON and JSON Schema Validators, were updated to the minimum compatible versions, with 3.5 being the lowest supported.

https://cmake.org/cmake/help/latest/release/3.31.html#deprecated-and-removed-features

The change includes:
- Pin googletest to latest v1.16.0
- yaml-cpp patch update `cmake_minimum_required(VERSION 3.10)`
- json patch update `cmake_minimum_required(VERSION 3.10)`
- json-schema-validator patch update `cmake_minimum_required(VERSION 3.10)`
- Updated ubuntu-20.04 to ubuntu-22.04. **GitHub Actions is deprecating the ubuntu-20.04 runner**.