### PR TITLE
[projmgr] Skip item from devices list when it is not end-leaf (#1308)

### DIFF
--- a/tools/projmgr/src/ProjMgrRpcServerData.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServerData.cpp
@@ -250,9 +250,13 @@ void RpcDataCollector::CollectBoardDevices(vector<RpcArgs::Device>& boardDevices
 void RpcDataCollector::CollectDeviceList(RpcArgs::DeviceList& deviceList, const std::string& namePattern, const std::string& vendor) const {
   list<RteDevice*> devices;
   if(m_model) {
-    m_model->GetDevices(devices, namePattern, vendor);
+    m_model->GetDevices(devices, namePattern, vendor, RteDeviceItem::VARIANT);
   }
   for(auto rteDevice : devices) {
+    if (!rteDevice->GetDeviceItems().empty()) {
+      // skip not end-leaf item
+      continue;
+    }
     deviceList.devices.push_back(FromRteDevice(rteDevice, false));
   }
 }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4038,6 +4038,10 @@ bool ProjMgrWorker::ListDevices(vector<string>& devices, const string& filter) {
     list<RteDevice*> filteredModelDevices;
     context.rteFilteredModel->GetDevices(filteredModelDevices, "", "", RteDeviceItem::VARIANT);
     for (const auto& deviceItem : filteredModelDevices) {
+      if (!deviceItem->GetDeviceItems().empty()) {
+        // skip not end-leaf item
+        continue;
+      }
       const string& deviceVendor = deviceItem->GetVendorName();
       const string& deviceName = deviceItem->GetFullDeviceName();
       const string& devicePack = deviceItem->GetPackageID();

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -183,7 +183,7 @@ TEST_F(ProjMgrRpcTests, RpcDeviceListNoContext) {
 
   EXPECT_TRUE(responses[1]["result"]["success"]);
   auto deviceList = responses[1]["result"]["devices"];
-  EXPECT_EQ(deviceList.size(), 7);
+  EXPECT_EQ(deviceList.size(), 8);
   auto d0 = deviceList[0];
   EXPECT_EQ(d0["id"], "ARM::RteTest_ARMCM0");
   EXPECT_EQ(d0["family"], "RteTest ARM Cortex M");
@@ -222,7 +222,7 @@ TEST_F(ProjMgrRpcTests, RpcDeviceListContext) {
 
   EXPECT_TRUE(responses[2]["result"]["success"]);
   auto deviceList = responses[2]["result"]["devices"];
-  EXPECT_EQ(deviceList.size(), 6);
+  EXPECT_EQ(deviceList.size(), 7);
   auto d0 = deviceList[0];
   EXPECT_EQ(d0["id"], "ARM::RteTest_ARMCM0");
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -532,7 +532,6 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListDevices) {
 
   auto outStr = streamRedirect.GetOutString();
   EXPECT_STREQ(outStr.c_str(),"\
-ARM::RteTest_ARMCM4 (ARM::RteTest_DFP@0.2.0)\n\
 ARM::RteTest_ARMCM4_FP (ARM::RteTest_DFP@0.2.0)\n\
 ARM::RteTest_ARMCM4_NOFP (ARM::RteTest_DFP@0.2.0)\n"
   );


### PR DESCRIPTION
Address https://github.com/ARM-software/vscode-cmsis-csolution/issues/318#issuecomment-3263823762
Fix command line `list devices` and RPC `GetDeviceList` method.