### PR TITLE
[projmgr] Accept listing same component multiple times in clayers

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1235,7 +1235,8 @@ protected:
   void AddMiscUniquely(MiscItem& dst, std::vector<MiscItem>& srcVec);
   bool AddGroup(const GroupNode& src, std::vector<GroupNode>& dst, ContextItem& context, const std::string root);
   bool AddFile(const FileNode& src, std::vector<FileNode>& dst, ContextItem& context, const std::string root);
-  bool AddComponent(const ComponentItem& src, const std::string& layer, std::vector<std::pair<ComponentItem, std::string>>& dst, TypePair type, ContextItem& context);
+  bool AddComponent(const ComponentItem& src, const std::string& layer, std::vector<std::pair<ComponentItem,
+    std::string>>& dst, TypePair type, ContextItem& context, bool ignoreDuplicates = false);
   void GetDeviceItem(const std::string& element, DeviceItem& device) const;
   void GetBoardItem (const std::string& element, BoardItem& board) const;
   bool GetPrecedentValue(std::string& outValue, const std::string& element) const;

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3525,7 +3525,7 @@ bool ProjMgrWorker::ProcessSequencesRelatives(ContextItem & context, bool rerun)
       if (!ProcessSequencesRelatives(context, component.build, clayer->directory)) {
         return false;
       }
-      if (!AddComponent(component, name, context.componentRequirements, context.type, context)) {
+      if (!AddComponent(component, name, context.componentRequirements, context.type, context, true)) {
         return false;
       }
     }
@@ -3795,10 +3795,15 @@ bool ProjMgrWorker::AddFile(const FileNode& src, vector<FileNode>& dst, ContextI
   return true;
 }
 
-bool ProjMgrWorker::AddComponent(const ComponentItem& src, const string& layer, vector<pair<ComponentItem, string>>& dst, TypePair type, ContextItem& context) {
+bool ProjMgrWorker::AddComponent(const ComponentItem& src, const string& layer, vector<pair<ComponentItem, string>>& dst,
+  TypePair type, ContextItem& context, bool ignoreDuplicates) {
   if (CheckContextFilters(src.type, context)) {
     for (auto& [dstNode, layer] : dst) {
       if (dstNode.component == src.component) {
+        if (ignoreDuplicates) {
+          ProjMgrLogger::Get().Warn("ignoring conflict: component '" + dstNode.component + "' is listed multiple times", context.name);
+          return true;
+        }
         ProjMgrLogger::Get().Error("conflict: component '" + dstNode.component + "' is listed multiple times", context.name);
         return false;
       }

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -7529,19 +7529,17 @@ TEST_F(ProjMgrUnitTests, DuplicateComponents) {
   argv[4] = (char*)"-o";
   argv[5] = (char*)testoutput_folder.c_str();
   argv[6] = (char*)"--context";
+  argv[7] = (char*)"duplicateComponents_cproject";
   argv[8] = (char*)"--no-check-schema";
-
-  const char* contexts[] = { "duplicateComponents_cproject", "duplicateComponents_clayer" };
-  int argCounts[] = { 8, 9 };  // without/with --no-check-schema
-  for (int argCount : argCounts) {
-    for (const char* context : contexts) {
-      argv[7] = (char*)context;
-      EXPECT_EQ(1, RunProjMgr(argCount, argv, m_envp));
-      auto errStr = streamRedirect.GetErrorString();
-      EXPECT_NE(string::npos, errStr.find("error csolution: conflict: component 'RteTest:CORE' is listed multiple times"));
-      streamRedirect.ClearStringStreams();
-    }
-  }
+  EXPECT_EQ(1, RunProjMgr(9, argv, m_envp));
+  auto errStr = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errStr.find("error csolution: conflict: component 'RteTest:CORE' is listed multiple times"));
+  
+  streamRedirect.ClearStringStreams();
+  argv[7] = (char*)"duplicateComponents_clayer";
+  EXPECT_EQ(0, RunProjMgr(9, argv, m_envp));
+  errStr = streamRedirect.GetErrorString();
+  EXPECT_NE(string::npos, errStr.find("warning csolution: ignoring conflict: component 'RteTest:CORE' is listed multiple times"));
 }
 
 TEST_F(ProjMgrUnitTests, ParseCommandLine_MutualExclusionOptions) {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- Address https://github.com/Open-CMSIS-Pack/devtools/issues/2429#issuecomment-4222604936

## Changes
<!-- List the changes this PR introduces -->
- Tolerates component being listed multiple times in clayers (set a `warning` instead of `error` in this case)
- Update test case

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
