### PR TITLE
[projmgr] Add reference to `compile_commands.json` file into `cbuild.yml`

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -300,8 +300,8 @@
       "items": { "$ref": "#/definitions/ArtifactType" }
     },
     "ArtifactType": {
-      "enum": [ "elf", "hex", "bin", "lib", "cmse-lib", "map" ],
-      "description": "Output type: elf (default), hex, bin, lib, cmse-lib or map."
+      "enum": [ "elf", "hex", "bin", "lib", "cmse-lib", "map", "comp-db" ],
+      "description": "Output type: elf (default), hex, bin, lib, cmse-lib, map or comp-db."
     },
     "ArtifactsType": {
       "oneOf": [

--- a/tools/projmgr/src/ProjMgrCbuild.cpp
+++ b/tools/projmgr/src/ProjMgrCbuild.cpp
@@ -431,6 +431,13 @@ void ProjMgrCbuild::SetOutputNode(YAML::Node node, const ContextItem* context) {
       node.push_back(fileNode);
     }
   }
+  if (!context->imageOnly) {
+    // add reference to compilation database
+    YAML::Node compdb;
+    SetNodeValue(compdb[YAML_TYPE], "comp-db");
+    SetNodeValue(compdb[YAML_FILE], "compile_commands.json");
+    node.push_back(compdb);
+  }
 }
 
 void ProjMgrCbuild::SetLinkerNode(YAML::Node node, const ContextItem* context) {

--- a/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core0.Debug+MultiCore.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core0.Debug+MultiCore.cbuild-gen.yml
@@ -43,6 +43,8 @@ build-gen:
   output:
     - type: elf
       file: core0.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTestGenerator:Check Global Generator@0.9.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core1.Debug+MultiCore.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/MultiCore/core1.Debug+MultiCore.cbuild-gen.yml
@@ -43,6 +43,8 @@ build-gen:
   output:
     - type: elf
       file: core1.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTestGenerator:Check Global Generator@0.9.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+Board.cbuild.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+Board.cbuild.yml
@@ -60,6 +60,8 @@ build:
   output:
     - type: elf
       file: single-core.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:GlobalLevel@0.0.2
       from-pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild-gen.yml
@@ -30,6 +30,8 @@ build-gen:
   output:
     - type: elf
       file: single-core.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTestGenerator:Check Global Generator@0.9.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/SingleCore/single-core.Debug+CM0.cbuild.yml
@@ -36,6 +36,8 @@ build:
   output:
     - type: elf
       file: single-core.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:GlobalLevel@0.0.2
       from-pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/ns.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/ns.Debug+CM0.cbuild-gen.yml
@@ -31,6 +31,8 @@ build-gen:
   output:
     - type: elf
       file: ns.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTestGenerator:Check Global Generator@0.9.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/s.Debug+CM0.cbuild-gen.yml
+++ b/tools/projmgr/test/data/ExternalGenerator/ref/TrustZone/s.Debug+CM0.cbuild-gen.yml
@@ -33,6 +33,8 @@ build-gen:
       file: s.axf
     - type: cmse-lib
       file: s_CMSE_Lib.o
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTestGenerator:Check Global Generator@0.9.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
+++ b/tools/projmgr/test/data/TestAccessSequences/ref/pack-access-sequences+CM4-Board.cbuild.yml
@@ -52,6 +52,8 @@ build:
   output:
     - type: elf
       file: pack-access-sequences.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Debug+TEST_TARGET.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: project.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestDefault/ref/empty/project.Release+TEST_TARGET.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: project.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/multiple-components.Debug+CM0.cbuild.yml
@@ -28,6 +28,8 @@ build:
   output:
     - type: elf
       file: multiple-components.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device&RteTestBundle:RteTest Generated Component@1.1.0
       condition: RteTest

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-layer.Debug+CM0.cbuild.yml
@@ -28,6 +28,8 @@ build:
   output:
     - type: elf
       file: test-gpdsc-layer.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
       condition: RteTest

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-multiple-generators.Debug+CM0.cbuild.yml
@@ -28,6 +28,8 @@ build:
   output:
     - type: elf
       file: test-gpdsc-multiple-generators.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
       condition: RteTest

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-project-files.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc-project-files.Debug+CM0.cbuild.yml
@@ -30,6 +30,8 @@ build:
   output:
     - type: elf
       file: test-gpdsc-project-files.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
       condition: RteDevice

--- a/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestGenerator/ref/test-gpdsc.Debug+CM0.cbuild.yml
@@ -28,6 +28,8 @@ build:
   output:
     - type: elf
       file: test-gpdsc.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTest@1.1.0
       condition: RteTest

--- a/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.AbsolutePath+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.AbsolutePath+TEST_TARGET.cbuild.yml
@@ -52,6 +52,8 @@ build:
   output:
     - type: elf
       file: setup-test.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build_AC6+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build_AC6+TEST_TARGET.cbuild.yml
@@ -45,6 +45,8 @@ build:
   output:
     - type: elf
       file: setup-test.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build_GCC+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestProjectSetup/ref/setup-test.Build_GCC+TEST_TARGET.cbuild.yml
@@ -51,6 +51,8 @@ build:
   output:
     - type: elf
       file: setup-test.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild.yml
@@ -42,6 +42,8 @@ build:
       file: run-debug.axf
     - type: hex
       file: run-debug.hex
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM4 RteTest

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild.yml
@@ -42,6 +42,8 @@ build:
       file: run-debug.axf
     - type: hex
       file: run-debug.hex
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/ComponentSources/ref/components.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ComponentSources/ref/components.Debug+RteTest_ARMCM3.cbuild.yml
@@ -43,6 +43,8 @@ build:
   output:
     - type: elf
       file: components.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:DupFilename@0.9.9
       from-pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ComponentSources/ref/versions.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ComponentSources/ref/versions.Debug+RteTest_ARMCM3.cbuild.yml
@@ -41,6 +41,8 @@ build:
   output:
     - type: elf
       file: versions.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:TestVersion@1.8-dev1
       from-pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Debug+RteTest_ARMCM3.cbuild.yml
@@ -33,6 +33,8 @@ build:
   output:
     - type: elf
       file: project1.axf
+    - type: comp-db
+      file: compile_commands.json
   linker:
     script: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src
     regions: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project1.Release+RteTest_ARMCM3.cbuild.yml
@@ -33,6 +33,8 @@ build:
   output:
     - type: elf
       file: project1.axf
+    - type: comp-db
+      file: compile_commands.json
   linker:
     script: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src
     regions: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Debug+RteTest_ARMCM3.cbuild.yml
@@ -33,6 +33,8 @@ build:
   output:
     - type: elf
       file: project2.axf
+    - type: comp-db
+      file: compile_commands.json
   linker:
     script: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src
     regions: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h

--- a/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ContextMap/ref/project2.Release+RteTest_ARMCM3.cbuild.yml
@@ -33,6 +33,8 @@ build:
   output:
     - type: elf
       file: project2.axf
+    - type: comp-db
+      file: compile_commands.json
   linker:
     script: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/ac6_linker_script.sct.src
     regions: ../data/TestSolution/ContextMap/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti-signret.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti-signret.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: branch-protection.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+bti.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: branch-protection.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+no-bp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/branch-protection.Debug+no-bp.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: branch-protection.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+dsp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+dsp.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: dsp.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+no-dsp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/dsp.Debug+no-dsp.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: dsp.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+big.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+big.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: endian.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+little.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/endian.Debug+little.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: endian.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-dp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-dp.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: fpu.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-sp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+fpu-sp.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: fpu.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+no-fpu.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/fpu.Debug+no-fpu.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: fpu.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-fp.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-fp.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: mve.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-int.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+mve-int.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: mve.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+no-mve.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/mve.Debug+no-mve.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: mve.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+non-secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+non-secure.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: trustzone.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure-only.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure-only.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: trustzone.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+secure.cbuild.yml
@@ -40,6 +40,8 @@ build:
       file: trustzone.axf
     - type: cmse-lib
       file: trustzone_CMSE_Lib.o
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+tz-disabled.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Debug+tz-disabled.cbuild.yml
@@ -38,6 +38,8 @@ build:
   output:
     - type: elf
       file: trustzone.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Fail+secure.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/DeviceAttributes/ref/trustzone.Fail+secure.cbuild.yml
@@ -40,6 +40,8 @@ build:
       file: trustzone.axf
     - type: cmse-lib
       file: trustzone_CMSE_Lib.o
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/Instances/ref/instances.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/Instances/ref/instances.Debug+RteTest_ARMCM3.cbuild.yml
@@ -43,6 +43,8 @@ build:
   output:
     - type: elf
       file: instances.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:ComponentLevel@0.0.1
       instances: 2

--- a/tools/projmgr/test/data/TestSolution/LanguageAndScope/ref/lang-scope.Debug_AC6+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LanguageAndScope/ref/lang-scope.Debug_AC6+RteTest_ARMCM3.cbuild.yml
@@ -39,6 +39,8 @@ build:
   output:
     - type: elf
       file: lang-scope.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:LanguageAndScope@0.9.9
       from-pack: ARM::RteTest@0.1.0-alpha0

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_ARMCM3.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.AutoGen+RteTest_Board.cbuild.yml
@@ -41,6 +41,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Board:Test:Rev1@1.1.1
       condition: BoardTest1

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_AC6+RteTest_ARMCM3.cbuild.yml
@@ -33,6 +33,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   linker:
     script: ../data/TestSolution/LinkerOptions/linkerScript.sct
     regions: ../data/TestSolution/LinkerOptions/RTE/Device/RteTest_ARMCM3/regions_RteTest_ARMCM3.h

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.Debug_GCC+RteTest_ARMCM3.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: linker.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.FromComponent+RteTest_ARMCM3.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityDefines+RteTest_ARMCM3.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/LinkerOptions/ref/linker.PriorityRegions+RteTest_ARMCM3.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: linker.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMetadata/ref/metadata.Debug+RteTest_ARMCM3.cbuild.yml
@@ -34,6 +34,8 @@ build:
   output:
     - type: elf
       file: metadata.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/PackMissing/ref/project+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMissing/ref/project+CM0.cbuild.yml
@@ -24,3 +24,5 @@ build:
   output:
     - type: elf
       file: project.axf
+    - type: comp-db
+      file: compile_commands.json

--- a/tools/projmgr/test/data/TestSolution/PackMissing/ref/project+Gen.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/PackMissing/ref/project+Gen.cbuild.yml
@@ -24,3 +24,5 @@ build:
   output:
     - type: elf
       file: project.axf
+    - type: comp-db
+      file: compile_commands.json

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
@@ -45,6 +45,8 @@ build:
   output:
     - type: lib
       file: liblibrary.a
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/TemplateAndApi/ref/template_api.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TemplateAndApi/ref/template_api.Debug+RteTest_ARMCM3.cbuild.yml
@@ -43,6 +43,8 @@ build:
   output:
     - type: elf
       file: template_api.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:TemplateFile@0.9.9
       from-pack: ARM::RteTest@0.1.0

--- a/tools/projmgr/test/data/TestSolution/TestBaseUpdate/ref/project.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TestBaseUpdate/ref/project.Debug+CM0.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: project.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/TestProject4/test_board_and_device+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/TestProject4/test_board_and_device+TEST_TARGET.cbuild.yml
@@ -40,6 +40,8 @@ build:
   output:
     - type: elf
       file: test_board_and_device.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild-gen.yml
@@ -35,6 +35,8 @@ build-gen:
   output:
     - type: elf
       file: TestProject3_1.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_1.Debug+TypeA.cbuild.yml
@@ -31,6 +31,8 @@ build:
   output:
     - type: elf
       file: TestProject3_1.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_5.Debug+TypeA.cbuild-gen.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_5.Debug+TypeA.cbuild-gen.yml
@@ -31,6 +31,8 @@ build-gen:
   output:
     - type: elf
       file: TestProject3_5.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTestSimple@1.1.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ref/TestProject3_5.Debug+TypeA.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/TestProject3_5.Debug+TypeA.cbuild.yml
@@ -31,6 +31,8 @@ build:
   output:
     - type: elf
       file: TestProject3_5.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:RteTest Generated Component:RteTestGenFiles@1.1.0
       from-pack: ARM::RteTestGenerator@0.1.0

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Debug+CM0.cbuild.yml
@@ -70,6 +70,8 @@ build:
   output:
     - type: elf
       file: test1.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test1.Release+CM0.cbuild.yml
@@ -53,6 +53,8 @@ build:
   output:
     - type: elf
       file: test1.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM0.cbuild.yml
@@ -77,6 +77,8 @@ build:
   output:
     - type: elf
       file: test2.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/cbuild/test2.Debug+CM3.cbuild.yml
@@ -74,6 +74,8 @@ build:
   output:
     - type: elf
       file: test2.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Debug+Target.cbuild.yml
@@ -43,6 +43,8 @@ build:
       file: executable.hex
     - type: map
       file: executable.axf.map
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/outputFiles.Library+Target.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: lib
       file: library-AC6.lib
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/pre-include+CM0.cbuild.yml
@@ -47,6 +47,8 @@ build:
   output:
     - type: elf
       file: pre-include.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/rtedir.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/rtedir.Debug+CM0.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: rtedir.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/ref/rtedir.Release+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/ref/rtedir.Release+CM0.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: rtedir.elf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM0 RteTest

--- a/tools/projmgr/test/data/TestSolution/simple/project.Debug+TEST_TARGET.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/simple/project.Debug+TEST_TARGET.cbuild.yml
@@ -37,6 +37,8 @@ build:
   output:
     - type: elf
       file: project.axf
+    - type: comp-db
+      file: compile_commands.json
   components:
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device

--- a/tools/projmgr/test/data/WestSupport/ref/core0.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/core0.Debug+CM0.cbuild.yml
@@ -23,6 +23,8 @@ build:
       file: zephyr/zephyr.elf
     - type: hex
       file: zephyr/zephyr.hex
+    - type: comp-db
+      file: compile_commands.json
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt

--- a/tools/projmgr/test/data/WestSupport/ref/core1.Debug+CM0.cbuild.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/core1.Debug+CM0.cbuild.yml
@@ -23,6 +23,8 @@ build:
       file: zephyr/zephyr.elf
     - type: hex
       file: zephyr/zephyr.hex
+    - type: comp-db
+      file: compile_commands.json
   licenses:
     - license: <unknown>
       license-agreement: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/license.txt


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/2261
The new file type `comp-db` has been chosen for consistency with other file types in the schema: it's short and still reasonably intuitive.
The suggested additional node `path` is not being added because it would be superfluous in the current output structure where the `cbuild.yml` is already in the `outdir` (either default or custom), so output files are located alongside `cbuild.yml` itself.