### PR TITLE
Refine discoverLayer errMsg

### DIFF
--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -836,8 +836,7 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
   StrVec layers;
   StrSet fails;
   if(!m_worker.ListLayers(layers, "", fails) || !m_worker.ElaborateVariablesConfigurations()) {
-    result.message = "No compatible software layer was found in the installed packs. "
-                     "Install additional packs containing suitable layers before restarting the \"Create Solution\" flow.";
+    result.message = "No compatible software layer was found in the installed packs.\nInstall additional packs containing suitable layers before restarting the 'Create Solution' flow.";
     return result;
   } else {
     // retrieve valid configurations

--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -836,7 +836,8 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
   StrVec layers;
   StrSet fails;
   if(!m_worker.ListLayers(layers, "", fails) || !m_worker.ElaborateVariablesConfigurations()) {
-    result.message = "No compatible software layer found. Review required connections of the project";
+    result.message = "No compatible software layer was found in the installed packs. "
+                     "Install additional packs containing suitable layers before restarting the \"Create Solution\" flow.";
     return result;
   } else {
     // retrieve valid configurations

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -1498,8 +1498,7 @@ TEST_F(ProjMgrRpcTests, RpcDiscoverLayers) {
     json({{ "solution", csolutionPath }, { "activeTarget", "" }}));
   responses = RunRpcMethods(requests);
   EXPECT_FALSE(responses[0]["result"]["success"]);
-  EXPECT_EQ(responses[0]["result"]["message"], "No compatible software layer was found in the installed packs. "
-    "Install additional packs containing suitable layers before restarting the \"Create Solution\" flow.");
+  EXPECT_EQ(responses[0]["result"]["message"], "No compatible software layer was found in the installed packs.\nInstall additional packs containing suitable layers before restarting the 'Create Solution' flow.");
 }
 
 TEST_F(ProjMgrRpcTests, RpcListMissingPacks) {

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -1498,7 +1498,8 @@ TEST_F(ProjMgrRpcTests, RpcDiscoverLayers) {
     json({{ "solution", csolutionPath }, { "activeTarget", "" }}));
   responses = RunRpcMethods(requests);
   EXPECT_FALSE(responses[0]["result"]["success"]);
-  EXPECT_EQ(responses[0]["result"]["message"], "No compatible software layer found. Review required connections of the project");
+  EXPECT_EQ(responses[0]["result"]["message"], "No compatible software layer was found in the installed packs. "
+    "Install additional packs containing suitable layers before restarting the \"Create Solution\" flow.");
 }
 
 TEST_F(ProjMgrRpcTests, RpcListMissingPacks) {


### PR DESCRIPTION
To address: https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/119
Updates the error message shown when no compatible software layer is found.

**User-facing improvements:**

* Updated the error message in `ProjMgrRpcServer.cpp` to clarify that no compatible software layer was found in the installed packs and to instruct users to install additional packs before restarting the "Create Solution" flow.

**Testing updates:**

* Updated the corresponding test in `ProjMgrRpcTests.cpp` to expect the new, more descriptive error message.