### PR TITLE
Use Bname="" for condition evaluation (#1305)

### DIFF
--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -1589,6 +1589,11 @@ bool RteProject::AddTarget(const string& name, const map<string, string>& attrib
     if (boardInfo) {
       targetAttributes.AddAttributes(boardInfo->GetAttributes(), false);
     }
+    if(targetAttributes.HasAttribute("Dname") &&
+      !targetAttributes.HasAttribute("Bname")) {
+      // set empty board name to filter-out board-specific items if device is selected
+      targetAttributes.AddAttribute("Bname", "");
+    }
 
     // add Brevision attribute if Bversion is specified
     if (!targetAttributes.HasAttribute("Brevision") && targetAttributes.HasAttribute("Bversion")) {

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -1126,7 +1126,7 @@ TEST_F(RteModelPrjTest, LoadCprjM4) {
   auto& allLayerDescriptors = rteKernel.GetGlobalModel()->GetLayerDescriptors();
   EXPECT_EQ(allLayerDescriptors.size(), 10);
   auto& filteredLayerDescriptors = activeTarget->GetFilteredModel()->GetLayerDescriptors();
-  EXPECT_EQ(filteredLayerDescriptors.size(), 10);
+  EXPECT_EQ(filteredLayerDescriptors.size(), 7);
   ca = activeTarget->GetComponentAggregate("ARM::Device:Startup");
   ASSERT_NE(ca, nullptr);
   EXPECT_EQ(ca->GetAttribute("layer"), "LayerOne");


### PR DESCRIPTION
Bname is set to explicit empty string if device is selected, but no board is specified
The filters-out all board-specific pack items that has conditions with Bname

Fixes https://github.com/Open-CMSIS-Pack/ST_B-U585I-IOT02A_BSP/issues/5