### PR TITLE
[csolution] Handle cmd line option `--active=` (empty argument)

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -165,7 +165,7 @@ protected:
   std::string m_clayerSearchPath;
   std::string m_export;
   std::string m_selectedToolchain;
-  std::string m_activeTargetSet;
+  std::optional<std::string> m_activeTargetSet;
   bool m_checkSchema;
   bool m_missingPacks;
   bool m_updateRteFiles;

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -549,7 +549,7 @@ bool ProjMgr::PopulateContexts(void) {
   }
 
   // Populate active target-set
-  if (!m_activeTargetSet.empty() && !m_worker.PopulateActiveTargetSet(m_activeTargetSet)) {
+  if (m_activeTargetSet.has_value() && !m_worker.PopulateActiveTargetSet(m_activeTargetSet.value())) {
     return false;
   }
 
@@ -581,7 +581,7 @@ bool ProjMgr::GenerateYMLConfigurationFiles(bool previousResult) {
 
   // Generate cbuild-run file
   if (previousResult && !m_processedContexts.empty() &&
-    (m_contextSet || !m_activeTargetSet.empty())) {
+    (m_contextSet || m_activeTargetSet.has_value())) {
     const auto& debugAdapters = GetDebugAdaptersFile();
     if (!debugAdapters.empty()) {
       if (!m_parser.ParseDebugAdapters(debugAdapters, m_checkSchema)) {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -5733,10 +5733,20 @@ bool ProjMgrWorker::ParseTargetSetContextSelection() {
 }
 
 bool ProjMgrWorker::PopulateActiveTargetSet(const string& activeTargetSet) {
+  const auto& targetTypes = m_parser->GetCsolution().targetTypes;
+  if (activeTargetSet.empty()) {
+    // cmd line option --active="" : take first target-type and first target-set
+    // target-type is mandatory, target-set is optional
+    m_activeTargetType = targetTypes.front().first;
+    if (!targetTypes.front().second.targetSet.empty()) {
+      m_activeTargetSet = targetTypes.front().second.targetSet.front();
+    }
+    return true;
+  }
   const auto& targetType = RteUtils::GetPrefix(activeTargetSet, '@');
   const auto& targetSet = RteUtils::GetSuffix(activeTargetSet, '@');
   bool targetSetFound = false;
-  for (const auto& [name, type] : m_parser->GetCsolution().targetTypes) {
+  for (const auto& [name, type] : targetTypes) {
     if (name == targetType) {
       for (const auto& item : type.targetSet) {
         if (item.set == targetSet) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -7032,6 +7032,13 @@ TEST_F(ProjMgrUnitTests, ConvertActiveTargetSet) {
   EXPECT_EQ("<default>", cbuildRun2["cbuild-run"]["target-set"].as<string>());
 
   streamRedirect.ClearStringStreams();
+  argv[4] = (char*)"";
+  EXPECT_EQ(0, RunProjMgr(5, argv, 0));
+  const YAML::Node& cbuildRun3 = YAML::LoadFile(testinput_folder + "/TestTargetSet/out/solution+Type1.cbuild-run.yml");
+  EXPECT_EQ("Type1", cbuildRun3["cbuild-run"]["target-type"].as<string>());
+  EXPECT_EQ("<default>", cbuildRun3["cbuild-run"]["target-set"].as<string>());
+
+  streamRedirect.ClearStringStreams();
   argv[4] = (char*)"Type1@Unknown";
   EXPECT_EQ(1, RunProjMgr(5, argv, 0));
   auto errStr = streamRedirect.GetErrorString();


### PR DESCRIPTION
Accept command line option `--active` with empty argument, implicitly taking the first `target-type` as the active one.
Being `--active` a "string option" rather than a "boolean flag", to be correctly parsed the "empty argument" needs to be in one of the formats:
```shell
--active=
--active ""
-a ""
```
Note `-a=` is not supported. In such case `=` is literally the argument.

Align with https://github.com/Open-CMSIS-Pack/cbuild/pull/443