### PR TITLE
[projmgr] Clean-up processed contexts by solution reloading

### DIFF
--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -1286,6 +1286,9 @@ void ProjMgr::Clear() {
   m_worker.Clear();
   m_runDebug.Clear();
   ProjMgrLogger::Get().Clear();
+  m_processedContexts.clear();
+  m_allContexts.clear();
+  m_failedContext.clear();
 }
 
 void ProjMgr::InitSolution(const std::string& csolution, const std::string& activeTargetSet, const bool& updateRte) {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/2286
Complementary to https://github.com/Open-CMSIS-Pack/devtools/pull/2279

The problem could be reproduced via RPC by loading a solution without errors, then introducing yml syntax errors and reloading the solution.
`ProjMgr` member variables related to context processing must be cleaned-up when reloading a solution.