### PR TITLE
[cbuildgen] Disable incremental link in debug config

### DIFF
--- a/tools/buildmgr/cbuildgen/CMakeLists.txt
+++ b/tools/buildmgr/cbuildgen/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_command(TARGET cbuildgen POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy 
 
 #
 if(MSVC)
-  target_link_options(cbuildgen PUBLIC "$<$<CONFIG:Debug>:/SAFESEH:NO>")
+  target_link_options(cbuildgen PUBLIC "$<$<CONFIG:Debug>:/SAFESEH:NO;/INCREMENTAL:NO>")
 endif(MSVC)
 set_property(TARGET cbuildgen PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
With the new GH Runner Image for windows-2022 [20250921.44.1](https://github.com/actions/runner-images/releases/tag/win22%2F20250921.44) the cbuildgen integration tests started to fail with an [internal linker error](https://github.com/Open-CMSIS-Pack/devtools/actions/runs/17992831402/job/51210581443):
```
LINK : fatal error LNK1000: unknown error at 00007FF745A8B899; consult documentation for technical support options
```
Proposed workaround: disable incremental linking because it tends to get flaky on large graphs.