### PR TITLE
[cbuild-run] `debug-topology` refinements

### DIFF
--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -135,8 +135,10 @@
         <compile header="Device/ARM/ARMCM0/Include/ARMCM0.h" define="ARMCM0"/>
         <memory name="FLASH_DUAL" access="rx" start="0x00000000" size="0x00080000" startup="1" default="1" Pname="cm0_core0"/>
         <memory name="SRAM_DUAL"  access="rwx" start="0x80000000" size="0x00020000" uninit="1" default="1" Pname="cm0_core1"/>
-        <debug defaultResetSequence="ResetSystem0" Pname="cm0_core0"/> 
-        <debug defaultResetSequence="ResetSystem1" Pname="cm0_core1"/> 
+        <debugport __dp="0"/>
+        <debugport __dp="1"/>
+        <debug defaultResetSequence="ResetSystem0" Pname="cm0_core0" __dp="0" __ap="0"/>
+        <debug defaultResetSequence="ResetSystem1" Pname="cm0_core1" __dp="1" __ap="0"/>
         <algorithm name="Device/ARM/Flash/CortexM4Dual.FLM" start="0x000A0000" size="0x00020000" RAMstart="0x000C0000" RAMsize="0x00040000" Pname="cm0_core1"/>
       </device>
       <device Dname="RteTest_ARMCM0_Single">

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2231,8 +2231,7 @@
         "apid":             { "type": "number", "description": "Access port ID to use for this processor." },
         "reset-sequence":   { "type": "string", "description": "Name of debug sequence for reset operation" }
       },
-      "additionalProperties": false,
-      "required": ["pname"]
+      "additionalProperties": false
     },
     "DebugPunitsType": {
       "description": "Specifies processor units in a symmetric multi-processor core (MPCore).",

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
@@ -9,9 +9,11 @@ cbuild-run:
     - file: out/core0/TestHW3/core0.axf
       info: generate by core0+TestHW3
       type: elf
+      pname: cm0_core0
     - file: out/core1/TestHW3/core1.axf
       info: generate by core1+TestHW3
       type: elf
+      pname: cm0_core1
     - file: ../data/TestRunDebug/customImage.bin
       info: load image info
       type: bin
@@ -126,8 +128,19 @@ cbuild-run:
       ram-start: 0x20000000
       ram-size: 0x00020000
   debug-topology:
+    debugports:
+      - dpid: 0
+        accessports:
+          - apid: 0
+            index: 0
+      - dpid: 1
+        accessports:
+          - apid: 1
+            index: 0
     processors:
       - pname: cm0_core0
+        apid: 0
         reset-sequence: ResetSystem0
       - pname: cm0_core1
+        apid: 1
         reset-sequence: ResetSystem1


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/2041:
- Emit static information for all processors regardless of context selection
- When relevant add `pname` for each `output`

Address https://github.com/Open-CMSIS-Pack/devtools/issues/2042:
- Populate `accessports` considering PDSC `<debug>` info