### PR TITLE
[projmgr] Skip cbuild-run generation when target-set has only `lib` contexts

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1034,6 +1034,13 @@ public:
    * @return vector of template items
   */
   std::vector<TemplateItem> CollectTemplates(const ContextItem& context);
+  
+  /**
+   * @brief check if all selected contexts have lib output
+   * @param reference to processed contexts
+   * @return true if it's lib only
+  */
+  bool IsLibOnly(const std::vector<ContextItem*>& contexts);
 
   /**
    * @brief clear worker members for reloading a solution

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -579,7 +579,7 @@ bool ProjMgr::GenerateYMLConfigurationFiles(bool previousResult) {
   }
 
   // Generate cbuild-run file
-  if (previousResult && !m_processedContexts.empty() &&
+  if (previousResult && !m_processedContexts.empty() && !m_worker.IsLibOnly(m_processedContexts) &&
     (m_contextSet || m_activeTargetSet.has_value())) {
     const auto& debugAdapters = GetDebugAdaptersFile();
     if (!debugAdapters.empty()) {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -5775,3 +5775,12 @@ bool ProjMgrWorker::PopulateActiveTargetSet(const string& activeTargetSet) {
   }
   return true;
 }
+
+bool ProjMgrWorker::IsLibOnly(const std::vector<ContextItem*>& contexts) {
+  for (auto& context : contexts) {
+    if (!context->outputTypes.lib.on) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4641,8 +4641,8 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_StandardLibrary) {
   const string& csolution = testinput_folder + "/TestSolution/StandardLibrary/library.csolution.yml";
   argv[1] = (char*)"convert";
   argv[2] = (char*)csolution.c_str();
-  argv[3] = (char*)"-c";
-  argv[4] = (char*)"library.Debug+RteTest_ARMCM3";
+  argv[3] = (char*)"-a";
+  argv[4] = (char*)"";
   argv[5] = (char*)"-o";
   argv[6] = (char*)testoutput_folder.c_str();
   argv[7] = (char*)"--cbuildgen";
@@ -4655,6 +4655,10 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_StandardLibrary) {
   // Check generated cbuild YMLs
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/library.Debug+RteTest_ARMCM3.cbuild.yml",
     testinput_folder + "/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml");
+
+  // Check there is no cbuild-run (target-set has only lib contexts)
+  const YAML::Node& cbuildIdx = YAML::LoadFile(testoutput_folder + "/library.cbuild-idx.yml");
+  EXPECT_FALSE(cbuildIdx["build-idx"]["cbuild-run"].IsDefined());
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_MultipleProject_SameFolder) {


### PR DESCRIPTION
Address https://github.com/ARM-software/vscode-cmsis-csolution/issues/312