### PR TITLE
[projmgr] Extend filtering when listing templates and examples

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -327,12 +327,13 @@ struct ExampleItem {
 
 /**
  * @brief template item containing
- *        name of example
+ *        name of template
  *        description
  *        path to the directory that contains the template
  *        path to the *.csolution.yml file
  *        path to copy the template into
  *        pack identifier
+ *        placeholder symmetric to ExampleItem for reusable template
 */
 struct TemplateItem {
   std::string name;
@@ -341,6 +342,7 @@ struct TemplateItem {
   std::string file;
   std::string copyTo;
   std::string pack;
+  std::vector<BoardItem> boards;
 };
 
 /**
@@ -1212,6 +1214,7 @@ protected:
   bool IsBoardListCompatible(const ContextItem& context, const std::vector<RteBoard*> compatibleBoards, const Collection<RteItem*>& boards);
   bool IsEnvironmentCompatible(const std::string& environment, const StrVec& filter);
   bool HasCompatibleEnvironment(const Collection<RteItem*>& environments, const StrVec& filter);
+  template<class T> bool CheckFilter(const std::string& filter, const T& item);
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4313,6 +4313,24 @@ std::vector<ExampleItem> ProjMgrWorker::CollectExamples(const ContextItem& conte
   return examples;
 }
 
+template<class T> bool ProjMgrWorker::CheckFilter(const std::string& filter, const T& item) {
+  const bool nameFound = item.name.find(filter) != string::npos;
+  const bool packFound = item.pack.find(filter) != string::npos;
+  const bool descriptionFound = m_verbose ? item.description.find(filter) != string::npos : false;
+  bool boardFound = false;
+  if (m_verbose) {
+    for (const auto& board : item.boards) {
+      if (board.vendor.find(filter) != std::string::npos ||
+        board.name.find(filter) != std::string::npos ||
+        board.revision.find(filter) != std::string::npos) {
+        boardFound = true;
+        break;
+      }
+    }
+  }
+  return nameFound || packFound || descriptionFound || boardFound;
+}
+
 bool ProjMgrWorker::ListExamples(vector<string>& examples, const string& filter) {
   const auto& selectedContext = m_selectedContexts.front();
   ContextItem& context = m_contexts[selectedContext];
@@ -4331,7 +4349,7 @@ bool ProjMgrWorker::ListExamples(vector<string>& examples, const string& filter)
   const auto& collectedExamples = CollectExamples(context, StrVec());
 
   for (const auto& exampleItem : collectedExamples) {
-    if (!filter.empty() && exampleItem.name.find(filter) == string::npos) {
+    if (!filter.empty() && !CheckFilter(filter, exampleItem)) {
       continue;
     }
     string example = exampleItem.boards.empty() ? "Reference Application: " : "";
@@ -4394,7 +4412,7 @@ bool ProjMgrWorker::ListTemplates(vector<string>& templates, const string& filte
   }
   const auto& collectedTemplates = CollectTemplates(context);
   for (const auto& templateItem : collectedTemplates) {
-    if (!filter.empty() && templateItem.name.find(filter) == string::npos) {
+    if (!filter.empty() && !CheckFilter(filter, templateItem)) {
       continue;
     }
     string templateStr = templateItem.name + " (" + templateItem.pack + ")";

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6879,7 +6879,7 @@ TEST_F(ProjMgrUnitTests, ListTargetSetsImageOnly) {
 }
 
 TEST_F(ProjMgrUnitTests, ListExamples) {
-  char* argv[8];
+  char* argv[9];
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/Examples/solution.csolution.yml";
 
@@ -6940,6 +6940,17 @@ PreIncludeEnvFolder@1.0.0 (ARM::RteTest@0.1.0)\n\
 PreIncludeEnvFolder@1.0.0 (ARM::RteTest@0.1.0)\n\
 ");
 
+  // test with filter option (description)
+  streamRedirect.ClearStringStreams();
+  argv[7] = (char*)"different folder description";
+  argv[8] = (char*)"--verbose";
+  EXPECT_EQ(0, RunProjMgr(9, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+PreIncludeEnvFolder@1.0.0 \\(ARM::RteTest@0.1.0\\)\n\
+  description: PreInclude Test Application with different folder description\n\
+")));
+
   // test with non-compatible device
   streamRedirect.ClearStringStreams();
   argv[5] = (char*)"CM0";
@@ -6973,6 +6984,17 @@ Board3 (ARM::RteTest_DFP@0.2.0)\n\
   EXPECT_STREQ(outStr.c_str(), "\
 Board1Template (ARM::RteTest_DFP@0.2.0)\n\
 ");
+
+  // test filter (description)
+  argv[4] = (char*)"Template one";
+  argv[5] = (char*)"--verbose";
+  streamRedirect.ClearStringStreams();
+  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+Board1Template \\(ARM::RteTest_DFP@0.2.0\\)\n\
+  description: \"Test board Template one\"\n\
+")));
 
   // list board's compatible template
   const string& csolution = testinput_folder + "/Examples/solution.csolution.yml";


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/2183

When listing `examples` and `templates`, search for the `--filter` string over `name`, `pack` and in verbose mode also over `description` and `boards`.