### PR TITLE
[cbuild-run] Rework gdbserver ports and processors order

### DIFF
--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
@@ -52,9 +52,9 @@ cbuild-run:
     start-pname: cm0_core1
     gdbserver:
       - port: 3333
-        pname: cm0_core0
-      - port: 3334
         pname: cm0_core1
+      - port: 3334
+        pname: cm0_core0
   debug-vars:
     vars: |
       __var DbgMCU_CR      = 0x00000007;   // DBGMCU_CR: DBG_SLEEP, DBG_STOP, DBG_STANDBY


### PR DESCRIPTION
Changes after feedback from @RobertRostohar:
- start listing `gdbserver` `port` from the `start-pname`
- set `debug-topology` `processors` according to `apid` order