### PR TITLE
Process pack requirements for a context only once (#1392)

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -1654,6 +1654,10 @@ vector<string> ProjMgrWorker::FindMatchingPackIdsInCbuildPack(const PackItem& ne
 }
 
 bool ProjMgrWorker::ProcessPackages(ContextItem& context, const string& packRoot) {
+
+  if(!context.packRequirements.empty()) {
+    return true; // already processed for context
+  }
   vector<PackItem> packRequirements;
 
   // Solution package requirements


### PR DESCRIPTION
Fixes problem of duplicated pack references when reporting packs over RPC