### PR TITLE
Add `build-scope` to include/exclude component files

### DIFF
--- a/libs/rtemodel/include/RteFile.h
+++ b/libs/rtemodel/include/RteFile.h
@@ -128,6 +128,13 @@ public:
   bool IsAddToProject() const override;
 
   /**
+   * @brief helper static method to check if category is a compilable source file
+   * @param category file category
+   * @return true if source category
+  */
+  static bool IsSourceCategory(Category category);
+
+  /**
    * @brief get file category
    * @return RteFile::Category
   */

--- a/libs/rtemodel/src/RteFile.cpp
+++ b/libs/rtemodel/src/RteFile.cpp
@@ -88,6 +88,15 @@ bool RteFile::IsAddToProject() const
   return false;
 }
 
+bool RteFile::IsSourceCategory(Category category) {
+  static const set<Category> sourceCategories = {
+    Category::SOURCE,
+    Category::SOURCE_C,
+    Category::SOURCE_CPP,
+    Category::SOURCE_ASM
+  };
+  return sourceCategories.find(category) != sourceCategories.end();
+}
 
 RteFile::Category RteFile::GetCategory() const
 {

--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -295,6 +295,7 @@ struct ComponentItem {
   std::string component;
   std::string condition;
   std::string fromPack;
+  std::string buildScope;
   BuildType build;
   TypeFilter type;
   int instances = 1;

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -46,6 +46,7 @@ static constexpr const char* YAML_BUILD = "build";
 static constexpr const char* YAML_BUILD_GEN = "build-gen";
 static constexpr const char* YAML_BUILD_IDX = "build-idx";
 static constexpr const char* YAML_BUILD_GEN_IDX = "build-gen-idx";
+static constexpr const char* YAML_BUILDSCOPE = "build-scope";
 static constexpr const char* YAML_BUILDTYPES = "build-types";
 static constexpr const char* YAML_CATEGORY = "category";
 static constexpr const char* YAML_CBUILDS = "cbuilds";

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -598,6 +598,12 @@
       "type": "integer",
       "description": "Maximum allowed instances of a component in a project. Default is 1 for one instance."
     },
+    "BuildScope": {
+      "title": "build-scope:",
+      "type": "string",
+      "enum": [ "include", "exclude" ],
+      "description": "Select build scope.\nDefault: include component source files for executable builds, exclude for library builds."
+    },
     "TargetTypes": {
       "title": "target-types:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#target-types",
       "type": "array",
@@ -1033,7 +1039,8 @@
         "not-for-context": { "$ref": "#/definitions/NotForContext" },
         "optimize":     { "$ref": "#/definitions/OptimizeType" },
         "undefine":     { "$ref": "#/definitions/UndefinesType" },
-        "warnings":     { "$ref": "#/definitions/WarningsType" }
+        "warnings":     { "$ref": "#/definitions/WarningsType" },
+        "build-scope":  { "$ref": "#/definitions/BuildScope" }
       },
       "allOf": [
         { "$ref": "#/definitions/TypeListMutualExclusion" },
@@ -1710,7 +1717,8 @@
         "generator":    { "$ref": "#/definitions/ComponentGeneratorType" },
         "from-pack":    { "$ref": "#/definitions/PackID" },
         "instances":    { "$ref": "#/definitions/InstancesType" },
-        "maxInstances": { "$ref": "#/definitions/MaxInstancesType" }
+        "maxInstances": { "$ref": "#/definitions/MaxInstancesType" },
+        "build-scope":  { "$ref": "#/definitions/BuildScope" }
       },
       "additionalProperties": false
     },

--- a/tools/projmgr/src/ProjMgrCbuild.cpp
+++ b/tools/projmgr/src/ProjMgrCbuild.cpp
@@ -204,7 +204,7 @@ void ProjMgrCbuild::SetComponentFilesNode(YAML::Node node, const ContextItem* co
 
     for (const auto& [file, attr, category, language, scope, version, select] : context->componentFiles.at(componentId)) {
       // Skip source files if build-scope excludes them
-      if ( !includeComponentSourceFiles && RteFile::IsSourceCategory(RteFile::CategoryFromString(category)) ) {
+      if (!includeComponentSourceFiles && RteFile::IsSourceCategory(RteFile::CategoryFromString(category))) {
         continue;
       }
 

--- a/tools/projmgr/src/ProjMgrCbuild.cpp
+++ b/tools/projmgr/src/ProjMgrCbuild.cpp
@@ -153,6 +153,7 @@ void ProjMgrCbuild::SetComponentsNode(YAML::Node node, const ContextItem* contex
       SetNodeValue(componentNode[YAML_IMPLEMENTS], api->ConstructComponentID(true));
     }
     SetControlsNode(componentNode, context, componentItem->build);
+    SetNodeValue(componentNode[YAML_BUILDSCOPE], componentItem->buildScope);
     SetComponentFilesNode(componentNode[YAML_FILES], context, componentId);
     if (!component.generator.empty()) {
       SetNodeValue(componentNode[YAML_GENERATOR][YAML_ID], component.generator);
@@ -189,7 +190,24 @@ void ProjMgrCbuild::SetDebugConfigNode(YAML::Node node, const ContextItem* conte
 
 void ProjMgrCbuild::SetComponentFilesNode(YAML::Node node, const ContextItem* context, const string& componentId) {
   if (context->componentFiles.find(componentId) != context->componentFiles.end()) {
+    // Default behavior:
+    // - executable build: include component source files
+    // - library    build: exclude component source files
+    bool includeComponentSourceFiles = !context->outputTypes.lib.on;
+    const string& buildScope = context->components.at(componentId).item->buildScope;
+    if (buildScope == "include") {
+      includeComponentSourceFiles = true;
+    }
+    else if (buildScope == "exclude") {
+      includeComponentSourceFiles = false;
+    }
+
     for (const auto& [file, attr, category, language, scope, version, select] : context->componentFiles.at(componentId)) {
+      // Skip source files if build-scope excludes them
+      if ( !includeComponentSourceFiles && RteFile::IsSourceCategory(RteFile::CategoryFromString(category)) ) {
+        continue;
+      }
+
       YAML::Node fileNode;
       SetNodeValue(fileNode[YAML_FILE], FormatPath(file, context->directories.cbuild));
       SetNodeValue(fileNode[YAML_CATEGORY], category);

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -537,6 +537,7 @@ bool ProjMgrYamlParser::ParseComponents(const YAML::Node& parent, const string& 
       ParseString(componentEntry, YAML_COMPONENT, componentItem.component);
       ParseString(componentEntry, YAML_CONDITION, componentItem.condition);
       ParseString(componentEntry, YAML_FROM_PACK, componentItem.fromPack);
+      ParseString(componentEntry, YAML_BUILDSCOPE, componentItem.buildScope);
       if (!ParseBuildType(componentEntry, file, componentItem.build)) {
         return false;
       }
@@ -1395,6 +1396,7 @@ const set<string> componentsKeys = {
   YAML_COMPONENT,
   YAML_CONDITION,
   YAML_FROM_PACK,
+  YAML_BUILDSCOPE,
   YAML_FORCONTEXT,
   YAML_NOTFORCONTEXT,
   YAML_COMPILER,

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/executable_componentBuildScope/executable_componentBuildScope.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/executable_componentBuildScope/executable_componentBuildScope.cproject.yml
@@ -3,10 +3,10 @@
 project:
 
   output:
-    type: lib
+    type: elf
 
   components:
     - component: CORE
     - component: Device:Startup&RteTest Startup
     - component: RteTest:LocalFile@0.0.3
-      build-scope: include
+      build-scope: exclude

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/library.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/library.csolution.yml
@@ -21,6 +21,7 @@ solution:
   projects:
     - project: library.cproject.yml
     - project: library_componentBuildScope/library_componentBuildScope.cproject.yml
+    - project: executable_componentBuildScope/executable_componentBuildScope.cproject.yml
 
   packs:
     - pack: ARM::RteTest

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/library.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/library.csolution.yml
@@ -20,6 +20,7 @@ solution:
 
   projects:
     - project: library.cproject.yml
+    - project: library_componentBuildScope/library_componentBuildScope.cproject.yml
 
   packs:
     - pack: ARM::RteTest

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/library_componentBuildScope/library_componentBuildScope.cproject.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/library_componentBuildScope/library_componentBuildScope.cproject.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+
+  output:
+    type: lib
+
+  components:
+    - component: CORE
+      build-scope: exclude
+    - component: Device:Startup&RteTest Startup
+    - component: RteTest:LocalFile@0.0.3
+      build-scope: include

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/executable_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/executable_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml
@@ -1,8 +1,8 @@
 build:
-  generated-by: csolution version 0.0.0+gb0d01e99
+  generated-by: csolution version 2.13.0+p46-g645108a5
   solution: ../../../../../data/TestSolution/StandardLibrary/library.csolution.yml
-  project: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/library_componentBuildScope.cproject.yml
-  context: library_componentBuildScope.Debug+RteTest_ARMCM3
+  project: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/executable_componentBuildScope.cproject.yml
+  context: executable_componentBuildScope.Debug+RteTest_ARMCM3
   compiler: GCC
   device: ARM::RteTest_ARMCM3
   device-pack: ARM::RteTest_DFP@0.2.0
@@ -35,18 +35,18 @@ build:
     - ARMCM3
     - _RTE_
   add-path:
-    - ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
+    - ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
-    - ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
+    - ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
     intdir: ../../../../tmp
     outdir: .
-    rtedir: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE
+    rtedir: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE
   output:
-    - type: lib
-      file: liblibrary_componentBuildScope.a
+    - type: elf
+      file: executable_componentBuildScope.elf
     - type: comp-db
       file: compile_commands.json
     - type: comp-db
@@ -63,10 +63,18 @@ build:
         - file: https://arm-software.github.io/CMSIS_5/Core_A/html/startup_c_pg.html
           category: doc
           version: 2.0.3
-        - file: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/Device/RteTest_ARMCM3/gcc_arm.ld
+        - file: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/Device/RteTest_ARMCM3/gcc_arm.ld
           category: linkerScript
           attr: config
           version: 2.2.0
+        - file: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/Device/RteTest_ARMCM3/startup_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 2.0.3
+        - file: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/Device/RteTest_ARMCM3/system_ARMCM3.c
+          category: sourceC
+          attr: config
+          version: 1.2.2
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -79,11 +87,8 @@ build:
     - component: ARM::RteTest:LocalFile@0.0.3
       from-pack: ARM::RteTest@0.1.0
       selected-by: RteTest:LocalFile@0.0.3
-      build-scope: include
+      build-scope: exclude
       files:
-        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/PreInclude/MyLocalPreInclude.c
-          category: sourceC
-          version: 0.0.3
         - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/PreInclude/MyLocalPreInclude.h
           category: preIncludeLocal
           version: 0.0.3
@@ -95,8 +100,10 @@ build:
         - file: https://arm-software.github.io/CMSIS_5/Pack/html/pdsc_apis_pg.html
           category: doc
           version: 1.1.2
+  linker:
+    script: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/Device/RteTest_ARMCM3/gcc_arm.ld
   constructed-files:
-    - file: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
+    - file: ../../../../../data/TestSolution/StandardLibrary/executable_componentBuildScope/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
       category: header
   licenses:
     - license: <unknown>

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library.Debug+RteTest_ARMCM3.cbuild.yml
@@ -65,14 +65,6 @@ build:
           category: linkerScript
           attr: config
           version: 2.2.0
-        - file: ../data/TestSolution/StandardLibrary/RTE/Device/RteTest_ARMCM3/startup_ARMCM3.c
-          category: sourceC
-          attr: config
-          version: 2.0.3
-        - file: ../data/TestSolution/StandardLibrary/RTE/Device/RteTest_ARMCM3/system_ARMCM3.c
-          category: sourceC
-          attr: config
-          version: 1.2.2
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0

--- a/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml
+++ b/tools/projmgr/test/data/TestSolution/StandardLibrary/ref/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml
@@ -1,23 +1,33 @@
 build:
-  generated-by: csolution version 1.6.0
-  solution: ../data/TestSolution/outputFiles.csolution.yml
-  project: ../data/TestSolution/outputFiles.cproject.yml
-  context: outputFiles.Library+Target
-  compiler: AC6
+  generated-by: csolution version 0.0.0+gb0d01e99
+  solution: ../../../../../data/TestSolution/StandardLibrary/library.csolution.yml
+  project: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/library_componentBuildScope.cproject.yml
+  context: library_componentBuildScope.Debug+RteTest_ARMCM3
+  compiler: GCC
   device: ARM::RteTest_ARMCM3
   device-pack: ARM::RteTest_DFP@0.2.0
   device-books:
     - name: http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/index.html
       title: Cortex-M3 Device Generic Users Guide
   dbgconf:
-    - file: ../data/TestSolution/.cmsis/outputFiles+Target.dbgconf
+    - file: ../../../../../data/TestSolution/StandardLibrary/.cmsis/library+RteTest_ARMCM3.dbgconf
       version: 0.0.2
   processor:
     fpu: off
     core: Cortex-M3
   packs:
+    - pack: ARM::RteTest@0.1.0
+      path: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0
     - pack: ARM::RteTest_DFP@0.2.0
       path: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0
+  misc:
+    Library:
+      - -Wl,--start-group
+      - -lm
+      - -lc
+      - -lgcc
+      - -lnosys
+      - -Wl,--end-group
   define:
     - ARMCM3
     - _RTE_
@@ -25,18 +35,18 @@ build:
     - ARMCM3
     - _RTE_
   add-path:
-    - ../data/TestSolution/RTE/_Library_Target
+    - ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   add-path-asm:
-    - ../data/TestSolution/RTE/_Library_Target
+    - ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3
     - ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include
   output-dirs:
-    intdir: tmp/outputFiles/Target/Library
-    outdir: out/outputFiles/Target/Library
-    rtedir: ../data/TestSolution/RTE
+    intdir: ../../../../tmp
+    outdir: .
+    rtedir: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE
   output:
     - type: lib
-      file: library-AC6.lib
+      file: liblibrary_componentBuildScope.a
     - type: comp-db
       file: compile_commands.json
     - type: comp-db
@@ -45,7 +55,7 @@ build:
     - component: ARM::Device:Startup&RteTest Startup@2.0.3
       condition: ARMCM3 RteTest
       from-pack: ARM::RteTest_DFP@0.2.0
-      selected-by: Startup
+      selected-by: Device:Startup&RteTest Startup
       files:
         - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Device/ARM/ARMCM3/Include/ARMCM3.h
           category: header
@@ -53,19 +63,31 @@ build:
         - file: https://arm-software.github.io/CMSIS_5/Core_A/html/startup_c_pg.html
           category: doc
           version: 2.0.3
-        - file: ../data/TestSolution/RTE/Device/RteTest_ARMCM3/ARMCM3_ac6.sct
+        - file: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/Device/RteTest_ARMCM3/gcc_arm.ld
           category: linkerScript
           attr: config
-          version: 1.2.0
+          version: 2.2.0
     - component: ARM::RteTest:CORE@0.1.1
       condition: Cortex-M Device
       from-pack: ARM::RteTest_DFP@0.2.0
       selected-by: CORE
       implements: RteTest:CORE@1.1.2
+      build-scope: exclude
       files:
         - file: ${CMSIS_PACK_ROOT}/ARM/RteTest_DFP/0.2.0/Doc/html/index.html
           category: doc
           version: 0.1.1
+    - component: ARM::RteTest:LocalFile@0.0.3
+      from-pack: ARM::RteTest@0.1.0
+      selected-by: RteTest:LocalFile@0.0.3
+      build-scope: include
+      files:
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/PreInclude/MyLocalPreInclude.c
+          category: sourceC
+          version: 0.0.3
+        - file: ${CMSIS_PACK_ROOT}/ARM/RteTest/0.1.0/PreInclude/MyLocalPreInclude.h
+          category: preIncludeLocal
+          version: 0.0.3
   apis:
     - api: RteTest:CORE@1.1.2
       from-pack: ARM::RteTest_DFP@0.2.0
@@ -75,7 +97,7 @@ build:
           category: doc
           version: 1.1.2
   constructed-files:
-    - file: ../data/TestSolution/RTE/_Library_Target/RTE_Components.h
+    - file: ../../../../../data/TestSolution/StandardLibrary/library_componentBuildScope/RTE/_Debug_RteTest_ARMCM3/RTE_Components.h
       category: header
   licenses:
     - license: <unknown>
@@ -86,3 +108,13 @@ build:
         - component: ARM::Device:Startup&RteTest Startup@2.0.3
         - component: ARM::RteTest:CORE@0.1.1
         - component: RteTest:CORE(API)
+    - license: BSD-3-Clause
+      packs:
+        - pack: ARM::RteTest@0.1.0
+      components:
+        - component: ARM::RteTest:LocalFile@0.0.3
+    - license: MIT
+      packs:
+        - pack: ARM::RteTest@0.1.0
+      components:
+        - component: ARM::RteTest:LocalFile@0.0.3

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4729,7 +4729,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_StandardLibrary) {
   const YAML::Node& cbuildIdx = YAML::LoadFile(testoutput_folder + "/library.cbuild-idx.yml");
   EXPECT_FALSE(cbuildIdx["build-idx"]["cbuild-run"].IsDefined());
 
-  // Check generated cbuild YMLs for componentBuildScope
+  // Check generated cbuild YMLs for componentBuildScope - library builds with include build-scope
   argv[3] = (char*)"-o";
   argv[4] = (char*)testoutput_folder.c_str();
   argv[5] = (char*)"-c";
@@ -4737,6 +4737,11 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_StandardLibrary) {
   EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
   ProjMgrTestEnv::CompareFile(testoutput_folder + "/out/library_componentBuildScope/RteTest_ARMCM3/Debug/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml",
     testinput_folder + "/TestSolution/StandardLibrary/ref/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml");
+  // Check generated cbuild YMLs for componentBuildScope - executable builds with exclude build-scope
+  argv[6] = (char*)"executable_componentBuildScope";
+  EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/out/executable_componentBuildScope/RteTest_ARMCM3/Debug/executable_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml",
+    testinput_folder + "/TestSolution/StandardLibrary/ref/executable_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_MultipleProject_SameFolder) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4728,6 +4728,15 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_StandardLibrary) {
   // Check there is no cbuild-run (target-set has only lib contexts)
   const YAML::Node& cbuildIdx = YAML::LoadFile(testoutput_folder + "/library.cbuild-idx.yml");
   EXPECT_FALSE(cbuildIdx["build-idx"]["cbuild-run"].IsDefined());
+
+  // Check generated cbuild YMLs for componentBuildScope
+  argv[3] = (char*)"-o";
+  argv[4] = (char*)testoutput_folder.c_str();
+  argv[5] = (char*)"-c";
+  argv[6] = (char*)"library_componentBuildScope";
+  EXPECT_EQ(0, RunProjMgr(7, argv, m_envp));
+  ProjMgrTestEnv::CompareFile(testoutput_folder + "/out/library_componentBuildScope/RteTest_ARMCM3/Debug/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml",
+    testinput_folder + "/TestSolution/StandardLibrary/ref/library_componentBuildScope.Debug+RteTest_ARMCM3.cbuild.yml");
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_MultipleProject_SameFolder) {


### PR DESCRIPTION
To address: https://github.com/Open-CMSIS-Pack/devtools/issues/2216

Introduces support for a new `build-scope` attribute for components to control whether component source files are included in different build types (library vs. executable). By default, component source files are:
* included in executable builds
* excluded from library builds

**Changes**

* Added `build-scope` attribute (`include | exclude`) to component definitions.
* Updated schema (common.schema.json) and YAML parsing to support and validate the new attribute.
* Updated build generation to include/exclude component source files, based on `build-scope` and build type.
* Added helper method `IsSourceCategory` to identify compatible source files.