### PR TITLE
Add support for Microchip XC32 toolchain in the CMSIS toolbox

### DIFF
--- a/tools/buildmgr/cbuildgen/config/XC.5.0.0.cmake
+++ b/tools/buildmgr/cbuildgen/config/XC.5.0.0.cmake
@@ -1,0 +1,133 @@
+# This file maps the CMSIS project options to toolchain settings.
+#
+#   - Applies to toolchain: Microchip XC32 Compiler version 5.0.0 and greater
+
+set(AS "xc32-gcc")
+set(CC "xc32-gcc")
+set(CPP "xc32-gcc")
+set(CXX "xc32-g++")
+set(OC "xc32-objcopy")
+
+set(TOOLCHAIN_ROOT "${REGISTERED_TOOLCHAIN_ROOT}")
+set(TOOLCHAIN_VERSION "${REGISTERED_TOOLCHAIN_VERSION}")
+
+if(DEFINED TOOLCHAIN_ROOT)
+  set(PREFIX)
+  set(EXT)
+  
+  set(AS ${TOOLCHAIN_ROOT}/${PREFIX}${AS}${EXT})
+  set(CC ${TOOLCHAIN_ROOT}/${PREFIX}${CC}${EXT})
+  set(CPP ${TOOLCHAIN_ROOT}/${PREFIX}${CPP}${EXT})
+  set(CXX ${TOOLCHAIN_ROOT}/${PREFIX}${CXX}${EXT})
+  set(OC ${TOOLCHAIN_ROOT}/${PREFIX}${OC}${EXT})
+endif()
+
+# Environment variables
+
+if(NOT DEFINED ENV{DEVICE_ID})
+    message(FATAL_ERROR "Environment variable DEVICE_ID not defined!")
+endif()
+
+if(NOT DEFINED ENV{DFP_PATH})
+    message(FATAL_ERROR "Environment variable DFP_PATH not defined!")
+endif()
+
+set(DEVICE_ID $ENV{DEVICE_ID})
+set(DFP_PATH  $ENV{DFP_PATH})
+set(LINKER_SCRIPT "${DFP_PATH}/xc32/${DEVICE_ID}/${DEVICE_ID}.ld")
+
+# Helpers
+
+function(cbuild_set_option_flags lang option value flags)
+  if(NOT DEFINED ${option}_${lang}_FLAGS)
+    return()
+  endif()
+  list(FIND ${option}_VALUES "${value}" _index)
+  if (${_index} GREATER -1)
+    list(GET ${option}_${lang}_FLAGS ${_index} flag)
+    if(NOT flag STREQUAL "")
+      string(STRIP "${flag} ${${flags}}" ${flags})
+      set(${flags} "${${flags}}" PARENT_SCOPE)
+    endif()
+  elseif(NOT value STREQUAL "")
+    string(TOLOWER "${option}" _option)
+    message(FATAL_ERROR "unkown '${_option}' value '${value}' !")
+  endif()
+endfunction()
+
+function(cbuild_set_options_flags lang optimize debug warnings language flags)
+  set(tmp "")
+  cbuild_set_option_flags(${lang} OPTIMIZE "${optimize}" tmp)
+  cbuild_set_option_flags(${lang} DEBUG    "${debug}"    tmp)
+  cbuild_set_option_flags(${lang} WARNINGS "${warnings}" tmp)
+  if(lang STREQUAL "CC" OR lang STREQUAL "CXX")
+    cbuild_set_option_flags(${lang} LANGUAGE "${language}" tmp)
+  endif()
+  set(${flags} "${tmp}" PARENT_SCOPE)
+endfunction()
+
+
+set(OPTIMIZE_VALUES       "debug" "none" "balanced" "size" "speed" "minimal")
+set(OPTIMIZE_CC_FLAGS     "-Og"   "-O0"  "-O2"      "-Os" "-O3"   "-O1")
+set(OPTIMIZE_CXX_FLAGS    ${OPTIMIZE_CC_FLAGS})
+set(OPTIMIZE_LD_FLAGS     ${OPTIMIZE_CC_FLAGS})
+set(OPTIMIZE_ASM_FLAGS    ${OPTIMIZE_CC_FLAGS})
+
+set(DEBUG_VALUES          "on"    "off")
+set(DEBUG_CC_FLAGS        "-g"    "")
+set(DEBUG_CXX_FLAGS       "-g"    "")
+set(DEBUG_LD_FLAGS        "-g"    "")
+set(DEBUG_ASM_FLAGS       "-g"    "")
+
+set(WARNINGS_VALUES       "on"     "off"       "all")
+set(WARNINGS_CC_FLAGS     "-Wall"  "-w"        "-Wall -Wextra")
+set(WARNINGS_CXX_FLAGS    "-Wall"  "-w"        "-Wall -Wextra")
+set(WARNINGS_ASM_FLAGS    "-Wall"  "-w"        "-Wall -Wextra")
+set(WARNINGS_LD_FLAGS     ""       ""          "")
+
+set(LANGUAGE_VALUES       "c90"      "gnu90"      "c99"      "gnu99"      "c11"      "gnu11"        "c++98"      "gnu++98"      "c++03"      "gnu++03"      "c++11"      "gnu++11"      "c++14"      "gnu++14"      "c++17"      "gnu++17"     )
+set(LANGUAGE_CC_FLAGS     "-std=c90" "-std=gnu90" "-std=c99" "-std=gnu99" "-std=c11" "-std=gnu11"   ""           ""             ""           ""             ""           ""             ""           ""             ""           ""            )
+set(LANGUAGE_CXX_FLAGS    ""         ""           ""         ""           ""         ""             "-std=c++98" "-std=gnu++98" "-std=c++03" "-std=gnu++03" "-std=c++11" "-std=gnu++11" "-std=c++14" "-std=gnu++14" "-std=c++17" "-std=gnu++17")
+
+# XC32 Processor/DFP flags
+set(XC32_COMMON_FLAGS "-mprocessor=${DEVICE_ID} -mdfp=${DFP_PATH}")
+
+# C Compiler
+
+set(CC_OPTIONS_FLAGS "")
+cbuild_set_options_flags(CC "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" "${LANGUAGE_CC}" CC_OPTIONS_FLAGS)
+set(CMAKE_C_FLAGS "${XC32_COMMON_FLAGS} ${CC_OPTIONS_FLAGS}")
+
+
+# C++ Compiler
+
+set(CXX_OPTIONS_FLAGS "")
+cbuild_set_options_flags(CXX "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" "${LANGUAGE_CXX}" CXX_OPTIONS_FLAGS)
+set(CMAKE_CXX_FLAGS "${XC32_COMMON_FLAGS} ${CXX_OPTIONS_FLAGS}")
+
+# Assembler
+
+set(ASM_OPTIONS_FLAGS "")
+cbuild_set_options_flags(ASM "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" "" ASM_OPTIONS_FLAGS)
+set(CMAKE_ASM_FLAGS "${XC32_COMMON_FLAGS} ${ASM_OPTIONS_FLAGS}")
+
+# Linker
+
+set(LD_OPTIONS_FLAGS "")
+cbuild_set_options_flags(LD "${OPTIMIZE}" "${DEBUG}" "${WARNINGS}" "" LD_OPTIONS_FLAGS)
+set(CMAKE_EXE_LINKER_FLAGS "${XC32_COMMON_FLAGS} ${LD_OPTIONS_FLAGS} -T ${LINKER_SCRIPT}")
+
+# ELF to HEX conversion
+set(ELF2HEX  -O ihex   "${OUT_DIR}/$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>.elf" "${OUT_DIR}/${HEX_FILE}")
+
+# ELF to BIN conversion
+set(ELF2BIN  -O binary "${OUT_DIR}/$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>.elf" "${OUT_DIR}/${BIN_FILE}")
+
+# Set CMake variables for toolchain initialization
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(CMAKE_ASM_COMPILER "${AS}")
+set(CMAKE_C_COMPILER "${CC}")
+set(CMAKE_CXX_COMPILER "${CXX}")
+set(CMAKE_OBJCOPY "${OC}")

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -187,7 +187,7 @@
     "CompilerType": {
       "title":"compiler:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#compiler",
       "type": "string",
-      "pattern": "^(GCC|CLANG|AC6|IAR|CLANG_TI)(@(>=)?([0-9]+\\.[0-9]+\\.[0-9]+((\\+|\\-)[a-zA-Z0-9_\\.\\+-]+)?))?$",
+      "pattern": "^(GCC|CLANG|AC6|IAR|CLANG_TI|XC)(@(>=)?([0-9]+\\.[0-9]+\\.[0-9]+((\\+|\\-)[a-zA-Z0-9_\\.\\+-]+)?))?$",
       "description": "Compiler toolchain to be used, optionally with version, for example AC6@6.23.0."
     },
     "ConsumesProvidesType": {


### PR DESCRIPTION
This PR aims to add support for the [XC32 Toolchain](https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc32) and provide a solution for the issue found [here](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/467).