### PR TITLE
[projmgr] Add `list templates` command

### DIFF
--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -567,7 +567,7 @@
     <template name="Board2" type="Board" file="Templates/board2.csolution.yml" condition="BoardTest2">
       <description>"Test board Template two"</description>
     </template>
-    <template name="Board3" type="Board" file="Templates/board3.csolution.yml" condition="BoardTest3">
+    <template name="Board3" type="Board" path="Templates" file="board3.csolution.yml" copy-to="Template3" condition="BoardTest3">
       <description>"Test board Template three"</description>
     </template>
     <clayer name="TestVariant" type="TestVariant" file="Layers/testvariant.clayer.yml">

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -193,6 +193,7 @@ protected:
   bool RunListConfigs();
   bool RunListDependencies();
   bool RunListExamples();
+  bool RunListTemplates();
   bool RunListContexts();
   bool RunListTargetSets();
   bool RunListGenerators();

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -316,6 +316,24 @@ struct ExampleItem {
 };
 
 /**
+ * @brief template item containing
+ *        name of example
+ *        description
+ *        path to the directory that contains the template
+ *        path to the *.csolution.yml file
+ *        path to copy the template into
+ *        pack identifier
+*/
+struct TemplateItem {
+  std::string name;
+  std::string description;
+  std::string path;
+  std::string file;
+  std::string copyTo;
+  std::string pack;
+};
+
+/**
  * @brief debugger type
  *        name of debug configuration
  *        brief description
@@ -588,6 +606,14 @@ public:
    * @return true if executed successfully
   */
   bool ListExamples(std::vector<std::string>& examples, const std::string& filter = RteUtils::EMPTY_STRING);
+
+  /**
+   * @brief list available csolution templates
+   * @param reference to list of csolution templates
+   * @param filter words to filter results
+   * @return true if executed successfully
+  */
+  bool ListTemplates(std::vector<std::string>& templates, const std::string& filter = RteUtils::EMPTY_STRING);
 
   /**
    * @brief list contexts
@@ -1146,6 +1172,7 @@ protected:
   std::vector<ExampleItem> CollectExamples(ContextItem& context);
   std::vector<RteBoard*> GetCompatibleBoards(ContextItem& context);
   bool IsBoardListCompatible(const std::vector<RteBoard*> compatibleBoards, const Collection<RteItem*>& boards);
+  std::vector<TemplateItem> CollectTemplates(ContextItem& context);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -31,6 +31,7 @@ Commands:\n\
   list devices                  Print list of available device names\n\
   list environment              Print list of environment configurations\n\
   list examples                 Print list of examples\n\
+  list templates                Print list of templates\n\
   list generators               Print list of code generators of a given context\n\
   list layers                   Print list of available, referenced and compatible layers\n\
   list packs                    Print list of used packs from the pack repository\n\
@@ -183,6 +184,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
     {"list components",   { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list dependencies", { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list examples",     { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list templates",    { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list contexts",     { false, {debug, filter, quiet, schemaCheck, verbose, ymlOrder}}},
     {"list target-sets",  { false, {debug, filter, quiet, schemaCheck, verbose}}},
     {"list generators",   { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose}}},
@@ -374,6 +376,10 @@ int ProjMgr::ProcessCommands() {
       }
     } else if (m_args == "examples") {
       if (!RunListExamples()) {
+        return ErrorCode::ERROR;
+      }
+    } else if (m_args == "templates") {
+      if (!RunListTemplates()) {
         return ErrorCode::ERROR;
       }
     } else if (m_args == "contexts") {
@@ -934,6 +940,31 @@ bool ProjMgr::RunListExamples(void) {
 
   for (const auto& example : examples) {
     ProjMgrLogger::out() << example << endl;
+  }
+  return true;
+}
+
+bool ProjMgr::RunListTemplates(void) {
+  if (!m_csolutionFile.empty()) {
+    // Parse all input files and create contexts
+    if (!PopulateContexts()) {
+      return false;
+    }
+  }
+
+  // Parse context selection
+  if (!ParseAndValidateContexts()) {
+    return false;
+  }
+
+  vector<string> csolutionTemplates;
+  if (!m_worker.ListTemplates(csolutionTemplates, m_filter)) {
+    ProjMgrLogger::Get().Error("processing templates list failed");
+    return false;
+  }
+
+  for (const auto& csolutionTemplate : csolutionTemplates) {
+    ProjMgrLogger::out() << csolutionTemplate << endl;
   }
   return true;
 }

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6964,6 +6964,51 @@ PreIncludeEnvFolder@1.0.0\n\
   EXPECT_TRUE(outStr.empty());
 }
 
+
+TEST_F(ProjMgrUnitTests, ListTemplates) {
+  char* argv[7];
+  StdStreamRedirect streamRedirect;
+
+  // list all templates
+  argv[1] = (char*)"list";
+  argv[2] = (char*)"templates";
+  EXPECT_EQ(0, RunProjMgr(3, argv, 0));
+  auto outStr = streamRedirect.GetOutString();
+  EXPECT_STREQ(outStr.c_str(), "\
+Board1Template (ARM::RteTest_DFP@0.2.0)\n\
+Board2 (ARM::RteTest_DFP@0.2.0)\n\
+Board3 (ARM::RteTest_DFP@0.2.0)\n\
+");
+
+  // test filter
+  argv[3] = (char*)"--filter";
+  argv[4] = (char*)"Board1";
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(5, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_STREQ(outStr.c_str(), "\
+Board1Template (ARM::RteTest_DFP@0.2.0)\n\
+");
+
+  // list board's compatible template
+  const string& csolution = testinput_folder + "/Examples/solution.csolution.yml";
+  const string expected = 
+  argv[3] = (char*)csolution.c_str();
+  argv[4] = (char*)"--active";
+  argv[5] = (char*)"TestBoard";
+  argv[6] = (char*)"--verbose";
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+Board3 \\(ARM::RteTest_DFP@0.2.0\\)\n\
+  description: \"Test board Template three\"\n\
+  path: .*/ARM/RteTest_DFP/0.2.0/Templates\n\
+  file: .*/ARM/RteTest_DFP/0.2.0/Templates/board3.csolution.yml\n\
+  copy-to: Template3\n\
+")));
+}
+
 TEST_F(ProjMgrUnitTests, ConvertActiveTargetSet) {
   char* argv[6];
   StdStreamRedirect streamRedirect;


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/2151
In the typical use case the results are filtered according to the [template's conditions](https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_csolution_pg.html#element_cs_template) evaluated for the selected target type:
```
$ csolution list templates <csolution.yml> -a <active target set>
<template name> (<pack>)
```
When the *.csolution.yml is not specified it lists all templates from installed packs.
The `--filter` option checks the presence of a filter string in the`<template name>`.

When the `--verbose` flag is used further information is printed:
```
<template name> (<pack>)
  description: <template description>
  path: <path to template's folder>
  file: <path to *.csolution.yml file>
  copy-to: <destination folder> (optional)
```