### PR TITLE
Do not validate for http:// URLs in elements and attributes that are …

### DIFF
--- a/tools/packchk/src/CheckFiles.cpp
+++ b/tools/packchk/src/CheckFiles.cpp
@@ -40,6 +40,10 @@ CheckFilesVisitor::~CheckFilesVisitor()
 */
 VISIT_RESULT CheckFilesVisitor::Visit(RteItem* item)
 {
+  const string& tag = item->GetTag();
+  if(tag == "environment") {
+    return VISIT_RESULT::SKIP_CHILDREN;
+  }
   m_checkFiles.CheckFile(item);
   m_checkFiles.CheckUrls(item);
   m_checkFiles.CheckDeprecated(item);

--- a/tools/packchk/test/data/TestUrlHttps/TestVendor.TestUrlHttps.pdsc
+++ b/tools/packchk/test/data/TestUrlHttps/TestVendor.TestUrlHttps.pdsc
@@ -47,6 +47,13 @@
       <subFamily DsubFamily="MyDevice">
         <device Dname="MyDeviceM0">
           <processor Dfpu="0" Dmpu="0" Dendian="Little-endian" Dclock="24000000"/>
+          <environment name="test_env">
+            <e:extension xmlns:e="http://example.com"
+                            schemaVersion="1.0"
+                            xsi:schemaLocation="http://example.com example.xsd">
+               <e:element value="test"/>
+            </e:extension>
+         </environment>
         </device>
       </subFamily>
     </family>

--- a/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
+++ b/tools/packchk/test/integtests/src/PackChkIntegTests.cpp
@@ -806,7 +806,7 @@ TEST_F(PackChkIntegTests, CheckUrlForHttp) {
   }
 
   if (M300_foundCnt != 8) {
-    FAIL() << "error: missing message M300";
+    FAIL() << "error: missing number of M300, found " << M300_foundCnt;
   }
 }
 


### PR DESCRIPTION
…definitely part of a different namespace

Since the XML parser does not seem to have much support at all for namespaces, this fix is very ... raw in that it only looks for a namespace delimiter `:` and if we find that in an element, mark it as ok. If we find it in an attribute, do not check it.

This fixes #2093