### PR TITLE
[projmgr] Add `$TargetSet$` access sequence for better `tmpdir` separation

### DIFF
--- a/libs/rteutils/include/RteConstants.h
+++ b/libs/rteutils/include/RteConstants.h
@@ -104,6 +104,7 @@ public:
   static constexpr const char* AS_COMPILER = "Compiler";
   static constexpr const char* AS_BUILD_TYPE = "BuildType";
   static constexpr const char* AS_TARGET_TYPE = "TargetType";
+  static constexpr const char* AS_TARGET_SET = "TargetSet";
   static constexpr const char* AS_DNAME = "Dname";
   static constexpr const char* AS_PNAME = "Pname";
   static constexpr const char* AS_BNAME = "Bname";

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -544,9 +544,6 @@ bool ProjMgr::PopulateContexts(void) {
   m_worker.SetOutputDir(m_outputDir);
   m_emitter.SetOutputDir(m_outputDir.empty() ? m_rootDir : RteFsUtils::AbsolutePath(m_outputDir).generic_string());
 
-  // Update tmp directory
-  m_worker.UpdateTmpDir();
-
   // Set root directory
   m_worker.SetRootDir(m_rootDir);
 
@@ -564,6 +561,9 @@ bool ProjMgr::PopulateContexts(void) {
   if (m_activeTargetSet.has_value() && !m_worker.PopulateActiveTargetSet(m_activeTargetSet.value())) {
     result = false;
   }
+
+  // Update tmp directory
+  m_worker.UpdateTmpDir();
 
   // Add image only context
   m_worker.AddImageOnlyContext();

--- a/tools/projmgr/src/ProjMgrCbuildIdx.cpp
+++ b/tools/projmgr/src/ProjMgrCbuildIdx.cpp
@@ -247,7 +247,8 @@ bool ProjMgrYamlEmitter::GenerateCbuildIndex(const vector<ContextItem*>& context
     rootNode[YAML_BUILD_IDX], contexts, m_parser, m_worker, m_outputDir, m_cbuildRun, failedContexts, executes);
 
   // set rebuild flags
-  if (NeedRebuild(filename, rootNode)) {
+  bool defaultTmpdir = RteFsUtils::Equivalent(m_parser->GetCsolution().directories.tmpdir, m_outputDir + "/tmp");
+  if (defaultTmpdir && NeedRebuild(filename, rootNode)) {
     rootNode[YAML_BUILD_IDX][YAML_REBUILD] = true;
   }
   else {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -137,9 +137,11 @@ void ProjMgrWorker::UpdateTmpDir() {
   auto& tmpdir = m_parser->GetCsolution().directories.tmpdir;
   auto& base = m_outputDir.empty() ? m_parser->GetCsolution().directory : m_outputDir;
   if (!tmpdir.empty()) {
-    if (ProjMgrUtils::HasAccessSequence(tmpdir) || !RteFsUtils::IsRelative(tmpdir)) {
-      ProjMgrLogger::Get().Warn("'tmpdir' does not support access sequences and must be relative to csolution.yml");
-      tmpdir.clear();
+    if (!m_activeTargetType.empty()) {
+      tmpdir = RteUtils::ExpandAccessSequences(tmpdir, {
+        { RteConstants::AS_TARGET_TYPE, m_activeTargetType },
+        { RteConstants::AS_TARGET_SET, m_activeTargetSet.set.empty() ? "default" : m_activeTargetSet.set } }
+      );
     }
   }
   tmpdir = base + "/" + (tmpdir.empty() ? "tmp" : tmpdir);
@@ -204,6 +206,7 @@ void ProjMgrWorker::AddContext(ContextDesc& descriptor, const TypePair& type, Co
     context.variables[RteConstants::AS_PROJECT] = context.cproject->name;
     context.variables[RteConstants::AS_BUILD_TYPE] = context.type.build;
     context.variables[RteConstants::AS_TARGET_TYPE] = context.type.target;
+    context.variables[RteConstants::AS_TARGET_SET] = context.targetSet.empty() ? "default" : context.targetSet;
 
     // solution and project access sequences with absolute paths
     context.absPathSequences[RteConstants::AS_SOLUTION_DIR_BR] = context.csolution->directory;

--- a/tools/projmgr/test/data/TestSolution/tmpdir-as.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/tmpdir-as.csolution.yml
@@ -1,15 +1,21 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
 
 solution:
+
+  compiler: AC6
+
   target-types:
     - type: TypeA
+      target-set:
+        - set: Set1
+          images:
+            - project-context: test1.Debug
 
   build-types:
     - type: Debug
-      compiler: AC6
 
   projects:
     - project: ./TestProject1/test1.cproject.yml
 
   output-dirs:
-    tmpdir: $BuildType$
+    tmpdir: tmp/$TargetType$/$TargetSet$

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4164,16 +4164,17 @@ TEST_F(ProjMgrUnitTests, OutputDirs) {
 }
 
 TEST_F(ProjMgrUnitTests, OutputDirsTmpdirAccessSequence) {
-  StdStreamRedirect streamRedirect;
-  char* argv[4];
+  char* argv[5];
   const string& csolution = testinput_folder + "/TestSolution/tmpdir-as.csolution.yml";
   argv[1] = (char*)"convert";
   argv[2] = (char*)csolution.c_str();
-  argv[3] = (char*)"--cbuildgen";
-  EXPECT_EQ(0, RunProjMgr(4, argv, m_envp));
+  argv[3] = (char*)"--active";
+  argv[4] = (char*)"TypeA@Set1";
+  EXPECT_EQ(0, RunProjMgr(5, argv, m_envp));
 
-  auto errStr = streamRedirect.GetErrorString();
-  EXPECT_TRUE(regex_search(errStr, regex("warning csolution: 'tmpdir' does not support access sequences and must be relative to csolution.yml")));
+  // Check custom tmp directory
+  const YAML::Node& cbuild = YAML::LoadFile(testinput_folder + "/TestSolution/tmpdir-as.cbuild-idx.yml");
+  EXPECT_EQ("tmp/TypeA/Set1", cbuild["build-idx"]["tmpdir"].as<string>());
 }
 
 TEST_F(ProjMgrUnitTests, OutputDirsAbsolutePath) {


### PR DESCRIPTION
Address ground issue reported in https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/102

Enable `$TargetType$` and `$TargetSet$` access sequences resolution in `tmpdir` customization:
```
  output-dirs:
    tmpdir: tmp/$TargetType$/$TargetSet$
```

This allows switching `target-set` back and forth without triggering rebuilds.