### PR TITLE
Hover info on Setup node and correct error type (#1385)

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -1745,7 +1745,7 @@
     "SetupType": {
       "type": "object",
       "properties": {
-        "setup":           {
+        "setup": {
           "title": "setup:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#setups",
           "type": "string",
           "description": "Description of the setup."
@@ -1773,7 +1773,7 @@
         "undefine":        { "$ref": "#/definitions/UndefinesType" },
         "warnings":        { "$ref": "#/definitions/WarningsType" }
       },
-      "oneOf": [
+      "allOf": [
         { "$ref": "#/definitions/TypeListMutualExclusion" }
       ],
       "additionalProperties": false
@@ -1851,7 +1851,7 @@
         "not-for-context": { "$ref": "#/definitions/NotForContext" },
         "for-compiler":    { "$ref": "#/definitions/CompilersType" }
       },
-      "oneOf": [
+      "allOf": [
         { "$ref": "#/definitions/TypeListMutualExclusion" }
       ],
       "additionalProperties": false


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/devtools/issues/2315

**VS Code uses an internal schema resolution engine to determine what hover text to show. When schemas have ambiguous matches (e.g. oneOf, $ref, or combinators), the language server may not choose a single effective path so it doesn’t show specific description/title. Also the language service has known limitations around hover text.**

In the specific case of `setup `node since the change include use of `allof `instead of `oneof`. It shouldn't make any change since we have only of ref to be complaint with.