### PR TITLE
RPC: Tolerate non-critical errors when loading solution

### DIFF
--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -295,9 +295,19 @@ RpcArgs::SuccessResult RpcHandler::LoadSolution(const string& solution, const st
   m_manager.LoadSolution(csolutionFile, activeTarget);
   map<string, ContextItem>* contexts = nullptr;
   m_worker.GetContexts(contexts);
-  result.success = m_solutionLoaded = contexts && !contexts->empty();
+  bool hasUsableContext = false;
+  if (contexts && !contexts->empty()) {
+    // ensure at least one context has a valid active target
+    for (const auto& contextItem : *contexts) {
+      if (contextItem.second.rteActiveTarget != nullptr) {
+        hasUsableContext = true;
+        break;
+      }
+    }
+  }
+  result.success = m_solutionLoaded = hasUsableContext;
   if(!result.success) {
-    // severe situation: contexts were not populated
+    // severe situation: contexts were not populated or are unusable
     result.message = "failed to load and process solution " + csolutionFile;
   }
   return result;


### PR DESCRIPTION
For RPC case we can tolerate loading solution with errors like typos in access sequences, missing packs and schema violations. 