### PR TITLE
[csolution-rpc] Fix examples filtering for `device` not being mounted on any board

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4233,7 +4233,7 @@ vector<RteBoard*> ProjMgrWorker::GetCompatibleBoards(const ContextItem& context)
 }
 
 bool ProjMgrWorker::IsBoardListCompatible(const ContextItem& context, const vector<RteBoard*> compatibleBoards, const Collection<RteItem*>& boards) {
-  if (compatibleBoards.empty()) {
+  if (!context.rteBoard && !context.rteDevice) {
     // no board/device is selected
     return true;
   }

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -668,6 +668,14 @@ TEST_F(ProjMgrRpcTests, RpcGetDraftProjects) {
   EXPECT_EQ(templates[1]["name"], "Board2");
   EXPECT_EQ(templates[2]["name"], "Board3");
 
+  // filter 'device' that's not mounted on any board
+  requests =
+    FormatRequest(1, "LoadPacks") +
+    FormatRequest(2, "GetDraftProjects", json{ { "filter", {{ "device", "RteTestGen_ARMCM0" }}} });
+  responses = RunRpcMethods(requests);
+  EXPECT_TRUE(responses[1]["result"]["success"]);
+  EXPECT_FALSE(responses[1]["result"].contains("examples"));
+
   // filter 'environment'
   requests =
     FormatRequest(1, "LoadPacks") +


### PR DESCRIPTION
Address https://github.com/ARM-software/vscode-cmsis-csolution/issues/326