### PR TITLE
Add `default` attribute to `memory` in cbuild-run.yml

### DIFF
--- a/tools/projmgr/include/ProjMgrRunDebug.h
+++ b/tools/projmgr/include/ProjMgrRunDebug.h
@@ -36,6 +36,7 @@ struct MemoryType {
   std::string access;
   std::string alias;
   std::string fromPack;
+  std::optional<bool> default;
   unsigned long long start = 0;
   unsigned long long size = 0;
   std::string pname;

--- a/tools/projmgr/include/ProjMgrRunDebug.h
+++ b/tools/projmgr/include/ProjMgrRunDebug.h
@@ -36,7 +36,7 @@ struct MemoryType {
   std::string access;
   std::string alias;
   std::string fromPack;
-  std::optional<bool> default;
+  std::optional<bool> bDefault;
   unsigned long long start = 0;
   unsigned long long size = 0;
   std::string pname;

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2247,12 +2247,13 @@
     "SystemMemoryType": {
       "type": "object",
       "properties": {
-        "name":      { "type": "string", "description": "Name of the memory region." },
+        "name":      { "type": "string",  "description": "Name of the memory region." },
         "access":    { "$ref": "#/definitions/MemoryAccessType" },
-        "start":     { "type": "number", "description": "Base address of the memory." },
-        "size":      { "type": "number", "description": "Size of the memory." },
-        "pname":     { "type": "string", "description": "Only accessible by the specified processor." },
-        "alias":     { "type": "string", "description": "Name of identical memory exposed at different address." },
+        "start":     { "type": "number",  "description": "Base address of the memory." },
+        "size":      { "type": "number",  "description": "Size of the memory." },
+        "pname":     { "type": "string",  "description": "Only accessible by the specified processor." },
+        "alias":     { "type": "string",  "description": "Name of identical memory exposed at different address." },
+        "default":   { "type": "boolean", "description": "Marks a general-purpose default memory region." },
         "from-pack": { "$ref": "#/definitions/PackID" }
       },
       "additionalProperties": false,

--- a/tools/projmgr/src/ProjMgrCbuildRun.cpp
+++ b/tools/projmgr/src/ProjMgrCbuildRun.cpp
@@ -131,6 +131,9 @@ void ProjMgrCbuildRun::SetResourcesNode(YAML::Node node, const SystemResourcesTy
     SetNodeValue(memoryNode[YAML_SIZE], ProjMgrUtils::ULLToHex(item.size));
     SetNodeValue(memoryNode[YAML_PNAME], item.pname);
     SetNodeValue(memoryNode[YAML_ALIAS], item.alias);
+    if (item.default.has_value()) {
+      memoryNode[YAML_DEFAULT] = item.default.value();
+    }
     SetNodeValue(memoryNode[YAML_FROM_PACK], item.fromPack);
     node[YAML_MEMORY].push_back(memoryNode);
   }

--- a/tools/projmgr/src/ProjMgrCbuildRun.cpp
+++ b/tools/projmgr/src/ProjMgrCbuildRun.cpp
@@ -131,8 +131,8 @@ void ProjMgrCbuildRun::SetResourcesNode(YAML::Node node, const SystemResourcesTy
     SetNodeValue(memoryNode[YAML_SIZE], ProjMgrUtils::ULLToHex(item.size));
     SetNodeValue(memoryNode[YAML_PNAME], item.pname);
     SetNodeValue(memoryNode[YAML_ALIAS], item.alias);
-    if (item.default.has_value()) {
-      memoryNode[YAML_DEFAULT] = item.default.value();
+    if (item.bDefault.has_value()) {
+      memoryNode[YAML_DEFAULT] = item.bDefault.value();
     }
     SetNodeValue(memoryNode[YAML_FROM_PACK], item.fromPack);
     node[YAML_MEMORY].push_back(memoryNode);

--- a/tools/projmgr/src/ProjMgrRunDebug.cpp
+++ b/tools/projmgr/src/ProjMgrRunDebug.cpp
@@ -212,6 +212,9 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
     item.size = memory->GetAttributeAsULL("size");
     item.fromPack = memory->GetPackageID(true);
     item.pname = memory->GetProcessorName();
+    if (memory->HasAttribute("default")) {
+      item.default = memory->IsDefault();
+    }
     m_runDebug.systemResources.memories.push_back(item);
   }
 

--- a/tools/projmgr/src/ProjMgrRunDebug.cpp
+++ b/tools/projmgr/src/ProjMgrRunDebug.cpp
@@ -213,7 +213,7 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
     item.fromPack = memory->GetPackageID(true);
     item.pname = memory->GetProcessorName();
     if (memory->HasAttribute("default")) {
-      item.default = memory->IsDefault();
+      item.bDefault = memory->IsDefault();
     }
     m_runDebug.systemResources.memories.push_back(item);
   }

--- a/tools/projmgr/test/data/ImageOnly/ref/image-only+CM0.cbuild-run.yml
+++ b/tools/projmgr/test/data/ImageOnly/ref/image-only+CM0.cbuild-run.yml
@@ -21,11 +21,13 @@ cbuild-run:
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IRAM1
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
     processors:
       - core: Cortex-M0

--- a/tools/projmgr/test/data/ImageOnly/ref/image-only-multicore+CM0.cbuild-run.yml
+++ b/tools/projmgr/test/data/ImageOnly/ref/image-only-multicore+CM0.cbuild-run.yml
@@ -21,22 +21,26 @@ cbuild-run:
         start: 0x00000000
         size: 0x00080000
         pname: cm0_core0
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: SRAM_DUAL
         access: rwx
         start: 0x80000000
         size: 0x00020000
         pname: cm0_core1
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IROM1
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IRAM1
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
     processors:
       - core: Cortex-M0

--- a/tools/projmgr/test/data/TestRunDebug/ref/custom+TestHW.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/custom+TestHW.cbuild-run.yml
@@ -17,11 +17,13 @@ cbuild-run:
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: SRAM
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
     processors:
       - core: Cortex-M4

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
@@ -33,11 +33,13 @@ cbuild-run:
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: SRAM
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: CustomMemory
         access: rwx

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild-run.yml
@@ -30,11 +30,13 @@ cbuild-run:
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IRAM1
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: RAM-External
         access: rwx

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
@@ -34,22 +34,26 @@ cbuild-run:
         start: 0x00000000
         size: 0x00080000
         pname: cm0_core0
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: SRAM_DUAL
         access: rwx
         start: 0x80000000
         size: 0x00020000
         pname: cm0_core1
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IROM1
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IRAM1
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
     processors:
       - core: Cortex-M0

--- a/tools/projmgr/test/data/WestSupport/ref/solution+CM0.cbuild-run.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/solution+CM0.cbuild-run.yml
@@ -36,22 +36,26 @@ cbuild-run:
         start: 0x00000000
         size: 0x00080000
         pname: cm0_core0
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: SRAM_DUAL
         access: rwx
         start: 0x80000000
         size: 0x00020000
         pname: cm0_core1
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IROM1
         access: rx
         start: 0x00000000
         size: 0x00040000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
       - name: IRAM1
         access: rwx
         start: 0x20000000
         size: 0x00020000
+        default: true
         from-pack: ARM::RteTest_DFP@0.2.0
     processors:
       - core: Cortex-M0


### PR DESCRIPTION
To address https://github.com/Open-CMSIS-Pack/devtools/issues/2424

This pull request introduces support for marking memory regions as `default` in the project manager tool. In cbuild-run.yml `default` is located right before the `from-pack:` property under `memory`.

* Updated the JSON schema (`common.schema.json`) to define the new `default` property for memory objects.
* Modified `ProjMgrRunDebug.cpp` to read the `default` attribute when collecting settings and to write it when generating YAML output.