### PR TITLE
Make behavior of pack filtering consistent in case of all packs enabled (#1411)

### DIFF
--- a/libs/rtemodel/src/RtePackage.cpp
+++ b/libs/rtemodel/src/RtePackage.cpp
@@ -6,7 +6,7 @@
 */
 /******************************************************************************/
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1139,7 +1139,7 @@ bool RtePackageFilter::AreAllExcluded() const
 
 bool RtePackageFilter::IsUseAllPacks() const
 {
-  return m_bUseAllPacks && m_selectedPacks.empty() && m_latestPacks.empty();
+  return m_bUseAllPacks;
 }
 
 bool RtePackageFilter::IsPackageSelected(const string& packId) const
@@ -1170,10 +1170,10 @@ bool RtePackageFilter::IsPackageFiltered(RtePackage* pack) const
 
 bool RtePackageFilter::IsPackageFiltered(const string& packId) const
 {
+  if(IsPackageSelected(packId)) { // pack is explicitly selected => filtered
+    return true;
+  }
   if (!IsUseAllPacks()) {
-    if (IsPackageSelected(packId))
-      return true;
-
     string commonId = RtePackage::CommonIdFromId(packId);
     if (m_latestPacks.find(commonId) == m_latestPacks.end())
       return false;
@@ -1185,8 +1185,9 @@ bool RtePackageFilter::IsPackageFiltered(const string& packId) const
       }
     }
   }
-  if (m_latestInstalledPacks.find(packId) != m_latestInstalledPacks.end())
+  if(m_latestInstalledPacks.find(packId) != m_latestInstalledPacks.end()) {
     return true;
+  }
   return false;
 }
 

--- a/libs/rteutils/include/CollectionUtils.h
+++ b/libs/rteutils/include/CollectionUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,6 +13,7 @@
 #include <vector>
 #include <set>
 #include <string>
+#include <optional>
 
 /**
  * @brief Returns value stored in a map for a given key or default value if no entry is found
@@ -85,6 +86,37 @@ auto key_set(const M& m) {
     for (const auto& kv : m)
         ks.insert(kv.first);
     return ks;
+}
+
+/**
+ * @brief Finds the first element in a container that satisfies a predicate.
+ *
+ * Searches the container in forward order and returns a reference to the
+ * first element for which the predicate returns true.
+ *
+ * @tparam Container A container type providing begin()/end() and value_type.
+ * @tparam Predicate A callable with signature bool(const value_type&).
+ *
+ * @param c     Container to search.
+ * @param pred  Predicate applied to each element.
+ *
+ * @return std::optional containing a reference to the matching element,
+ *         or std::nullopt if no such element is found.
+ *
+ * @note The returned reference remains valid only as long as the container
+ *       is not structurally modified (e.g. erase, reallocation).
+ *
+ * @complexity Linear in the size of the container.
+ */
+template <typename Container, typename Predicate>
+auto find_item(Container& c, Predicate pred)
+    -> std::optional<std::reference_wrapper<typename Container::value_type>>
+{
+    auto it = std::find_if(std::begin(c), std::end(c), pred);
+    if(it == std::end(c)) {
+      return std::nullopt;
+    }
+    return *it;   // reference, not a copy
 }
 
 /**

--- a/libs/rteutils/test/src/RteUtilsTest.cpp
+++ b/libs/rteutils/test/src/RteUtilsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -497,6 +497,15 @@ TEST(RteUtils, CollectionUtils)
 
   EXPECT_EQ(*get_or_default(strToPtr, "two", sDefault), '2');
   EXPECT_EQ(*get_or_default(strToPtr, "four", sDefault), 'd');
+
+  auto notFound = find_item(intToInt, [](const auto& kv) {return kv.second < 5; });
+  EXPECT_FALSE(!!notFound);
+  auto foundInt = find_item(intToInt, [](const auto& kv) {return kv.second > 5; });
+  ASSERT_TRUE(!!foundInt);
+  auto& [key, val] = foundInt->get();
+  EXPECT_EQ(key, 1);
+  EXPECT_EQ(val, 10);
+
 }
 
 TEST(RteUtils, ExpandAccessSequences) {

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -327,18 +327,17 @@ void RpcHandler::UpdateFilter(const string& context, RteTarget* rteTarget, bool 
   StoreSelectedComponents(rteTarget, selectedComponents);
 
   RtePackageFilter packFilter;
-  if(!all) {
-    // construct and apply filter
-    // use resolved pack ID's from selected references
-    set<string> packIds;
-    for(auto& ref : GetPackReferences(context)) {
-      if(ref.selected && ref.resolvedPack.has_value()) {
-        packIds.insert(ref.resolvedPack.value());
-      }
+  // construct and apply filter
+  // use resolved pack ID's from selected references
+  set<string> packIds;
+  for(auto& ref : GetPackReferences(context)) {
+    if(ref.selected && ref.resolvedPack.has_value()) {
+      packIds.insert(ref.resolvedPack.value());
     }
-    packFilter.SetSelectedPackages(packIds);
-    packFilter.SetUseAllPacks(false);
   }
+  packFilter.SetSelectedPackages(packIds);
+  packFilter.SetUseAllPacks(all);
+
   // only update filter if differs from current state
   if(!packFilter.IsEqual(rteTarget->GetPackageFilter())) {
     rteTarget->SetPackageFilter(packFilter);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -567,11 +567,13 @@ bool ProjMgrWorker::LoadPacks(ContextItem& context) {
   set<string> selectedPacks;
   const bool allOrLatest = (m_loadPacksPolicy == LoadPacksPolicy::ALL) || (m_loadPacksPolicy == LoadPacksPolicy::LATEST);
   for (const auto& pack : m_loadedPacks) {
-    if (allOrLatest || (context.pdscFiles.find(pack->GetPackageFileName()) != context.pdscFiles.end())) {
+    if (context.pdscFiles.find(pack->GetPackageFileName()) != context.pdscFiles.end()) {
       selectedPacks.insert(pack->GetPackageID());
     }
   }
   RtePackageFilter filter;
+   // use all packs is enabled by default, by default policy it should be disabled if selectedPacks is not empty
+  filter.SetUseAllPacks(allOrLatest || selectedPacks.empty());
   filter.SetSelectedPackages(selectedPacks);
   context.rteActiveTarget->SetPackageFilter(filter);
   context.rteActiveTarget->UpdateFilterModel();

--- a/tools/projmgr/test/data/TestSolution/test_pack_requirements.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/test_pack_requirements.csolution.yml
@@ -8,12 +8,16 @@ solution:
   build-types:
     - type: Debug
       compiler: AC6
+    - type: DebugOldDfp
+      compiler: AC6
     - type: Release
       compiler: GCC
 
   packs:
     - pack: ARM::RteTest
       for-context: .Debug
+    - pack: ARM::RteTest_DFP@0.1.1
+      for-context: .DebugOldDfp
     - pack: ARM::RteTest_DFP@>=0.2.0
       for-context: .Release
     - pack: ARM::RteTestRequired


### PR DESCRIPTION
* Make behavior of pack filtering consistent in case of all packs enabled

Filter to use all latest packs also includes all explicitly selected
Required by RPC and is consistent with csolution processing

* Update tools/projmgr/test/src/ProjMgrRpcTests.cpp

Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>

* Copyright and format

---------

Co-authored-by: Daniel Brondani <daniel.brondani@arm.com>