### PR TITLE
Migrate workflows to windows-2022 due to upcoming deprecation of windows-2019

### DIFF
--- a/.github/matrix_includes_buildmgr.json
+++ b/.github/matrix_includes_buildmgr.json
@@ -40,7 +40,7 @@
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "binary_extension":".exe-amd64",
@@ -50,7 +50,7 @@
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "binary_extension":".exe-arm64",

--- a/.github/matrix_includes_packchk.json
+++ b/.github/matrix_includes_packchk.json
@@ -28,14 +28,14 @@
         "binary": "packchk"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "runOn": "always",
         "binary": "packchk.exe"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "runOn": "always",

--- a/.github/matrix_includes_packgen.json
+++ b/.github/matrix_includes_packgen.json
@@ -29,14 +29,14 @@
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "binary": "packgen.exe",
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "binary": "packgen.exe",

--- a/.github/matrix_includes_projmgr.json
+++ b/.github/matrix_includes_projmgr.json
@@ -36,7 +36,7 @@
         "goswig": false
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "binary": "csolution.exe",
@@ -45,7 +45,7 @@
         "goswig": false
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "binary": "csolution.exe",

--- a/.github/matrix_includes_svdconv.json
+++ b/.github/matrix_includes_svdconv.json
@@ -28,14 +28,14 @@
         "binary": "svdconv"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "runOn": "always",
         "binary": "svdconv.exe"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "runOn": "always",

--- a/.github/matrix_includes_test_libs.json
+++ b/.github/matrix_includes_test_libs.json
@@ -24,13 +24,13 @@
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "amd64",
         "runOn": "always"
     },
     {
-        "runs_on":"windows-2019",
+        "runs_on":"windows-2022",
         "target":"windows",
         "arch": "arm64",
         "runOn": "always"


### PR DESCRIPTION
* Migrate workflows to windows-2022 due to upcoming deprecation of windows-2019
