### PR TITLE
Add localtime_s to cross-platform (#1426)

### DIFF
--- a/libs/crossplatform/include/CrossPlatform.h
+++ b/libs/crossplatform/include/CrossPlatform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -30,6 +30,8 @@
 
 #define _popen popen
 #define _pclose pclose
+// localtime_r has inverted arguments as localtime_s, therfore define with parameters
+#define localtime_s(tm_ptr, time_ptr) localtime_r((time_ptr), (tm_ptr))
 
 /* Windows defines */
 #define MAX_PATH  260

--- a/libs/rtefsutils/src/RteFsUtils.cpp
+++ b/libs/rtefsutils/src/RteFsUtils.cpp
@@ -14,6 +14,7 @@
 
 #include "RteFsUtils.h"
 
+#include "CrossPlatform.h"
 #include "CrossPlatformUtils.h"
 #include "RteUtils.h"
 #include "WildCards.h"
@@ -927,11 +928,7 @@ std::string RteFsUtils::FileTimeToString(const fs::file_time_type& timeStamp) {
        timeStamp - fs::file_time_type::clock::now() + std::chrono::system_clock::now());
      std::time_t t = std::chrono::system_clock::to_time_t(sctp);
     std::tm tm{};
-#if defined(_WIN32)
     localtime_s(&tm, &t);      // Windows secure version
-#else
-    localtime_r(&t, &tm);      // POSIX thread-safe version
-#endif
     std::ostringstream oss;
     oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
     strTime = oss.str();


### PR DESCRIPTION
* Create add localtime_s to cross-platform

* Add missing include in UnitTest.cpp

* Add definition for localtime_s using localtime_r

Define localtime_s to use localtime_r with inverted arguments.