### PR TITLE
[projmgr] Update `list examples` command

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -301,6 +301,7 @@ struct EnvironmentItem {
  *        list of components
  *        list of categories
  *        list of keywords
+ *        pack identifier
 */
 struct ExampleItem {
   std::string name;
@@ -313,6 +314,7 @@ struct ExampleItem {
   std::vector<std::string> components;
   std::vector<std::string> categories;
   std::vector<std::string> keywords;
+  std::string pack;
 };
 
 /**
@@ -1171,7 +1173,7 @@ protected:
   bool ParseTargetSetContextSelection();
   std::vector<ExampleItem> CollectExamples(ContextItem& context);
   std::vector<RteBoard*> GetCompatibleBoards(ContextItem& context);
-  bool IsBoardListCompatible(const std::vector<RteBoard*> compatibleBoards, const Collection<RteItem*>& boards);
+  bool IsBoardListCompatible(const ContextItem& context, const std::vector<RteBoard*> compatibleBoards, const Collection<RteItem*>& boards);
   std::vector<TemplateItem> CollectTemplates(ContextItem& context);
 };
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6900,32 +6900,6 @@ TEST_F(ProjMgrUnitTests, ListTargetSetsImageOnly) {
 }
 
 TEST_F(ProjMgrUnitTests, ListExamples) {
-  const string expected = "\
-PreInclude@1.0.0\n\
-  description: PreInclude Test Application\n\
-  doc: .*/ARM/RteTest/0.1.0/Examples/PreInclude/Abstract.txt\n\
-  environment: uv\n\
-    load: .*/ARM/RteTest/0.1.0/Examples/PreInclude/PreInclude.uvprojx\n\
-    folder: .*/ARM/RteTest/0.1.0/Examples/PreInclude\n\
-  boards:\n\
-    Keil::RteTest Dummy board\n\
-  components:\n\
-    RteTest:GlobalLevel\n\
-PreIncludeEnvFolder@1.0.0\n\
-  description: PreInclude Test Application with different folder description\n\
-  doc: .*/ARM/RteTest/0.1.0/Examples/PreInclude/Abstract.txt\n\
-  environment: uv\n\
-    load: .*/ARM/RteTest/0.1.0/Examples/PreInclude.uvprojx\n\
-    folder: .*/ARM/RteTest/0.1.0/Examples/PreInclude\n\
-  boards:\n\
-    Keil::RteTest Dummy board\n\
-  components:\n\
-    RteTest:GlobalLevel\n\
-  categories:\n\
-    Example Project\n\
-  keywords:\n\
-    Getting Started\n\
-";
   char* argv[8];
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/Examples/solution.csolution.yml";
@@ -6938,23 +6912,54 @@ PreIncludeEnvFolder@1.0.0\n\
   argv[5] = (char*)"TestBoard";
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
   auto outStr = streamRedirect.GetOutString();
-  EXPECT_TRUE(regex_search(outStr, regex(expected)));
+  EXPECT_STREQ(outStr.c_str(), "\
+PreInclude@1.0.0 (ARM::RteTest@0.1.0)\n\
+PreIncludeEnvFolder@1.0.0 (ARM::RteTest@0.1.0)\n\
+");
+
+  // test with verbose flag
+  streamRedirect.ClearStringStreams();
+  argv[6] = (char*)"--verbose";
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+PreInclude@1.0.0 \\(ARM::RteTest@0.1.0\\)\n\
+  description: PreInclude Test Application\n\
+  doc: .*/ARM/RteTest/0.1.0/Examples/PreInclude/Abstract.txt\n\
+  environment: uv\n\
+    load: .*/ARM/RteTest/0.1.0/Examples/PreInclude/PreInclude.uvprojx\n\
+    folder: .*/ARM/RteTest/0.1.0/Examples/PreInclude\n\
+  boards:\n\
+    Keil::RteTest Dummy board\n\
+PreIncludeEnvFolder@1.0.0 \\(ARM::RteTest@0.1.0\\)\n\
+  description: PreInclude Test Application with different folder description\n\
+  doc: .*/ARM/RteTest/0.1.0/Examples/PreInclude/Abstract.txt\n\
+  environment: uv\n\
+    load: .*/ARM/RteTest/0.1.0/Examples/PreInclude.uvprojx\n\
+    folder: .*/ARM/RteTest/0.1.0/Examples/PreInclude\n\
+  boards:\n\
+    Keil::RteTest Dummy board\n\
+")));
 
   // test with compatible device
   streamRedirect.ClearStringStreams();
   argv[5] = (char*)"CM0_Dual";
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));
   outStr = streamRedirect.GetOutString();
-  EXPECT_TRUE(regex_search(outStr, regex(expected)));
+  EXPECT_STREQ(outStr.c_str(), "\
+PreInclude@1.0.0 (ARM::RteTest@0.1.0)\n\
+PreIncludeEnvFolder@1.0.0 (ARM::RteTest@0.1.0)\n\
+");
 
   // test with filter option
   streamRedirect.ClearStringStreams();
   argv[6] = (char*)"--filter";
-  argv[7] = (char*)"Getting Started";
+  argv[7] = (char*)"EnvFolder";
   EXPECT_EQ(0, RunProjMgr(8, argv, 0));
   outStr = streamRedirect.GetOutString();
-  EXPECT_TRUE(outStr.find("PreIncludeEnvFolder@1.0.0") != string::npos);
-  EXPECT_TRUE(outStr.find("PreInclude@1.0.0") == string::npos);
+  EXPECT_STREQ(outStr.c_str(), "\
+PreIncludeEnvFolder@1.0.0 (ARM::RteTest@0.1.0)\n\
+");
 
   // test with non-compatible device
   streamRedirect.ClearStringStreams();


### PR DESCRIPTION
Address feedback https://github.com/Open-CMSIS-Pack/devtools/issues/2140#issuecomment-3089690055
- do not print `components`, `categories`, `keywords`
- search for `--filter` only among example names. Do not add further command line options to avoid asymmetry with other `list` commands. In RPC methods `board`, `device` and `environment` will be input parameters and the results will be filtered accordingly.
- handle `--verbose` flag
- print "Reference Application:" before such examples (hardware agnostic examples)
- filter out "Reference Applications" for boards that do not have `clayer` with type `Board`