### PR TITLE
Set Bname to empty string if not defined  (#1351)

### DIFF
--- a/libs/rtemodel/include/RteInstance.h
+++ b/libs/rtemodel/include/RteInstance.h
@@ -428,7 +428,7 @@ public:
    * @param attr attributes to set as XmlItem reference
    * @return true if changed
   */
-  virtual bool SetPackageAttributes(const XmlItem& attr) { return m_packageAttributes.SetAttributes(attr); }
+  virtual bool SetPackageAttributes(const XmlItem& attr) { return m_packageAttributes.CopyAttributes(attr); }
 
   /**
    * @brief get pointer to resolved RtePackage
@@ -594,7 +594,7 @@ public:
    * @param attr pack attributes to set
    * @return true if attribute values have changed
   */
-   bool SetPackageAttributes(const XmlItem& attr) override { return SetAttributes(attr); }
+   bool SetPackageAttributes(const XmlItem& attr) override { return CopyAttributes(attr); }
 
   /**
    * @brief check if this object contains pack attributes directly rather than in a dedicated child
@@ -714,7 +714,7 @@ public:
    * @param attr pack attributes
    * @return true if changed
   */
-   bool SetPackageAttributes(const XmlItem& attr) override { return SetAttributes(attr); }
+   bool SetPackageAttributes(const XmlItem& attr) override { return CopyAttributes(attr); }
 
   /**
    * @brief check if this object contains pack attributes directly rather than in a dedicated child

--- a/libs/rtemodel/include/RteModel.h
+++ b/libs/rtemodel/include/RteModel.h
@@ -446,7 +446,7 @@ public:
    * @param books collection of file path mapped to book title to fill
    * @param deviceAttributes device attributes
   */
-  void GetBoardBooks(std::map<std::string, std::string>& books, const std::map<std::string, std::string>& deviceAttributes) const;
+  void GetBoardBooks(std::map<std::string, std::string>& books, const XmlItem& deviceAttributes) const;
 
 public:
   /**

--- a/libs/rtemodel/src/RteInstance.cpp
+++ b/libs/rtemodel/src/RteInstance.cpp
@@ -157,9 +157,9 @@ void RteInstanceTargetInfo::CopySettings(const RteInstanceTargetInfo& other)
   SetVersionMatchMode(other.GetVersionMatchMode());
   SetExcluded(other.IsExcluded());
   SetIncludeInLib(other.IsIncludeInLib());
-  m_memOpt.SetAttributes(other.GetMemOpt());
-  m_cOpt.SetAttributes(other.GetCOpt());
-  m_asmOpt.SetAttributes(other.GetAsmOpt());
+  m_memOpt.CopyAttributes(other.GetMemOpt());
+  m_cOpt.CopyAttributes(other.GetCOpt());
+  m_asmOpt.CopyAttributes(other.GetAsmOpt());
 }
 
 
@@ -700,7 +700,7 @@ void RteFileInstance::Update(RteItem* f, bool bUpdateComponent)
     for (auto [targetName, ti] : m_targetInfos) {
       RteComponentInstance* ci = GetComponentInstance(targetName);
       if (ci) {
-        ci->SetAttributes(m_componentAttributes);
+        ci->CopyAttributes(m_componentAttributes);
         ci->SetPackageAttributes(m_packageAttributes);
       }
     }

--- a/libs/rtemodel/src/RteModel.cpp
+++ b/libs/rtemodel/src/RteModel.cpp
@@ -800,13 +800,14 @@ void RteModel::GetBoardBooks(map<string, string>& books, const string& device, c
     return;
   XmlItem ea;
   d->GetEffectiveAttributes(ea);
-  GetBoardBooks(books, ea.GetAttributes());
+  GetBoardBooks(books, ea);
 }
 
-void RteModel::GetBoardBooks(map<string, string>& books, const map<string, string>& deviceAttributes) const
+void RteModel::GetBoardBooks(map<string, string>& books, const XmlItem& deviceAttributes) const
 {
-  if (m_boards.empty())
+  if(m_boards.empty()) {
     return;
+  }
   for (auto [_, b] : m_boards) {
     if (b->HasCompatibleDevice(deviceAttributes)) {
       b->GetBooks(books);

--- a/libs/rtemodel/src/RteProject.cpp
+++ b/libs/rtemodel/src/RteProject.cpp
@@ -137,7 +137,7 @@ RteLicenseInfo* RteLicenseInfoCollection::EnsureLicenseInfo(RteItem* item, RteIt
     m_LicensInfos[licId] = info;
     string licFile;
     if (license) {
-      info->SetAttributes(*license);
+      info->CopyAttributes(*license);
       if(!info->HasAttribute("spdx")) {
         licFile = license->GetName();
       }
@@ -399,7 +399,7 @@ RteComponentInstance* RteProject::AddComponent(RteComponent* c, int instanceCoun
   if (c->IsGenerated() && c->HasAttribute("selectable") ) {
     RteItem* packInfo = c->GetFirstChild("package");
     if (packInfo) {
-      ci->SetPackageAttributes(packInfo->GetAttributes());
+      ci->SetPackageAttributes(*packInfo);
     }
   }
 
@@ -1460,18 +1460,18 @@ RteItem::ConditionResult RteProject::ResolveComponents(bool bFindReplacementForA
       }
 
       // first try to find a component from the same vendor
-      t->GetComponentAggregates(componentAttributes.GetAttributes(), aggregates);
+      t->GetComponentAggregates(componentAttributes, aggregates);
 
       // try to find a component from any vendor
       if (aggregates.empty()) {
         componentAttributes.RemoveAttribute("Cvendor");
-        t->GetComponentAggregates(componentAttributes.GetAttributes(), aggregates);
+        t->GetComponentAggregates(componentAttributes, aggregates);
       }
 
       // try to find a component with any variant
       if (aggregates.empty() && !componentAttributes.GetCvariantName().empty()) {
         componentAttributes.RemoveAttribute("Cvariant");
-        t->GetComponentAggregates(componentAttributes.GetAttributes(), aggregates);
+        t->GetComponentAggregates(componentAttributes, aggregates);
       }
 
     }
@@ -1601,7 +1601,7 @@ bool RteProject::AddTarget(const string& name, const map<string, string>& attrib
       targetAttributes.RemoveAttribute("Bversion");
     }
 
-    bool changed = target->SetAttributes(targetAttributes);
+    bool changed = target->CopyAttributes(targetAttributes);
     if (supported) {
       if (bNewTarget) {
         AddTargetInfo(name);

--- a/libs/rtemodel/src/RteTarget.cpp
+++ b/libs/rtemodel/src/RteTarget.cpp
@@ -582,6 +582,13 @@ void RteTarget::ProcessAttributes() // called from SetAttributes(), AddAttribute
 {
   if (m_bDestroy)
     return;
+
+  // set empty board name to filter-out board-specific items if device is selected
+  if(HasAttribute("Dname") &&
+    !HasAttribute("Bname")) {
+    AddAttribute("Bname", "");
+  }
+
   m_device = 0;
   RteModel *model = GetFilteredModel();
   if (!model)

--- a/libs/rtemodel/test/src/RteChkTest.cpp
+++ b/libs/rtemodel/test/src/RteChkTest.cpp
@@ -36,7 +36,7 @@ From DFP: 24\n\
 From BSP: 0\n\
 \n\
 Devices: 10\n\
-Boards: 14\n\
+Boards: 15\n\
 \n\
 completed\n";
 
@@ -53,7 +53,7 @@ completed\n";
   EXPECT_EQ(rteChk.GetPackCount(), 8);
   EXPECT_EQ(rteChk.GetComponentCount(), 60);
   EXPECT_EQ(rteChk.GetDeviceCount(), 10);
-  EXPECT_EQ(rteChk.GetBoardCount(), 14);
+  EXPECT_EQ(rteChk.GetBoardCount(), 15);
 
   string s = RteUtils::EnsureLf(ss.str());
   EXPECT_EQ(s, summary);

--- a/libs/rtemodel/test/src/RteItemTest.cpp
+++ b/libs/rtemodel/test/src/RteItemTest.cpp
@@ -262,4 +262,33 @@ TEST(RteItemTest, GetInstancePathName) {
   EXPECT_EQ(instanceFile, "MySolDir/.cmsis/MySolName+MyTarget.dbgconf");
 }
 
+TEST(RteTargetTest, ProcessAttributes_Bname) {
+  RteTarget target(nullptr, nullptr, "test", {});
+
+  // Bname is not set by default
+  EXPECT_FALSE(target.HasAttribute("Bname"));
+
+  // Bname is not set when no Dname
+  target.SetAttributes({{"Dfpu", "NO_FPU"}});
+  EXPECT_FALSE(target.HasAttribute("Bname"));
+  target.ClearAttributes();
+
+  // Bname is set to empty if Dname and no Bname
+  target.SetAttributes({{"Dname", "MyDevice"}});
+  EXPECT_TRUE(target.HasAttribute("Bname"));
+  EXPECT_EQ(target.GetAttribute("Bname"), "");
+  target.ClearAttributes();
+
+  // Bname only
+  target.SetAttributes({{"Bname", "MyBoard"}});
+  EXPECT_TRUE(target.HasAttribute("Bname"));
+  EXPECT_EQ(target.GetAttribute("Bname"), "MyBoard");
+  target.ClearAttributes();
+
+  // Bname with Dname
+  target.SetAttributes({{"Bname", "MyBoard"}, {"Dname", "MyDevice"}});
+  EXPECT_TRUE(target.HasAttribute("Bname"));
+  EXPECT_EQ(target.GetAttribute("Bname"), "MyBoard");
+}
+
 // end of RteItemTest.cpp

--- a/libs/rtemodel/test/src/RteModelTest.cpp
+++ b/libs/rtemodel/test/src/RteModelTest.cpp
@@ -433,7 +433,7 @@ TEST_F(RteModelPrjTest, LoadCprj) {
   EXPECT_EQ(boardName, "RteTest Test board");
   // get layers
   auto& allLayerDescriptors = rteKernel.GetGlobalModel()->GetLayerDescriptors();
-  EXPECT_EQ(allLayerDescriptors.size(), 10);
+  EXPECT_EQ(allLayerDescriptors.size(), 13);
   auto& filteredLayerDescriptors = activeTarget->GetFilteredModel()->GetLayerDescriptors();
   EXPECT_EQ(filteredLayerDescriptors.size(), 8);
 
@@ -1077,7 +1077,7 @@ TEST_F(RteModelPrjTest, LoadCprjM4) {
   EXPECT_TRUE(boardName.empty());
   // get layers
   auto& allLayerDescriptors = rteKernel.GetGlobalModel()->GetLayerDescriptors();
-  EXPECT_EQ(allLayerDescriptors.size(), 10);
+  EXPECT_EQ(allLayerDescriptors.size(), 13);
   auto& filteredLayerDescriptors = activeTarget->GetFilteredModel()->GetLayerDescriptors();
   EXPECT_EQ(filteredLayerDescriptors.size(), 7);
   ca = activeTarget->GetComponentAggregate("ARM::Device:Startup");
@@ -1160,7 +1160,7 @@ TEST_F(RteModelPrjTest, LoadCprjM4_Board) {
   EXPECT_EQ(boardName, "RteTest CM4 board");
   // get layers
   auto& allLayerDescriptors = rteKernel.GetGlobalModel()->GetLayerDescriptors();
-  EXPECT_EQ(allLayerDescriptors.size(), 10);
+  EXPECT_EQ(allLayerDescriptors.size(), 13);
   auto& filteredLayerDescriptors = activeTarget->GetFilteredModel()->GetLayerDescriptors();
   EXPECT_EQ(filteredLayerDescriptors.size(), 7);
 

--- a/libs/xmltree/include/XmlItem.h
+++ b/libs/xmltree/include/XmlItem.h
@@ -47,13 +47,13 @@ public:
    * @brief parametrized constructor
    * @param tag XML tag
   */
-  XmlItem(const std::string& tag) : m_tag(tag), m_lineNumber(0) {};
+  explicit XmlItem(const std::string& tag) : m_tag(tag), m_lineNumber(0) {};
 
   /**
    * @brief parametrized constructor to instantiate with given attributes
    * @param attributes collection as key to value pairs
   */
-  XmlItem(const std::map<std::string, std::string>& attributes) : m_attributes(attributes), m_lineNumber(0) {};
+  explicit XmlItem(const std::map<std::string, std::string>& attributes) : m_attributes(attributes), m_lineNumber(0) {};
 
   /**
    * @brief virtual destructor
@@ -163,7 +163,7 @@ public:
    * @param attributes instance of XmlItem containing attributes to assign
    * @return true if attributes are set
   */
-  bool SetAttributes(const XmlItem &attributes);
+  bool CopyAttributes(const XmlItem &attributes);
 
   /**
    * @brief assign specified attribute value from supplied object to this one

--- a/libs/xmltree/src/XmlItem.cpp
+++ b/libs/xmltree/src/XmlItem.cpp
@@ -102,7 +102,7 @@ bool XmlItem::SetAttributes(const map<string, string>& attributes)
 }
 
 
-bool XmlItem::SetAttributes(const XmlItem& attributes)
+bool XmlItem::CopyAttributes(const XmlItem& attributes)
 {
   return SetAttributes(attributes.GetAttributes());
 }

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -317,6 +317,13 @@
       <require Bname="RteTest Dummy board" Bvendor="Keil" Brevision="1.2.3"/>
     </condition>
 
+    <condition id="AnyBoard">
+      <description>Test component filtering on Dummy any Board</description>
+      <require Dvendor="ARM:82" Dname="*ARMCM*"/>
+      <require Bname="Any Board" Bvendor="Keil" Brevision="1.2.3"/>
+    </condition>
+
+
     <condition id="BoardDependent">
       <description>Checks board dependency</description>
       <accept condition="BoardTest1"/>
@@ -549,6 +556,11 @@
       <mountedDevice    deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM0_Dual"/>
       <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM4_NOFP"/>
     </board>
+    <board name="Any Board" vendor="Keil" revision="1.2.3">
+      <description>Board for AnyBoard Tests</description>
+      <mountedDevice    deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM3"/>
+      <compatibleDevice deviceIndex="0" Dvendor="ARM:82" Dname="RteTest_ARMCM3"/>
+    </board>
   </boards>
 
   <csolution>
@@ -560,6 +572,15 @@
     </clayer>
     <clayer name="Board3" type="Board" file="Layers/board3.clayer.yml" condition="BoardTest3">
       <description>"Test board layer three"</description>
+    </clayer>
+    <clayer name="AnyBoard1" type="Board" file="Layers/board1.clayer.yml" condition="AnyBoard">
+      <description>"Test any board layer 1"</description>
+    </clayer>
+    <clayer name="AnyBoard2" type="Board" file="Layers/board2.clayer.yml" condition="AnyBoard">
+      <description>"Test any board layer 2"</description>
+    </clayer>
+    <clayer name="AnyBoard3" type="Board" file="Layers/board3.clayer.yml" condition="AnyBoard">
+      <description>"Test any board layer 3"</description>
     </clayer>
     <template name="Board1Template" file="Templates/board1.csolution.yml" condition="BoardTest1">
       <description>"Test board Template one"</description>

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -756,7 +756,7 @@ bool ProjMgr::RunConvert(const std::string& csolution, const std::string& active
   if (!csolution.empty()) {
     InitSolution(csolution, activeTargetSet, updateRte);
   }
-  
+
   // Configure
   bool Success = Configure();
 
@@ -1090,8 +1090,8 @@ bool ProjMgr::RunListLayers(void) {
 
   // Step3: Detect layers and list them
   vector<string> layers;
-  error = !m_worker.ListLayers(layers, m_clayerSearchPath, m_failedContext);
-  if (error) {
+  if (!m_worker.ListLayers(layers, m_clayerSearchPath, m_failedContext)) {
+    error = true;
     for (const string& context : m_failedContext) {
       ProjMgrLogger::Get().Error("no compatible software layer found. Review required connections of the project", context);
     }

--- a/tools/projmgr/test/data/TestLayers/genericlayers.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/genericlayers.csolution.yml
@@ -13,6 +13,7 @@ solution:
       device: :cm0_core0
     - type: AnyBoard
       device: RteTest_ARMCM3
+      board: Any Board
     - type: BoardSpecific
       board: RteTest board listing
 

--- a/tools/projmgr/test/data/TestLayers/variables-notdefined.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/variables-notdefined.csolution.yml
@@ -9,6 +9,7 @@ solution:
   target-types:
     - type: TargetType
       device: RteTest_ARMCM0
+      board: RteTest Dummy board
 
   projects:
     - project: variables-notdefined.cproject.yml

--- a/tools/projmgr/test/data/TestProject/test_component_csub.cproject.yml
+++ b/tools/projmgr/test/data/TestProject/test_component_csub.cproject.yml
@@ -2,6 +2,7 @@
 
 project:
   device: RteTest_ARMCM0
+  board: RteTest Test board
   compiler: AC6
   components:
     - component: Board:Test:Rev1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/layer/linker.clayer.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/layer/linker.clayer.yml
@@ -4,6 +4,7 @@ layer:
 
   components:
     - component: Board:Test:Rev1
+      not-for-context: +RteTest_ARMCM3
     - component: Device:Startup&RteTest Startup
       for-context: [.PriorityRegions, .PriorityDefines, .Debug_GCC]
     - component: RteTest:CORE

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+gab7ac463
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.AutoGen+RteTest_ARMCM3
@@ -26,11 +26,9 @@ build:
     - _RTE_
   add-path:
     - ../data/TestSolution/LinkerOptions/RTE/_AutoGen_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
     - ../data/TestSolution/LinkerOptions/RTE/_AutoGen_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/AutoGen
@@ -40,14 +38,6 @@ build:
     - type: elf
       file: linker.axf
   components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -83,5 +73,4 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2023-11-15T14:22:43" tool="csolution 0.0.0+gab7ac463"/>
+  <created timestamp="2025-11-17T14:04:17" tool="csolution 0.0.0+ga8747d9a"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -20,7 +20,6 @@
   </target>
 
   <components>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.2.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+ge3c3a1b8
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.Debug_AC6+RteTest_ARMCM3
@@ -20,17 +20,11 @@ build:
       path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
   define:
     - ARMCM3
-    - _RTE_
   define-asm:
     - ARMCM3
-    - _RTE_
   add-path:
-    - ../data/TestSolution/LinkerOptions/RTE/_Debug_AC6_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
-    - ../data/TestSolution/LinkerOptions/RTE/_Debug_AC6_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/Debug_AC6
@@ -39,25 +33,11 @@ build:
   output:
     - type: elf
       file: linker.axf
-  components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
   linker:
     script: ../data/TestSolution/LinkerOptions/linkerScript.sct
     regions: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h
-  constructed-files:
-    - file: ../data/TestSolution/LinkerOptions/RTE/_Debug_AC6_RteTest_ARMCM3/RTE_Components.h
-      category: header
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
-      components:
-        - component: ARM::Board:Test:Rev1@1.1.1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2023-04-21T15:26:17" tool="csolution 0.0.0+g036d6ac8"/>
+  <created timestamp="2025-11-17T12:11:39" tool="csolution 0.0.0+ga8747d9a"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -18,9 +18,5 @@
     <output elf="linker.axf" intdir="tmp/linker/RteTest_ARMCM3/Debug_AC6" name="linker" outdir="out/linker/RteTest_ARMCM3/Debug_AC6" rtedir="../data/TestSolution/LinkerOptions/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestSolution/LinkerOptions/linkerScript.sct" regions="../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h"/>
   </target>
-
-  <components>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
-  </components>
 </cprj>
 

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+ge3c3a1b8
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.Debug_GCC+RteTest_ARMCM3
@@ -26,11 +26,9 @@ build:
     - _RTE_
   add-path:
     - ../data/TestSolution/LinkerOptions/RTE/_Debug_GCC_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
     - ../data/TestSolution/LinkerOptions/RTE/_Debug_GCC_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/Debug_GCC
@@ -40,14 +38,6 @@ build:
     - type: elf
       file: linker.elf
   components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -94,5 +84,4 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2023-04-21T15:26:17" tool="csolution 0.0.0+g036d6ac8"/>
+  <created timestamp="2025-11-17T12:11:39" tool="csolution 0.0.0+ga8747d9a"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -22,7 +22,6 @@
   </target>
 
   <components>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3" rtedir="../data/TestSolution/LinkerOptions/layer/RTE">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/GCC/gcc_arm.ld" version="2.2.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+gab7ac463
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.FromComponent+RteTest_ARMCM3
@@ -26,11 +26,9 @@ build:
     - _RTE_
   add-path:
     - ../data/TestSolution/LinkerOptions/RTE/_FromComponent_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
     - ../data/TestSolution/LinkerOptions/RTE/_FromComponent_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/FromComponent
@@ -40,14 +38,6 @@ build:
     - type: elf
       file: linker.axf
   components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -82,5 +72,4 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cprj
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cprj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <cprj schemaVersion="2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="CPRJ.xsd">
-  <created timestamp="2023-11-15T14:21:58" tool="csolution 0.0.0+gab7ac463"/>
+  <created timestamp="2025-11-17T13:50:06" tool="csolution 0.0.0+ga8747d9a"/>
 
   <info isLayer="false">
     <description>Automatically generated project</description>
@@ -20,7 +20,6 @@
   </target>
 
   <components>
-    <component Cclass="Board" Cgroup="Test" Csub="Rev1" Cvendor="ARM" Cversion="1.1.1"/>
     <component Cclass="Device" Cgroup="Startup" Cvariant="RteTest Startup" Cvendor="ARM" Cversion="2.0.3">
       <file attr="config" category="linkerScript" name="Device/ARM/ARMCM3/Source/ARM/ARMCM3_ac6.sct" version="1.2.0"/>
       <file attr="config" category="sourceC" name="Device/ARM/ARMCM3/Source/startup_ARMCM3.c" version="2.0.3"/>

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+g538e263a
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.PriorityDefines+RteTest_ARMCM3
@@ -26,11 +26,9 @@ build:
     - _RTE_
   add-path:
     - ../data/TestSolution/LinkerOptions/RTE/_PriorityDefines_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
     - ../data/TestSolution/LinkerOptions/RTE/_PriorityDefines_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/PriorityDefines
@@ -40,14 +38,6 @@ build:
     - type: elf
       file: linker.axf
   components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -107,7 +97,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
         - component: RteTest:CORE(API)

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
@@ -1,5 +1,5 @@
 build:
-  generated-by: csolution version 0.0.0+g538e263a
+  generated-by: csolution version 0.0.0+ga8747d9a
   solution: ../data/TestSolution/LinkerOptions/linker.csolution.yml
   project: ../data/TestSolution/LinkerOptions/linker.cproject.yml
   context: linker.PriorityRegions+RteTest_ARMCM3
@@ -26,11 +26,9 @@ build:
     - _RTE_
   add-path:
     - ../data/TestSolution/LinkerOptions/RTE/_PriorityRegions_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
     - ../data/TestSolution/LinkerOptions/RTE/_PriorityRegions_RteTest_ARMCM3
-    - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: tmp/linker/RteTest_ARMCM3/PriorityRegions
@@ -40,14 +38,6 @@ build:
     - type: elf
       file: linker.axf
   components:
-    - component: ARM::Board:Test:Rev1@1.1.1
-      condition: BoardTest1
-      from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Board:Test:Rev1
-      files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM0/Include/ARMCM0.h
-          category: header
-          version: 1.1.1
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -105,7 +95,6 @@ build:
       packs:
         - pack: ARM::RteTest_DFP@0.2.0
       components:
-        - component: ARM::Board:Test:Rev1@1.1.1
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
         - component: RteTest:CORE(API)

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -323,8 +323,8 @@ TEST_F(ProjMgrRpcTests, RpcBoardListNoContext) {
 
   EXPECT_TRUE(responses[1]["result"]["success"]);
   auto boardList = responses[1]["result"]["boards"];
-  EXPECT_EQ(boardList.size(), 14);
-  auto b0 = boardList[0];
+  EXPECT_EQ(boardList.size(), 15);
+  auto b0 = boardList[1];
   EXPECT_EQ(b0["id"], "Keil::RteTest board listing:Rev.C");
   EXPECT_EQ(b0["pack"], "ARM::RteTestBoard@0.1.0");
   EXPECT_FALSE(b0.contains("description"));
@@ -360,8 +360,8 @@ TEST_F(ProjMgrRpcTests, RpcBoardListContext) {
 
   EXPECT_TRUE(responses[2]["result"]["success"]);
   auto boardList = responses[2]["result"]["boards"];
-  EXPECT_EQ(boardList.size(), 11);
-  auto b0 = boardList[0];
+  EXPECT_EQ(boardList.size(), 12);
+  auto b0 = boardList[1];
   EXPECT_EQ(b0["id"], "Keil::RteTest board test revision:Rev1");
   EXPECT_EQ(b0["pack"], "ARM::RteTest_DFP@0.2.0");
   EXPECT_FALSE(b0.contains("description"));
@@ -566,7 +566,7 @@ TEST_F(ProjMgrRpcTests, RpcSelectComponent) {
   EXPECT_EQ("ARM::RteTest:CORE", validation["conditions"][0]["aggregates"][0]);
 
   EXPECT_FALSE(responses[3]["result"]["classes"][0].contains("result"));
-  string res = responses[3]["result"]["classes"][2]["result"];
+  string res = responses[3]["result"]["classes"][1]["result"];
   EXPECT_EQ(res, "SELECTABLE");
 
   EXPECT_TRUE(responses[4]["result"]["success"]); // components resolved

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -1641,7 +1641,7 @@ TEST_F(ProjMgrUnitTests, ListLayersCompatible) {
   argv[7] = (char*)"-d";
   EXPECT_EQ(0, RunProjMgr(8, argv, m_envp));
 
-  const string& expectedErrStr = "\
+   const string& expectedErrStr = "\
 debug csolution: check for context 'genericlayers.CompatibleLayers\\+AnyBoard'\n\
 \n\
 check combined connections:\n\
@@ -1680,10 +1680,8 @@ clayer of type 'TestVariant' was uniquely found:\n\
   .*/ARM/RteTest_DFP/0.2.0/Layers/testvariant.clayer.yml\n\
 \n\
 ";
-
   const string& errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(regex_match(errStr, regex(expectedErrStr)));
-
   const string& expectedOutStr = "\
 info csolution: valid configuration #1: \\(context 'genericlayers.CompatibleLayers\\+AnyBoard'\\)\n\
   .*/TestLayers/genericlayers.cproject.yml\n\
@@ -1705,7 +1703,6 @@ info csolution: valid configuration #3: \\(context 'genericlayers.CompatibleLaye
 .*/ARM/RteTest_DFP/0.2.0/Layers/board3.clayer.yml \\(layer type: Board\\)\n\
 .*/ARM/RteTest_DFP/0.2.0/Layers/testvariant.clayer.yml \\(layer type: TestVariant\\)\n\
 ";
-
   const string& outStr = streamRedirect.GetOutString();
   EXPECT_TRUE(regex_match(outStr, regex(expectedOutStr)));
 }
@@ -2318,10 +2315,6 @@ TEST_F(ProjMgrUnitTests, LayerVariablesNotDefined) {
   string expectedErrStr = ".*\
 error csolution: undefined variables in variables-notdefined.csolution.yml:.*\
   - \\$NotDefined\\$.*\
-  .*/ARM/RteTest_DFP/0.2.0/Layers/board1.clayer.yml \\(layer type: Board\\).*\
-  .*/ARM/RteTest_DFP/0.2.0/Layers/board2.clayer.yml \\(layer type: Board\\).*\
-  .*/ARM/RteTest_DFP/0.2.0/Layers/board3.clayer.yml \\(layer type: Board\\).*\
-no valid combination of clayers was found.*\
 ";
 
   string errStr = streamRedirect.GetErrorString();
@@ -2354,14 +2347,12 @@ TEST_F(ProjMgrUnitTests, LayerVariablesNotDefined_SearchPath) {
   argv[5] = (char*)"--clayer-path";
   argv[6] = (char*)clayerSearchPath.c_str();
   argv[7] = (char*)"-d";
-  EXPECT_EQ(0, RunProjMgr(8, argv, m_envp));
+  EXPECT_EQ(1, RunProjMgr(8, argv, m_envp));
 
   const string& expectedErrStr = ".*\
 error csolution: undefined variables in variables-notdefined.csolution.yml:.*\
   - \\$NotDefined\\$.*\
 debug csolution: check for context \\'variables-notdefined\\.BuildType\\+TargetType\\'.*\
-clayer of type 'Board' was uniquely found:\
-  .*/TestLayers/variables/target1.clayer.yml.*\
 ";
 
   string errStr = streamRedirect.GetErrorString();
@@ -7009,7 +7000,7 @@ Board1Template \\(ARM::RteTest_DFP@0.2.0\\)\n\
 
   // list board's compatible template
   const string& csolution = testinput_folder + "/Examples/solution.csolution.yml";
-  const string expected = 
+  const string expected =
   argv[3] = (char*)csolution.c_str();
   argv[4] = (char*)"--active";
   argv[5] = (char*)"TestBoard";

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -469,7 +469,7 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessComponents_Csub) {
   EXPECT_TRUE(context.components.find("ARM::Board:Test:Rev1@1.1.1") != context.components.end());
 
   auto errorMap = ProjMgrLogger::Get().GetErrors();
-  EXPECT_EQ("no component was found with identifier 'Board:Test'", errorMap["test_component_csub"][0]);
+  EXPECT_EQ("no component was found with identifier 'Board:Test'\n  did you mean 'Board:Test:Rev1'?", errorMap["test_component_csub"][0]);
   EXPECT_EQ("no component was found with identifier 'Device:Startup'\n  did you mean 'Device:Startup&RteTest Startup'?",
     errorMap["test_component_csub"][1]);
  }


### PR DESCRIPTION
* Set Bname empty in RteTarget ProcessAttributes

* Fix RPC tests

* Remove ambiguity in XmlItem::SetAttributes()

by making two XmlItem constructors explicit

* Make ubuntu C++ compiler happy

* Try to fix the tests

* Fix test data end test

* Change one overload of SetAttributes to CopyAttributes

To satisfy compiler.