### PR TITLE
[projmgr] Fix `for-compiler` check and error message (#1409)

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1143,6 +1143,7 @@ public:
     m_missingFiles.clear();
     m_types = {};
     m_activeTargetType.clear();
+    m_missingToolchains.clear();
     m_undefCompiler = false;
     m_isSetupCommand = false;
   };
@@ -1303,6 +1304,7 @@ protected:
   template<class T> bool CheckFilter(const std::string& filter, const T& item);
   void ResolvePackRequirement(ContextItem& context, const PackItem& packEntry, bool ignoreCBuildPack);
   void FormatResolvedPackIds();
+  void RetrieveToolchainConfigFiles();
 };
 
 #endif  // PROJMGRWORKER_H

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5221,7 +5221,7 @@ warning csolution: build-type '.UnknownBuild' does not exist in solution\n\
 warning csolution: target-type '+Debug' does not exist in solution, did you mean '.Debug'?\n\
 warning csolution: target-type '+MappedDebug' does not exist in solution, did you mean '.MappedDebug'?\n\
 warning csolution: target-type '+UnknownTarget' does not exist in solution\n\
-warning csolution: compiler 'Ac6' is not supported\n\
+warning csolution: 'for-compiler: Ac6' is not supported\n\
 ";
   auto errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(errStr.find(expected) != string::npos);


### PR DESCRIPTION
Ensure `m_toolchainConfigFiles` are already retrieved when checking `for-compiler` entries.
Extend error message to evidence it's a `for-compiler` mismatch rather than `compiler`.
Clean-up relevant variables when disposing context.