### PR TITLE
[projmgr] Remove placeholders `trace` and `terminal` from cbuild-run schema

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2180,9 +2180,7 @@
         "clock":           { "type": "number", "description": "Selected debug clock speed (in Hz)." },
         "dbgconf":         { "type": "string", "description": "Debugger configuration file (pinout, trace)." },
         "start-pname":     { "type": "string", "description": "Debugger connects at start to this processor." },
-        "gdbserver":       { "$ref": "#/definitions/GdbServersType" },
-        "terminal":        { "type": "string", "description": "Terminal port of the debugger." },
-        "trace":           { "type": "string", "description": "Trace port of the debugger." }
+        "gdbserver":       { "$ref": "#/definitions/GdbServersType" }
       },
       "additionalProperties": true,
       "required": ["name"]


### PR DESCRIPTION
Remove [placeholders](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/1ba77e99d32ff364dca22e352920ed90864d169c/docs/YML-CBuild-Format.md?plain=1#L924-L925) `trace` and `terminal` from cbuild-run schema to allow unrestricted use of such properties as debug adapter capabilities, as recently added in [debug-adapter-registry #35](https://github.com/Open-CMSIS-Pack/debug-adapter-registry/pull/35/files#diff-1f12263a135215f55279a89a5775f02e59b316d20ce40b781c0c6e9079285b20R10).

Fix nightly build [failure](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/actions/runs/17934078159/job/51009880502#step:22:53).