### PR TITLE
[projmgr] Update test case `OutputDirsAbsolutePath`

### DIFF
--- a/tools/projmgr/test/data/TestSolution/outdirs-absolute.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/outdirs-absolute.csolution.yml
@@ -17,6 +17,6 @@ solution:
     - project: ./TestProject1/test1.cproject.yml
 
   output-dirs:
-    cprjdir: C:/$Compiler$
+    cprjdir: Z:/$Compiler$
     intdir: /$Compiler$
     tmpdir: /root

--- a/tools/projmgr/test/data/TestSolution/outdirs-absolute.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/outdirs-absolute.csolution.yml
@@ -17,6 +17,6 @@ solution:
     - project: ./TestProject1/test1.cproject.yml
 
   output-dirs:
-    cprjdir: Z:/$Compiler$
+    cprjdir: \\non_existing_cmsis/$Compiler$
     intdir: /$Compiler$
     tmpdir: /root

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4126,7 +4126,7 @@ TEST_F(ProjMgrUnitTests, OutputDirsAbsolutePath) {
   argv[2] = (char*)"--solution";
   argv[3] = (char*)csolution.c_str();
   argv[4] = (char*)"--cbuildgen";
-  EXPECT_EQ(CrossPlatformUtils::GetHostType() == "win" ? 1 : 0, RunProjMgr(5, argv, m_envp));
+  EXPECT_EQ(1, RunProjMgr(5, argv, m_envp));
 
   auto errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(regex_search(errStr, regex("warning csolution: absolute path .* is not portable, use relative path instead")));


### PR DESCRIPTION
The test case `OutputDirsAbsolutePath` is intended to catch a non-portable absolute path on Windows.
GH Runners for win-amd64 started to use the `C:` drive letter instead of `D:`, hiding the portability issue under test and causing the [test failure](https://github.com/Open-CMSIS-Pack/devtools/actions/runs/15009141329/job/42192679789).
This PR sets an UNC path `\\non_existing_cmsis` in the non-portable absolute path under test, restoring the expected test behavior.