### PR TITLE
[projmgr] Schema refinements around `west`

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -389,6 +389,11 @@
         ]
       }
     },
+    "WestDefinesType": {
+      "title": "west-defs:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#west-defs",
+      "description": "Defines forwarded to CMake via west build system.",
+      "$ref": "#/definitions/DefinesType"
+    },
     "DefinesType": {
       "title": "define:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#define",
       "type": "array",
@@ -611,7 +616,7 @@
         "undefine":     { "$ref": "#/definitions/UndefinesType" },
         "variables":    { "$ref": "#/definitions/VariablesType" },
         "warnings":     { "$ref": "#/definitions/WarningsType" },
-        "west-defs":    { "$ref": "#/definitions/DefinesType" }
+        "west-defs":    { "$ref": "#/definitions/WestDefinesType" }
       },
       "additionalProperties": false,
       "required" : [ "type"]
@@ -649,7 +654,7 @@
         "undefine":     { "$ref": "#/definitions/UndefinesType" },
         "variables":    { "$ref": "#/definitions/VariablesType" },
         "warnings":     { "$ref": "#/definitions/WarningsType" },
-        "west-defs":    { "$ref": "#/definitions/DefinesType" }
+        "west-defs":    { "$ref": "#/definitions/WestDefinesType" }
       },
       "additionalProperties": false,
       "required" : [ "type"]
@@ -676,8 +681,9 @@
         "not-for-context": { "$ref": "#/definitions/NotForContext" }
       },
       "additionalProperties": false,
-      "oneOf": [
-        { "$ref": "#/definitions/TypeListMutualExclusion"}
+      "allOf": [
+        { "$ref": "#/definitions/TypeListMutualExclusion" },
+        { "oneOf": [ { "required": ["project"], "not": {"required": ["west"]} }, { "required": ["west"], "not": {"required": ["project"]} } ] }
       ]
     },
     "ProcessorTrustzone": {
@@ -2426,7 +2432,7 @@
         "project-id": { "type": "string", "description": "Project identifier (default: last sub-dir name of app-path)." },
         "board":      { "type": "string", "description": "Board name used for west build invocation (default: variable $west-board$)."},
         "device":     { "$ref": "#/definitions/ProcessorNameType" },
-        "west-defs":  { "$ref": "#/definitions/DefinesType" },
+        "west-defs":  { "$ref": "#/definitions/WestDefinesType" },
         "west-opts":  { "type": "string", "description": "Options for the west tool (default: empty)." }
       },
       "additionalProperties": false,

--- a/tools/projmgr/test/data/WestSupport/core0/core0.cproject.yml
+++ b/tools/projmgr/test/data/WestSupport/core0/core0.cproject.yml
@@ -1,1 +1,0 @@
-project:

--- a/tools/projmgr/test/data/WestSupport/core1/core1.cproject.yml
+++ b/tools/projmgr/test/data/WestSupport/core1/core1.cproject.yml
@@ -1,1 +1,0 @@
-project:

--- a/tools/projmgr/test/data/WestSupport/ref/core0.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/core0.Debug+CM0.cbuild.yml
@@ -1,7 +1,6 @@
 build:
   generated-by: csolution version 0.0.0
   solution: ../../../../solution.csolution.yml
-  project: ../../../../core0/core0.cproject.yml
   context: core0.Debug+CM0
   compiler: AC6
   board: Keil::RteTest Dummy board:1.2.3

--- a/tools/projmgr/test/data/WestSupport/ref/core1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/core1.Debug+CM0.cbuild.yml
@@ -1,7 +1,6 @@
 build:
   generated-by: csolution version 0.0.0
   solution: ../../../../solution.csolution.yml
-  project: ../../../../core1/core1.cproject.yml
   context: core1.Debug+CM0
   compiler: AC6
   board: Keil::RteTest Dummy board:1.2.3

--- a/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
@@ -3,9 +3,6 @@ build-idx:
   csolution: solution.csolution.yml
   cbuild-run: out/solution+CM0.cbuild-run.yml
   tmpdir: tmp
-  cprojects:
-    - cproject: core0/core0.cproject.yml
-    - cproject: core1/core1.cproject.yml
   cbuilds:
     - cbuild: out/core0/CM0/Debug/core0.Debug+CM0.cbuild.yml
       west: true

--- a/tools/projmgr/test/data/WestSupport/solution.csolution.yml
+++ b/tools/projmgr/test/data/WestSupport/solution.csolution.yml
@@ -24,14 +24,12 @@ solution:
 
   # List related projects.
   projects:
-    - project: core0/core0.cproject.yml
-      west:
+    - west:
         app-path: ./west/core0
         device: :cm0_core0
         west-defs:
           - CORE: 0
-    - project: core1/core1.cproject.yml
-      west:
+    - west:
         app-path: ./west/core1
         project-id: core1
         device: :cm0_core1


### PR DESCRIPTION
Related to https://github.com/ARM-software/vscode-cmsis-csolution/issues/404, complementary to https://github.com/Open-CMSIS-Pack/devtools/pull/2258.
- Treat `project` and `west` nodes under `projects` as mutual exclusive
- Fix side-effect of YAML language server in vscode not showing tooltips for these nodes
- Add title and description to `west-defs` to differentiate them from C/C++ `define` while reusing its format
- Update test cases
