### PR TITLE
[projmgr] Add RPC method `DiscoverLayers` (#1330)

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -71,6 +71,14 @@ public:
   bool LoadSolution(const std::string& csolution, const std::string& activeTargetSet);
 
   /**
+   * @brief setup contexts
+   * @param path to <solution>.csolution.yml file
+   * @param active target set in the format <target-type>[@<set>]
+   * @return processing status
+  */
+  bool SetupContexts(const std::string& csolution, const std::string& activeTargetSet);  
+
+  /**
    * @brief convert solution and generate yml files
    * @param path to <solution>.csolution.yml file
    * @param active target set in the format <target-type>[@<set>]

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -368,6 +368,42 @@ struct DebuggerType {
 };
 
 /**
+ * @brief settings type containing
+ *        connection set
+*/
+struct SettingsType {
+  std::string set;
+};
+
+/**
+ * @brief layer variable type containing
+ *        variable name
+ *        clayer path
+ *        brief description
+ *        list of connection sets
+ *        directory path that contains the layer (from PDSC)
+ *        clayer path relative to directory path (from PDSC)
+ *        proposed destination directory for the layer (from PDSC)
+*/
+struct LayerVariable {
+  std::string name;
+  std::string clayer;
+  std::string description;
+  std::vector<SettingsType> settings;
+  std::string path;
+  std::string file;
+  std::string copyTo;
+};
+
+/**
+ * @brief variables configuration type containing
+ *        list of layer variables
+*/
+struct VariablesConfiguration {
+  std::vector<LayerVariable> variables;
+};
+
+/**
  * @brief project context item containing
  *        pointer to csolution,
  *        pointer to cproject,
@@ -431,6 +467,7 @@ struct DebuggerType {
  *        image only flag
  *        west options
  *        west on flag
+ *        layer variables configurations
 */
 struct ContextItem {
   CdefaultItem* cdefault = nullptr;
@@ -502,6 +539,7 @@ struct ContextItem {
   bool imageOnly = false;
   WestDesc west;
   bool westOn = false;
+  std::vector<VariablesConfiguration> variablesConfigurations;
 };
 
 /**
@@ -1052,6 +1090,18 @@ public:
   bool IsLibOnly(const std::vector<ContextItem*>& contexts);
 
   /**
+   * @brief get processed contexts
+   * @return reference to vector with context items
+  */
+  const std::vector<ContextItem*>& GetProcessedContexts(void);
+
+  /**
+   * @brief elaborate possible variables configurations according to compatible layers
+   * @return true if there are configurations available
+  */
+  bool ElaborateVariablesConfigurations();
+
+  /**
    * @brief clear worker members for reloading a solution
    * @return true if there is no error
   */
@@ -1094,6 +1144,7 @@ protected:
   std::map<std::string, ContextItem> m_contexts;
   std::map<std::string, std::set<std::string>> m_contextErrMap;
   std::vector<std::string> m_selectedContexts;
+  std::vector<ContextItem*> m_processedContexts;
   std::string m_outputDir;
   std::string m_packRoot;
   std::string m_compilerRoot;

--- a/tools/projmgr/test/data/TestLayers/ref/rpc-discover-layers.json
+++ b/tools/projmgr/test/data/TestLayers/ref/rpc-discover-layers.json
@@ -1,0 +1,149 @@
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "configurations": [
+      {
+        "variables": [
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
+            "copy-to": "path/to/config1",
+            "file": "config1.clayer.yml",
+            "name": "Config1-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
+            "settings": [
+              {
+                "set": "set1.select1 (connect A - set 1 select 1)"
+              },
+              {
+                "set": "set2.select1 (connect C - set 2 select 1)"
+              }
+            ]
+          },
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config2.clayer.yml",
+            "copy-to": "path/to/config2",
+            "file": "Layers/config2.clayer.yml",
+            "name": "Config2-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
+            "settings": [
+              {
+                "set": "set1.select1 (connect F - set 1 select 1)"
+              }
+            ]
+          },
+          {
+            "clayer": "",
+            "name": "Incompatible-Layer"
+          }
+        ]
+      },
+      {
+        "variables": [
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
+            "copy-to": "path/to/config1",
+            "file": "config1.clayer.yml",
+            "name": "Config1-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
+            "settings": [
+              {
+                "set": "set1.select1 (connect A - set 1 select 1)"
+              },
+              {
+                "set": "set2.select1 (connect C - set 2 select 1)"
+              }
+            ]
+          },
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config3.clayer.yml",
+            "copy-to": "path/to/config3",
+            "file": "Layers/config3.clayer.yml",
+            "name": "Config2-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
+            "settings": [
+              {
+                "set": "set3.select1 (connect F - set 3 select 1)"
+              }
+            ]
+          },
+          {
+            "clayer": "",
+            "name": "Incompatible-Layer"
+          }
+        ]
+      },
+      {
+        "variables": [
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
+            "copy-to": "path/to/config1",
+            "file": "config1.clayer.yml",
+            "name": "Config1-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
+            "settings": [
+              {
+                "set": "set1.select2 (connect B - set 1 select 2)"
+              },
+              {
+                "set": "set2.select2 (connect D - set 2 select 2)"
+              }
+            ]
+          },
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config2.clayer.yml",
+            "copy-to": "path/to/config2",
+            "file": "Layers/config2.clayer.yml",
+            "name": "Config2-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
+            "settings": [
+              {
+                "set": "set1.select2 (connect G - set 1 select 2)"
+              }
+            ]
+          },
+          {
+            "clayer": "",
+            "name": "Incompatible-Layer"
+          }
+        ]
+      },
+      {
+        "variables": [
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
+            "copy-to": "path/to/config1",
+            "file": "config1.clayer.yml",
+            "name": "Config1-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
+            "settings": [
+              {
+                "set": "set1.select2 (connect B - set 1 select 2)"
+              },
+              {
+                "set": "set2.select2 (connect D - set 2 select 2)"
+              }
+            ]
+          },
+          {
+            "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config3.clayer.yml",
+            "copy-to": "path/to/config3",
+            "file": "Layers/config3.clayer.yml",
+            "name": "Config2-Layer",
+            "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
+            "settings": [
+              {
+                "set": "set3.select2 (connect G - set 3 select 2)"
+              }
+            ]
+          },
+          {
+            "clayer": "",
+            "name": "Incompatible-Layer"
+          }
+        ]
+      }
+    ],
+    "success": true
+  }
+}

--- a/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrGeneratorUnitTests.cpp
@@ -90,14 +90,7 @@ TEST_F(ProjMgrGeneratorUnitTests, GenFiles) {
   const string generatorInputFile = testinput_folder + "/TestSolution/tmp/TestProject3_1.Debug+TypeA.cbuild-gen.yml";
   const string generatedGPDSC = testinput_folder + "/TestSolution/TestProject3_1/gendir/RteTestGen_ARMCM0/RteTest.gpdsc";
 
-  auto stripAbsoluteFunc = [](const std::string& in) {
-    std::string str = in;
-    RteUtils::ReplaceAll(str, testinput_folder, "${DEVTOOLS(data)}");
-    RteUtils::ReplaceAll(str, testcmsispack_folder, "${DEVTOOLS(packs)}");
-    return str;
-  };
-
-  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, stripAbsoluteFunc);
+  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, ProjMgrTestEnv::StripAbsoluteFunc);
 
   EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));
   EXPECT_EQ(true, std::filesystem::exists(generatedGPDSC));
@@ -190,14 +183,7 @@ TEST_F(ProjMgrGeneratorUnitTests, DryRun) {
 
   EXPECT_EQ(0, ProjMgr::RunProjMgr(7, argv, envp));
 
-  auto stripAbsoluteFunc = [](const std::string& in) {
-    std::string str = in;
-    RteUtils::ReplaceAll(str, testinput_folder, "${DEVTOOLS(data)}");
-    RteUtils::ReplaceAll(str, testcmsispack_folder, "${DEVTOOLS(packs)}");
-    return str;
-  };
-
-  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, stripAbsoluteFunc);
+  ProjMgrTestEnv::CompareFile(testinput_folder + "/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml",  generatorInputFile, ProjMgrTestEnv::StripAbsoluteFunc);
 
   EXPECT_EQ(true, std::filesystem::exists(generatorInputFile));
   EXPECT_EQ(false, std::filesystem::exists(rteDir + "/Device"));

--- a/tools/projmgr/test/src/ProjMgrTestEnv.cpp
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.cpp
@@ -163,6 +163,13 @@ void ProjMgrTestEnv::TearDown() {
   CleanUpEnvp();
 }
 
+std::string ProjMgrTestEnv::StripAbsoluteFunc(const std::string& in) {
+  std::string str = in;
+  RteUtils::ReplaceAll(str, testinput_folder, "${DEVTOOLS(data)}");
+  RteUtils::ReplaceAll(str, testcmsispack_folder, "${DEVTOOLS(packs)}");
+  return str;
+};
+
 void ProjMgrTestEnv::CompareFile(const string& file1, const string& file2, LineReplaceFunc_t file2LineReplaceFunc) {
   ifstream f1, f2;
   string l1, l2;

--- a/tools/projmgr/test/src/ProjMgrTestEnv.h
+++ b/tools/projmgr/test/src/ProjMgrTestEnv.h
@@ -60,6 +60,7 @@ class ProjMgrTestEnv : public ::testing::Environment {
 public:
   void SetUp() override;
   void TearDown() override;
+  static std::string StripAbsoluteFunc(const std::string& in);
   static void CompareFile(const std::string& file1, const std::string& file2, LineReplaceFunc_t file2LineReplaceFunc = nullptr);
   static const std::string& GetCmsisPackRoot();
   static std::map<std::string, std::string, RtePackageComparator> GetEffectivePdscFiles(bool bLatestsOnly = false);

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1726,13 +1726,8 @@ TEST_F(ProjMgrUnitTests, ListLayersConfigurations_update_idx_pack_layer) {
   EXPECT_EQ(0, RunProjMgr(6, argv, m_envp));
   EXPECT_TRUE(regex_match(streamRedirect.GetOutString(), regex(expectedOutStr)));
 
-  auto stripAbsoluteFunc = [](const std::string& in) {
-    std::string str = in;
-    RteUtils::ReplaceAll(str, testcmsispack_folder, "${DEVTOOLS(packs)}");
-    return str;
-  };
   ProjMgrTestEnv::CompareFile(testinput_folder + "/TestLayers/ref/config.cbuild-idx.yml",
-    testinput_folder + "/TestLayers/config.cbuild-idx.yml", stripAbsoluteFunc);
+    testinput_folder + "/TestLayers/config.cbuild-idx.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   EXPECT_TRUE(ProjMgrYamlSchemaChecker().Validate(testinput_folder + "/TestLayers/config.cbuild-idx.yml"));
 }
 
@@ -5422,39 +5417,32 @@ TEST_F(ProjMgrUnitTests, ExternalGenerator) {
   argv[6] = (char*)"core0.Debug+MultiCore";
   EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
 
-  auto stripAbsoluteFunc = [](const std::string& in) {
-    std::string str = in;
-    RteUtils::ReplaceAll(str, testinput_folder, "${DEVTOOLS(data)}");
-    RteUtils::ReplaceAll(str, testcmsispack_folder, "${DEVTOOLS(packs)}");
-    return str;
-  };
-
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/MultiCore/extgen.cbuild-gen-idx.yml",
-    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/MultiCore/core0.Debug+MultiCore.cbuild-gen.yml",
-    testinput_folder + "/ExternalGenerator/tmp/core0.Debug+MultiCore.cbuild-gen.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/core0.Debug+MultiCore.cbuild-gen.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/MultiCore/core1.Debug+MultiCore.cbuild-gen.yml",
-    testinput_folder + "/ExternalGenerator/tmp/core1.Debug+MultiCore.cbuild-gen.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/core1.Debug+MultiCore.cbuild-gen.yml", ProjMgrTestEnv::StripAbsoluteFunc);
 
   // run single-core
   argv[6] = (char*)"single-core.Debug+CM0";
   EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
 
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/SingleCore/extgen.cbuild-gen-idx.yml",
-    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild-gen.yml",
-    testinput_folder + "/ExternalGenerator/tmp/single-core.Debug+CM0.cbuild-gen.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/single-core.Debug+CM0.cbuild-gen.yml", ProjMgrTestEnv::StripAbsoluteFunc);
 
   // run trustzone
   argv[6] = (char*)"ns.Debug+CM0";
   EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
 
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/TrustZone/extgen.cbuild-gen-idx.yml",
-    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/extgen.cbuild-gen-idx.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/TrustZone/ns.Debug+CM0.cbuild-gen.yml",
-    testinput_folder + "/ExternalGenerator/tmp/ns.Debug+CM0.cbuild-gen.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/ns.Debug+CM0.cbuild-gen.yml", ProjMgrTestEnv::StripAbsoluteFunc);
   ProjMgrTestEnv::CompareFile(testinput_folder + "/ExternalGenerator/ref/TrustZone/s.Debug+CM0.cbuild-gen.yml",
-    testinput_folder + "/ExternalGenerator/tmp/s.Debug+CM0.cbuild-gen.yml", stripAbsoluteFunc);
+    testinput_folder + "/ExternalGenerator/tmp/s.Debug+CM0.cbuild-gen.yml", ProjMgrTestEnv::StripAbsoluteFunc);
 
   // convert single core
   argv[2] = (char*)"convert";


### PR DESCRIPTION
Relates to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/419

Changes:
- Add RPC method `DiscoverLayers` similar to the command-line `csolution list layers --update-idx`.
- Move collection of possible layer variables configurations from emitter to worker for code re-use between command-line and rpc processing -> `ProjMgrWorker::ElaborateVariablesConfigurations()`.
- Add test cases and update test utility functions.

Note: similar to the related command-line feature, solutions with undefined layer variables over multiple projects are currently not supported.