### PR TITLE
[projmgr] Add `ConvertSolution`, update `LoadSolution` and `GetVersion` RPC methods

### DIFF
--- a/tools/projmgr/CMakeLists.txt
+++ b/tools/projmgr/CMakeLists.txt
@@ -17,8 +17,8 @@ include(FetchContent)
 FetchContent_Declare(
   rpc-interface
   DOWNLOAD_EXTRACT_TIMESTAMP ON
-  URL https://github.com/brondani/csolution-rpc/releases/download/v0.0.4/csolution-rpc.zip
-  URL_HASH SHA256=643ab30d25f47b55735bc6fecd3622ad1c7619d8fac901e2b19cd594a01df8b2
+  URL https://github.com/Open-CMSIS-Pack/csolution-rpc/releases/download/v0.0.4/csolution-rpc.zip
+  URL_HASH SHA256=ca9bfdacb35b44b6cadf29d87123adbfc1a5e944af7f2aefda0ccf7fd4bd216f
 )
 FetchContent_MakeAvailable(rpc-interface)
 

--- a/tools/projmgr/CMakeLists.txt
+++ b/tools/projmgr/CMakeLists.txt
@@ -17,8 +17,8 @@ include(FetchContent)
 FetchContent_Declare(
   rpc-interface
   DOWNLOAD_EXTRACT_TIMESTAMP ON
-  URL https://github.com/Open-CMSIS-Pack/csolution-rpc/releases/download/v0.0.3/csolution-rpc.zip
-  URL_HASH SHA256=edc762373b3b7dad5b966ecb271f03866b12841675e0967a809c10c9883f29f4
+  URL https://github.com/brondani/csolution-rpc/releases/download/v0.0.4/csolution-rpc.zip
+  URL_HASH SHA256=643ab30d25f47b55735bc6fecd3622ad1c7619d8fac901e2b19cd594a01df8b2
 )
 FetchContent_MakeAvailable(rpc-interface)
 

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -70,6 +70,16 @@ public:
   */
   bool LoadSolution(const std::string& csolution, const std::string& activeTargetSet);
 
+  /**
+   * @brief convert solution and generate yml files
+   * @param path to <solution>.csolution.yml file
+   * @param active target set in the format <target-type>[@<set>]
+   * @param update-rte: create/update configuration files
+   * @return processing status
+  */
+  bool RunConvert(const std::string&csolution = RteUtils::EMPTY_STRING,
+    const std::string& activeTargetSet = RteUtils::EMPTY_STRING, const bool& updateRte = false);
+
 protected:
   /**
    * @brief parse command line options
@@ -185,7 +195,6 @@ protected:
   std::set<std::string> m_failedContext;
 
   bool RunConfigure();
-  bool RunConvert();
   bool RunCodeGenerator();
   bool RunListPacks();
   bool RunListBoards();
@@ -212,6 +221,7 @@ protected:
   bool ParseAndValidateContexts();
   bool ProcessContexts();
   bool IsSolutionImageOnly();
+  void InitSolution(const std::string& csolution, const std::string& activeTargetSet, const bool& updateRte);
 };
 
 #endif  // PROJMGR_H

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -65,9 +65,10 @@ public:
   /**
    * @brief load solution
    * @param path to <solution>.csolution.yml file
+   * @param active target set in the format <target-type>[@<set>]
    * @return processing status
   */
-  bool LoadSolution(const std::string& csolution);
+  bool LoadSolution(const std::string& csolution, const std::string& activeTargetSet);
 
 protected:
   /**

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -1286,14 +1286,19 @@ void ProjMgr::Clear() {
   ProjMgrLogger::Get().Clear();
 }
 
-bool ProjMgr::LoadSolution(const std::string& csolution) {
+bool ProjMgr::LoadSolution(const std::string& csolution, const std::string& activeTargetSet) {
   Clear();
 
   m_csolutionFile = csolution;
   m_rootDir = RteUtils::ExtractFilePath(m_csolutionFile, false);
-
-  m_contextSet = true;
   m_updateRteFiles = false;
+
+  if (activeTargetSet.empty()) {
+    // fallback to 'context-set' for backward compatibility
+    m_contextSet = true;
+  } else {
+    m_activeTargetSet = activeTargetSet;
+  }
 
   if (!PopulateContexts()) {
     return false;

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -81,7 +81,7 @@ public:
   RpcArgs::SuccessResult Apply(const string& context) override;
   RpcArgs::SuccessResult Resolve(const string& context) override;
   RpcArgs::SuccessResult LoadPacks(void) override;
-  RpcArgs::SuccessResult LoadSolution(const string& solution) override;
+  RpcArgs::SuccessResult LoadSolution(const string& solution, const string& activeTarget) override;
   RpcArgs::UsedItems GetUsedItems(const string& context) override;
   RpcArgs::PacksInfo GetPacksInfo(const string& context) override;
   RpcArgs::DeviceList GetDeviceList(const string& context, const string& namePattern, const string& vendor) override;
@@ -201,6 +201,7 @@ RpcArgs::GetVersionResult RpcHandler::GetVersion(void) {
   RpcArgs::GetVersionResult res = {{true}};
   res.message = string("Running ") + INTERNAL_NAME + " " + VERSION_STRING;
   res.version = VERSION_STRING;
+  res.apiVersion = RPC_API_VERSION;
   return res;
 }
 
@@ -279,7 +280,7 @@ RpcArgs::SuccessResult RpcHandler::LoadPacks(void) {
   return result;
 }
 
-RpcArgs::SuccessResult RpcHandler::LoadSolution(const string& solution) {
+RpcArgs::SuccessResult RpcHandler::LoadSolution(const string& solution, const string& activeTarget) {
   RpcArgs::SuccessResult result = {false};
   const auto csolutionFile = RteFsUtils::MakePathCanonical(solution);
   if (!regex_match(csolutionFile, regex(".*\\.csolution\\.(yml|yaml)"))) {
@@ -290,7 +291,7 @@ RpcArgs::SuccessResult RpcHandler::LoadSolution(const string& solution) {
     result.message = "Packs must be loaded before loading solution";
     return result;
   }
-  result.success = m_solutionLoaded = m_manager.LoadSolution(csolutionFile);
+  result.success = m_solutionLoaded = m_manager.LoadSolution(csolutionFile, activeTarget);
   if (!m_solutionLoaded) {
     result.message = "failed to load and process solution " + csolutionFile;
   }

--- a/tools/projmgr/test/data/TestRpc/minimal.csolution.yml
+++ b/tools/projmgr/test/data/TestRpc/minimal.csolution.yml
@@ -7,6 +7,10 @@ solution:
   target-types:
     - type: TestHW
       device: RteTest_ARMCM4_NOFP
+      target-set:
+        - set: 
+          images:
+           - project-context: minimal
 
   projects:
     - project: minimal.cproject.yml

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -23,6 +23,7 @@ string schema_folder;
 string templates_folder;
 string etc_folder;
 string bin_folder;
+char* m_envp[4];
 
 StdStreamRedirect::StdStreamRedirect() :
   m_outbuffer(""), m_cerrbuffer(""),
@@ -153,10 +154,13 @@ void ProjMgrTestEnv::SetUp() {
 
   // copy linker script template files
   fs::copy(fs::path(templates_folder), fs::path(testcmsiscompiler_folder), fs::copy_options::recursive, ec);
+
+  // env vars
+  SetUpEnvp();
 }
 
 void ProjMgrTestEnv::TearDown() {
-  // Reserved
+  CleanUpEnvp();
 }
 
 void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2, LineReplaceFunc_t file2LineReplaceFunc) {
@@ -275,6 +279,31 @@ int ProjMgrTestEnv::CountOccurrences(const std::string input, const std::string 
     pos += substring.length();
   }
   return occurrences;
+}
+
+void ProjMgrTestEnv::SetUpEnvp() {
+  std::string ac6 = "AC6_TOOLCHAIN_6_18_0=" + testinput_folder;
+  std::string gcc = "GCC_TOOLCHAIN_11_2_1=" + testinput_folder;
+  std::string iar = "IAR_TOOLCHAIN_8_50_6=" + testinput_folder;
+
+  // Allocate memory for environment variables
+  m_envp[0] = new char[ac6.size() + 1];
+  m_envp[1] = new char[iar.size() + 1];
+  m_envp[2] = new char[gcc.size() + 1];
+
+  // Copy strings to allocated memory
+  strcpy(m_envp[0], ac6.c_str());
+  strcpy(m_envp[1], iar.c_str());
+  strcpy(m_envp[2], gcc.c_str());
+
+  // Null terminator
+  m_envp[3] = nullptr;
+}
+
+void ProjMgrTestEnv::CleanUpEnvp() {
+  delete[] m_envp[0];
+  delete[] m_envp[1];
+  delete[] m_envp[2];
 }
 
 int main(int argc, char **argv) {

--- a/tools/projmgr/test/src/ProjMgrTestEnv.h
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.h
@@ -20,6 +20,8 @@ extern std::string testcmsiscompiler_folder;
 extern std::string schema_folder;
 extern std::string etc_folder;
 extern std::string bin_folder;
+extern char* m_envp[4];
+
 /**
  * @brief direct console output to string
 */
@@ -66,6 +68,8 @@ public:
   static bool FilterId(const std::string& id, const std::string& includeIds);
   static bool IsFileInCbuildFilesList(const std::vector<std::map<std::string, std::string>> files, const std::string file);
   static int CountOccurrences(const std::string input, const std::string substring);
+  void SetUpEnvp();
+  void CleanUpEnvp();
 };
 
 #endif  // PROJMGRTESTENV_H

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -33,32 +33,10 @@ protected:
 
   void SetUp() {
     m_context.clear();
-    std::string ac6 = "AC6_TOOLCHAIN_6_18_0=" + testinput_folder;
-    std::string gcc = "GCC_TOOLCHAIN_11_2_1=" + testinput_folder;
-    std::string iar = "IAR_TOOLCHAIN_8_50_6=" + testinput_folder;
-
-    // Allocate memory for environment variables
-    m_envp[0] = new char[ac6.size() + 1];
-    m_envp[1] = new char[iar.size() + 1];
-    m_envp[2] = new char[gcc.size() + 1];
-
-    // Copy strings to allocated memory
-    std::strcpy(m_envp[0], ac6.c_str());
-    std::strcpy(m_envp[1], iar.c_str());
-    std::strcpy(m_envp[2], gcc.c_str());
-
-    // Null terminator
-    m_envp[3] = nullptr;
   };
 
   void TearDown() {
-    cleanupEnvp();
-  }
-
-  void cleanupEnvp() {
-    delete[] m_envp[0];
-    delete[] m_envp[1];
-    delete[] m_envp[2];
+    // reserved
   }
 
   void GetFilesInTree(const string& dir, set<string>& files) {
@@ -98,8 +76,6 @@ protected:
     fout.close();
     return csolutionFile;
   }
-
-  char* m_envp[4];
 };
 
 TEST_F(ProjMgrUnitTests, Validate_Logger) {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/406
Start addressing https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/408

- Handle `LoadSolution` method request with `activeTarget` parameter
- Add `apiVersion` to `GetVersion` method response
- Add`ConvertSolution` method handling
