### PR TITLE
[projmgr] Fixes for RPC methods (#1352)

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1127,6 +1127,8 @@ public:
     m_missingFiles.clear();
     m_types = {};
     m_activeTargetType.clear();
+    m_undefCompiler = false;
+    m_isSetupCommand = false;
   };
 
 protected:

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -714,6 +714,10 @@ RpcArgs::ConvertSolutionResult RpcHandler::ConvertSolution(const string& solutio
     if (m_worker.HasVarDefineError()) {
       const auto& vars = m_worker.GetUndefLayerVars();
       result.undefinedLayers = StrVec(vars.begin(), vars.end());
+      const auto& selectCompiler = m_worker.GetSelectableCompilers();
+      if (!selectCompiler.empty()) {
+        result.selectCompiler = selectCompiler;
+      }
       result.message = "Layer variables undefined, names can be found under 'undefinedLayers'";
     } else if (m_worker.HasCompilerDefineError()) {
       result.selectCompiler = m_worker.GetSelectableCompilers();
@@ -768,6 +772,9 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
             }
             if (!variable.file.empty()) {
               lv.file = variable.file;
+            }
+            if (!variable.description.empty()) {
+              lv.description = variable.description;
             }
             if (!variable.copyTo.empty()) {
               lv.copyTo = variable.copyTo;

--- a/tools/projmgr/test/data/TestLayers/ref/rpc-discover-layers.json
+++ b/tools/projmgr/test/data/TestLayers/ref/rpc-discover-layers.json
@@ -8,6 +8,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
             "copy-to": "path/to/config1",
+            "description": "Config1 Layer Description",
             "file": "config1.clayer.yml",
             "name": "Config1-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
@@ -23,6 +24,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config2.clayer.yml",
             "copy-to": "path/to/config2",
+            "description": "Config2 Layer Description",
             "file": "Layers/config2.clayer.yml",
             "name": "Config2-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
@@ -43,6 +45,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
             "copy-to": "path/to/config1",
+            "description": "Config1 Layer Description",
             "file": "config1.clayer.yml",
             "name": "Config1-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
@@ -58,6 +61,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config3.clayer.yml",
             "copy-to": "path/to/config3",
+            "description": "Config3 Layer Description",
             "file": "Layers/config3.clayer.yml",
             "name": "Config2-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
@@ -78,6 +82,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
             "copy-to": "path/to/config1",
+            "description": "Config1 Layer Description",
             "file": "config1.clayer.yml",
             "name": "Config1-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
@@ -93,6 +98,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config2.clayer.yml",
             "copy-to": "path/to/config2",
+            "description": "Config2 Layer Description",
             "file": "Layers/config2.clayer.yml",
             "name": "Config2-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",
@@ -113,6 +119,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config1.clayer.yml",
             "copy-to": "path/to/config1",
+            "description": "Config1 Layer Description",
             "file": "config1.clayer.yml",
             "name": "Config1-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0/Layers",
@@ -128,6 +135,7 @@
           {
             "clayer": "${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Layers/config3.clayer.yml",
             "copy-to": "path/to/config3",
+            "description": "Config3 Layer Description",
             "file": "Layers/config3.clayer.yml",
             "name": "Config2-Layer",
             "path": "${DEVTOOLS(packs)}/ARM/RteTest_DFP/0.2.0",

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -813,7 +813,8 @@ TEST_F(ProjMgrRpcTests, RpcDiscoverLayers) {
   auto responses = RunRpcMethods(requests);
 
   // valid configurations: compare response with golden reference
-  EXPECT_TRUE(CompareRpcResponse(responses[0], testinput_folder + "/TestLayers/ref/rpc-discover-layers.json"));
+  EXPECT_TRUE(CompareRpcResponse(responses[0], testinput_folder + "/TestLayers/ref/rpc-discover-layers.json"))
+    << "json response:\n" << ProjMgrTestEnv::StripAbsoluteFunc(responses[0].dump(2));
 
   // unknown active target set
   csolutionPath = testinput_folder + "/TestLayers/config.csolution.yml";


### PR DESCRIPTION
Related to https://github.com/ARM-software/vscode-cmsis-csolution/issues/285
Fixes for `ConvertSolution` and `DiscoverLayers` methods.