### PR TITLE
[projmgr] Allow non-unique `blocks` items in `flash-info`

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2120,7 +2120,7 @@
     "FlashInfoBlocksType": {
       "description": "An ordered list of subsequent blocks (block is the smallest unit that can be erased).",
       "type": "array",
-      "uniqueItems": true,
+      "uniqueItems": false,
       "items": { "$ref": "#/definitions/FlashInfoBlockType" }
     },
     "FlashInfoBlockType": {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2447

## Changes
<!-- List the changes this PR introduces -->
- Relax schema allowing non-unique `blocks` items in `flash-info`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
