### PR TITLE
Modify clang linker script

### DIFF
--- a/tools/projmgr/templates/clang_linker_script.ld.src
+++ b/tools/projmgr/templates/clang_linker_script.ld.src
@@ -84,11 +84,11 @@ SECTIONS
 {
     .init : {
         KEEP (*(.vectors))
-        #if 0
+#if 0
         /* Remove the interrupt vector table provided by picolibc, as CMSIS already provides one */
         KEEP (*(.text.init.enter))
-        #endif
         KEEP (*(.data.init.enter))
+#endif
         KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
     } >ROM0 AT>ROM0 :text
 

--- a/tools/projmgr/templates/clang_linker_script.ld.src
+++ b/tools/projmgr/templates/clang_linker_script.ld.src
@@ -84,7 +84,10 @@ SECTIONS
 {
     .init : {
         KEEP (*(.vectors))
+        #if 0
+        /* Remove the interrupt vector table provided by picolibc, as CMSIS already provides one */
         KEEP (*(.text.init.enter))
+        #endif
         KEEP (*(.data.init.enter))
         KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
     } >ROM0 AT>ROM0 :text

--- a/tools/projmgr/templates/clang_linker_script.ld.src
+++ b/tools/projmgr/templates/clang_linker_script.ld.src
@@ -84,11 +84,17 @@ SECTIONS
 {
     .init : {
         KEEP (*(.vectors))
-#if 0
-        /* Remove the interrupt vector table provided by picolibc, as CMSIS already provides one */
+
+        /* Disable by default
+         *
+         * *.init.enter contains a vector table provided by picolibc,
+         * whereas CMSIS already provides a vector table via .vectors
+         */
+        /*
         KEEP (*(.text.init.enter))
         KEEP (*(.data.init.enter))
-#endif
+        */
+
         KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
     } >ROM0 AT>ROM0 :text
 
@@ -132,7 +138,7 @@ SECTIONS
         KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP (*(.init_array .ctors))
         PROVIDE_HIDDEN ( __init_array_end = . );
-        PROVIDE_HIDDEN ( __bothinit_array_end = . ); 
+        PROVIDE_HIDDEN ( __bothinit_array_end = . );
 
         PROVIDE_HIDDEN ( __fini_array_start = . );
         KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
@@ -154,7 +160,7 @@ SECTIONS
     } >ROM0 AT>ROM0 :text
 
     /* additional sections when compiling with C++ exception support */
-    
+
     .except_ordered : {
         *(.gcc_except_table *.gcc_except_table.*)
         KEEP (*(.eh_frame .eh_frame.*))
@@ -168,7 +174,7 @@ SECTIONS
         *(.ARM.exidx*)
         PROVIDE(__exidx_end = .);
     } >ROM0 AT>ROM0 :text
-    
+
 
     /*
      * Data values which are preserved across reset


### PR DESCRIPTION
Commented out the section for removing the interrupt vector table provided by picolibc.

## Fixes
<!-- List the issue(s) this PR resolves -->
- duplicate interrupt vector [573](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/573)

## Changes
<!-- List the changes this PR introduces -->
- comment out the `KEEP (*(.text.init.enter))` and `KEEP (*(.data.init.enter))`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
