### PR TITLE
[projmgr] show messages in Problems, Ouput and cbuild-idx.yml if no compatible layer found

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -88,6 +88,12 @@ public:
   bool RunConvert(const std::string&csolution = RteUtils::EMPTY_STRING,
     const std::string& activeTargetSet = RteUtils::EMPTY_STRING, const bool& updateRte = false);
 
+  /**
+   * @brief call function to (re-)generate cbuild-idx.yml
+   * @return true if executed successfully
+   */
+  bool CallGenerateCbuildIndex();
+
 protected:
   /**
    * @brief parse command line options

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -657,9 +657,9 @@ bool ProjMgr::Configure() {
 
   if (m_worker.HasVarDefineError()) {
     auto undefVars = m_worker.GetUndefLayerVars();
-    string errMsg = "undefined variables in "+ fs::path(m_csolutionFile).filename().generic_string() +":\n";
+    string errMsg = "undefined variables in "+ fs::path(m_csolutionFile).filename().generic_string() +":";
     for (const string& var : undefVars) {
-      errMsg += "  - $" + var + "$\n";
+      errMsg += "\n  - $" + var + "$";
     }
     ProjMgrLogger::Get().Error(errMsg);
   }
@@ -1097,9 +1097,9 @@ bool ProjMgr::RunListLayers(void) {
   bool error = m_worker.HasVarDefineError() && !m_updateIdx;
   if (error) {
     auto undefVars = m_worker.GetUndefLayerVars();
-    string errMsg = "undefined variables in " + fs::path(m_csolutionFile).filename().generic_string() + ":\n";
+    string errMsg = "undefined variables in " + fs::path(m_csolutionFile).filename().generic_string() + ":";
     for (const string& var : undefVars) {
-      errMsg += "  - $" + var + "$\n";
+      errMsg += "\n  - $" + var + "$";
     }
     ProjMgrLogger::Get().Error(errMsg);
   }
@@ -1123,13 +1123,8 @@ bool ProjMgr::RunListLayers(void) {
   // Update the cbuild-idx.yml file with layer information
   if (m_updateIdx) {
     // Generate Cbuild index
-    const auto& processedContexts = m_worker.GetProcessedContexts();
-    if (!processedContexts.empty()) {
-      m_worker.ElaborateVariablesConfigurations();
-      if (!m_emitter.GenerateCbuildIndex(processedContexts,
-        m_failedContext, map<string, ExecutesItem>())) {
-        return false;
-      }
+    if (!CallGenerateCbuildIndex()) {
+      return false;
     }
   }
   return !error;
@@ -1373,3 +1368,16 @@ bool ProjMgr::IsSolutionImageOnly() {
   }
   return imageOnly;
 }
+
+bool ProjMgr::CallGenerateCbuildIndex() {
+  const auto& processedContexts = m_worker.GetProcessedContexts();
+  if (!processedContexts.empty()) {
+    m_worker.ElaborateVariablesConfigurations();
+    if (!m_emitter.GenerateCbuildIndex(processedContexts,
+      m_failedContext, map<string, ExecutesItem>())) {
+      return false;
+    }
+  }
+	return true;
+}
+

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -826,6 +826,8 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
   }
   if(!m_manager.SetupContexts(csolutionFile, activeTarget)) {
     result.message = "Setup of solution contexts failed";
+		ProjMgrLogger::Get().Error(result.message.value());
+    m_manager.CallGenerateCbuildIndex();
     return result;
   }
   m_worker.SetUpCommand(true);
@@ -833,6 +835,8 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
   StrSet fails;
   if(!m_worker.ListLayers(layers, "", fails) || !m_worker.ElaborateVariablesConfigurations()) {
     result.message = "No compatible software layer found. Review required connections of the project";
+		ProjMgrLogger::Get().Error(result.message.value());
+    m_manager.CallGenerateCbuildIndex();
     return result;
   } else {
     // retrieve valid configurations

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4415,7 +4415,7 @@ TEST_F(ProjMgrUnitTests, RunCheckContextProcessing) {
   EXPECT_EQ(2, RunProjMgr(8, argv, 0));
 
   // Check error for processed context
-  const string expected = "error csolution: undefined variables in contexts.csolution.yml:\n  - $LayerVar$\n\n";
+  const string expected = "error csolution: undefined variables in contexts.csolution.yml:\n  - $LayerVar$\n";
   auto errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(errStr.find(expected) != string::npos);
 


### PR DESCRIPTION
To address https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/119

**Centralization of cbuild index generation:**

* Added a new method `CallGenerateCbuildIndex()` to `ProjMgr` to centralize the generation of the `cbuild-idx.yml` file. The method is now reused across multiple locations to eliminate code duplication.
*  Regenerate a `cbuild-idx.yml` is required. This ensures consistent synchronization of error messages in the file, particularly for cases where `cbuild-idx.yml` is already generated prior to `RpcHandler::DiscoverLayers`.
* Integrated `result.message` into `ProjMgrLogger` so that all messages produced during the process are captured in the generated `cbuild-idx.yml` file. These messages in `ProjMgrLogger` are also exposed via the RPC method `RpcHandler::GetLogMessages` and displayed in the frontend.

**Error reporting improvements:**

* Updated error messages for `undefined variables` to print each variable on its own line without an extra newline at the end, making the output more consistent. Adjusted the expected error message in `ProjMgrUnitTests.cpp` to match the new error output format.