### PR TITLE
Separate workflow reusable-call runs from standalone runs

### DIFF
--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -118,7 +118,7 @@ jobs:
         (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/tools/buildmgr/')) ||
         ((github.event.schedule != '') && (!github.event.repository.private))
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/buildmgr.yml
+++ b/.github/workflows/buildmgr.yml
@@ -32,7 +32,7 @@ on:
     types: [ published ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -16,7 +16,7 @@ on:
       - '!**/*.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -8,7 +8,7 @@ on:
       - '**/*.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/packchk.yml
+++ b/.github/workflows/packchk.yml
@@ -37,7 +37,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/packgen.yml
+++ b/.github/workflows/packgen.yml
@@ -32,7 +32,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/projmgr.yml
+++ b/.github/workflows/projmgr.yml
@@ -36,7 +36,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/svdconv.yml
+++ b/.github/workflows/svdconv.yml
@@ -29,7 +29,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -21,7 +21,7 @@ on:
       - 'test/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Changes
Fix concurrency collisions between scheduled and push-triggered workflows

Previously, workflows such as `packchk`, `packgen`, and `projmgr ` etc used a concurrency group based only on `${{ github.workflow }}-${{ github.ref }}`. This caused runs triggered by different events (e.g. nightly schedule vs. push to main) to share the same concurrency group and cancel each other when `cancel-in-progress: true` was set.

As a result, a scheduled `nightly `run could be unexpectedly cancelled by a push-triggered run. For e.g. https://github.com/Open-CMSIS-Pack/devtools/actions/runs/24540773684/attempts/1
This change updates the concurrency group to include `${{ github.event_name }}`, ensuring that runs triggered by different event types are isolated:

`${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
