### PR TITLE
[projmgr] Fix `telnet` port numbering

### DIFF
--- a/tools/projmgr/include/ProjMgrRunDebug.h
+++ b/tools/projmgr/include/ProjMgrRunDebug.h
@@ -227,6 +227,7 @@ protected:
     const std::map<std::string, RteDeviceProperty*>& pnames);
   void CollectTelnetOptions(const ContextItem& context, DebugAdapterItem& adapter,
     const std::map<std::string, RteDeviceProperty*>& pnames);
+  void SetTelnetPort(TelnetOptionsItem& item, unsigned long long& port, std::set<unsigned long long>& usedPorts);
   CustomItem& CustomMapFind(std::vector<std::pair<std::string, CustomItem>>& customMap, const std::string& key);
   void MergeCustomItems(const CustomItem& src, CustomItem& dst);
 };

--- a/tools/projmgr/test/data/TestRunDebug/telnet.csolution.yml
+++ b/tools/projmgr/test/data/TestRunDebug/telnet.csolution.yml
@@ -54,6 +54,20 @@ solution:
             name: J-Link Server
             start-pname: cm0_core1
 
+        - set: CustomPorts
+          images:
+            - project-context: core0
+            - project-context: core1
+          debugger:
+            name: CMSIS-DAP
+            telnet:
+              - mode: monitor
+                pname: cm0_core1
+                port: 1234
+              - mode: monitor
+                pname: cm0_core0
+                port: 5678
+
         - set: Warnings
           images:
             - project-context: core0

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -6904,6 +6904,20 @@ R"(- mode: off
   pname: cm0_core1
   port: 4444)", sstream3.str());
 
+  // dual core with custom port numbers
+  argv[6] = (char*)"DualCore@CustomPorts";
+  EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
+  const YAML::Node& cbuildrun4 = YAML::LoadFile(testoutput_folder + "/out/telnet+DualCore.cbuild-run.yml");
+  stringstream sstream4;
+  sstream4 << cbuildrun4["cbuild-run"]["debugger"]["telnet"];
+  EXPECT_EQ(
+    R"(- mode: monitor
+  pname: cm0_core0
+  port: 5678
+- mode: monitor
+  pname: cm0_core1
+  port: 1234)", sstream4.str());
+
   // warnings
   StdStreamRedirect streamRedirect;
   argv[6] = (char*)"DualCore@Warnings";


### PR DESCRIPTION
Reported by @RobertRostohar: user specified telnet port numbers for non-start-pnames were not being respected.