### PR TITLE
[csolution-rpc] Expose evaluated dynamic access sequences

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -481,6 +481,7 @@ struct VariablesConfiguration {
  *        layer variables configurations
  *        unresolved components
  *        map of available packs for locked packs
+ *        map of sequences to expanded absolute paths
 */
 struct ContextItem {
   CdefaultItem* cdefault = nullptr;
@@ -555,6 +556,7 @@ struct ContextItem {
   std::vector<VariablesConfiguration> variablesConfigurations;
   std::set<RteComponentInstance*> unresolvedComponents;
   StrMap availablePackVersions;
+  StrMap absPathSequences;
 };
 
 /**
@@ -1272,7 +1274,7 @@ protected:
   void SetDefaultLinkerScript(ContextItem& context);
   void CheckAndGenerateRegionsHeader(ContextItem& context);
   bool GenerateRegionsHeader(ContextItem& context, std::string& generatedRegionsFile);
-  void ExpandAccessSequence(const ContextItem& context, const ContextItem& refContext, const std::string& sequence, const std::string& outdir, std::string& item, bool withHeadingDot);
+  void ExpandAccessSequence(ContextItem& context, const ContextItem& refContext, const std::string& sequence, const std::string& outdir, std::string& item, bool withHeadingDot);
   void ExpandPackDir(ContextItem& context, const std::string& pack, std::string& item);
   bool GetGeneratorDir(const RteGenerator* generator, ContextItem& context, const std::string& layer, std::string& genDir);
   bool GetGeneratorOptions(ContextItem& context, const std::string& layer, GeneratorOptionsItem& options);

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -372,6 +372,7 @@ RpcArgs::ContextInfo RpcHandler::GetContextInfo(const string& context) {
 
   auto& contextItem = GetContext(context);
   contextInfo.variables = contextItem.variables;
+  contextInfo.variables.merge((StrMap)contextItem.absPathSequences);
   contextInfo.attributes = contextItem.targetAttributes;
   contextInfo.pname = contextItem.deviceItem.pname;
 
@@ -511,6 +512,7 @@ RpcArgs::VariablesResult RpcHandler::GetVariables(const string& context) {
   res.success = false;
   auto& contextItem = GetContext(context);
   res.variables = contextItem.variables;
+  res.variables.merge((StrMap)contextItem.absPathSequences);
   res.success = true;
   return res;
 }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3493,39 +3493,46 @@ bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem & context, bool rerun)
   return true;
 }
 
-void ProjMgrWorker::ExpandAccessSequence(const ContextItem& context, const ContextItem& refContext, const string& sequence, const string& outdir, string& item, bool withHeadingDot) {
-  const string refContextOutDir = refContext.directories.cprj + "/" + refContext.directories.outdir;
-  const string relOutDir = outdir.empty() ? refContextOutDir : RteFsUtils::RelativePath(refContextOutDir, outdir, withHeadingDot);
+void ProjMgrWorker::ExpandAccessSequence(ContextItem& context, const ContextItem& refContext, const string& sequence, const string& outdir, string& item, bool withHeadingDot) {
+  string refContextOutDir = refContext.directories.outdir;
+  RteFsUtils::NormalizePath(refContextOutDir, refContext.directories.cprj);
   string regExStr = "\\$";
   string replacement;
   if (sequence == RteConstants::AS_SOLUTION_DIR) {
     regExStr += RteConstants::AS_SOLUTION_DIR;
-    replacement = outdir.empty() ? refContext.csolution->directory : RteFsUtils::RelativePath(refContext.csolution->directory, outdir, withHeadingDot);
+    replacement = refContext.csolution->directory;
   } else if (sequence == RteConstants::AS_PROJECT_DIR) {
     regExStr += RteConstants::AS_PROJECT_DIR;
-    replacement = outdir.empty() ? refContext.cproject->directory : RteFsUtils::RelativePath(refContext.cproject->directory, outdir, withHeadingDot);
+    replacement = refContext.cproject->directory;
   } else if (sequence == RteConstants::AS_OUT_DIR) {
     regExStr += RteConstants::AS_OUT_DIR;
-    replacement = relOutDir;
+    replacement = refContextOutDir;
   } else if (sequence == RteConstants::AS_ELF) {
     regExStr += RteConstants::AS_ELF;
-    replacement = refContext.outputTypes.elf.on ? relOutDir + "/" + refContext.outputTypes.elf.filename : "";
+    replacement = refContext.outputTypes.elf.on ? refContextOutDir + "/" + refContext.outputTypes.elf.filename : "";
   } else if (sequence == RteConstants::AS_BIN) {
     regExStr += RteConstants::AS_BIN;
-    replacement = refContext.outputTypes.bin.on ? relOutDir + "/" + refContext.outputTypes.bin.filename : "";
+    replacement = refContext.outputTypes.bin.on ? refContextOutDir + "/" + refContext.outputTypes.bin.filename : "";
   } else if (sequence == RteConstants::AS_HEX) {
     regExStr += RteConstants::AS_HEX;
-    replacement = refContext.outputTypes.hex.on ? relOutDir + "/" + refContext.outputTypes.hex.filename : "";
+    replacement = refContext.outputTypes.hex.on ? refContextOutDir + "/" + refContext.outputTypes.hex.filename : "";
   } else if (sequence == RteConstants::AS_LIB) {
     regExStr += RteConstants::AS_LIB;
-    replacement = refContext.outputTypes.lib.on ? relOutDir + "/" + refContext.outputTypes.lib.filename : "";
+    replacement = refContext.outputTypes.lib.on ? refContextOutDir + "/" + refContext.outputTypes.lib.filename : "";
   } else if (sequence == RteConstants::AS_CMSE) {
     regExStr += RteConstants::AS_CMSE;
-    replacement = refContext.outputTypes.cmse.on ? relOutDir + "/" + refContext.outputTypes.cmse.filename : "";
+    replacement = refContext.outputTypes.cmse.on ? refContextOutDir + "/" + refContext.outputTypes.cmse.filename : "";
   } else if (sequence == RteConstants::AS_MAP) {
     regExStr += RteConstants::AS_MAP;
-    replacement = refContext.outputTypes.map.on ? relOutDir + "/" + refContext.outputTypes.map.filename : "";
+    replacement = refContext.outputTypes.map.on ? refContextOutDir + "/" + refContext.outputTypes.map.filename : "";
   }
+  // store sequence and its evaluated absolute path
+  context.absPathSequences[item.substr(1, item.size() - 2)] = replacement;
+  // get relative path
+  if (!replacement.empty() && !outdir.empty()) {
+    replacement = RteFsUtils::RelativePath(replacement, outdir, withHeadingDot);
+  }
+  // replace sequence
   regex regEx = regex(regExStr + "\\(.*\\)\\$");
   item = regex_replace(item, regEx, replacement);
 }

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType1.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType1.cprj
@@ -18,6 +18,7 @@
     <output elf="variables.axf" intdir="tmp/variables/TargetType1/BuildType1" name="variables" outdir="out/variables/TargetType1/BuildType1" rtedir="../data/TestLayers/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
     <defines>App-Layer;Build1-Layer;SolutionDir-Layer;Target1-Layer</defines>
+    <includes>out/variables/TargetType1/BuildType1</includes>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType2.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType1+TargetType2.cprj
@@ -18,6 +18,7 @@
     <output elf="variables.axf" intdir="tmp/variables/TargetType2/BuildType1" name="variables" outdir="out/variables/TargetType2/BuildType1" rtedir="../data/TestLayers/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct"/>
     <defines>App-Layer;Build1-Layer;SolutionDir-Layer;Target2-Layer</defines>
+    <includes>out/variables/TargetType2/BuildType1</includes>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType1.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType1.cprj
@@ -18,6 +18,7 @@
     <output elf="variables.axf" intdir="tmp/variables/TargetType1/BuildType2" name="variables" outdir="out/variables/TargetType1/BuildType2" rtedir="../data/TestLayers/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM0/ARMCM0_ac6.sct"/>
     <defines>App-Layer;Build2-Layer;SolutionDir-Layer;Target1-Layer</defines>
+    <includes>out/variables/TargetType1/BuildType2</includes>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType2.cprj
+++ b/tools/projmgr/test/data/TestLayers/ref/variables/variables.BuildType2+TargetType2.cprj
@@ -18,6 +18,7 @@
     <output elf="variables.axf" intdir="tmp/variables/TargetType2/BuildType2" name="variables" outdir="out/variables/TargetType2/BuildType2" rtedir="../data/TestLayers/RTE" type="exe"/>
     <ldflags compiler="AC6" file="../data/TestLayers/variables/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct"/>
     <defines>App-Layer;Build2-Layer;SolutionDir-Layer;Target2-Layer</defines>
+    <includes>out/variables/TargetType2/BuildType2</includes>
   </target>
 
   <components>

--- a/tools/projmgr/test/data/TestLayers/variables/solutionDir.clayer.yml
+++ b/tools/projmgr/test/data/TestLayers/variables/solutionDir.clayer.yml
@@ -2,5 +2,8 @@
 
 layer:
 
+  add-path:
+    - $OutDir()$
+
   define:
     - SolutionDir-Layer

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -1434,6 +1434,7 @@ TEST_F(ProjMgrRpcTests, RpcGetVariables) {
   EXPECT_EQ(vars["Dpack"], testcmsispack_folder + "/ARM/RteTest_DFP/0.2.0/");
   EXPECT_EQ(vars["Pname"], "");
   EXPECT_EQ(vars["Project"], "variables");
+  EXPECT_EQ(vars["OutDir()"], testinput_folder + "/TestLayers/out/variables/TargetType1/BuildType1");
   EXPECT_EQ(vars["Solution"], "variables");
   EXPECT_EQ(vars["TargetType"], "TargetType1");
   EXPECT_EQ(vars["VarBuildLayer"], "./variables/build1.clayer.yml");


### PR DESCRIPTION
Store absolute paths of evaluated dynamic access sequences such as `OutDir()`.
Expose them via RPC methods `GetVariables` and `GetContextInfo`.
Background support for https://github.com/ARM-software/vscode-cmsis-csolution/issues/510