### PR TITLE
remove crt0 library from linker command

### DIFF
--- a/tools/projmgr/templates/cdefault.yml
+++ b/tools/projmgr/templates/cdefault.yml
@@ -40,7 +40,6 @@ default:
       C:
         - -std=gnu11
       Link:
-        - -lcrt0
         - -Wl,-print-memory-usage
         - -Wl,--gc-sections
 


### PR DESCRIPTION
fixing #338
C runtime library linking changed in version LLVM/CLANG 20.1.0 We are accepting that projects using previous version will need to add `-lcrt0` manually to the project when relying on `cdefault.yml` from `$CMSIS_TOOLBOX/etc`