### PR TITLE
[projmgr] Add `list npus` to filter devices with NPUs

### DIFF
--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -135,7 +135,7 @@
       <memory id="IROM1" start="0x00000000" size="0x00040000" startup="1" default="1"/>
       <memory id="IRAM1" start="0x20000000" size="0x00020000" uninit="1" default="1"/>
       <environment name="VELA">
-        <file name="scripts/vela/vela_subfamilyLevel.ini" type="ini"/>
+        <file name="Scripts/vela/vela_subfamilyLevel.ini" type="ini"/>
       </environment>
       <device Dname="RteTest_ARMCM0">
         <processor Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" Dendian="Configurable" Dclock="10000000"/>
@@ -165,7 +165,7 @@
         <feature type="NPU" n="Ethos-U55" m="256MACs" Pname="cm0_core1"/>
         <feature type="NPU" n="Ethos-U85"/> 
         <environment name="VELA">
-          <file name="scripts/vela/vela_deviceLevel.ini" type="ini"/>
+          <file name="Scripts/vela/vela_deviceLevel.ini" type="ini"/>
         </environment>
       </device>
       <device Dname="RteTest_ARMCM0_Single">

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -134,7 +134,9 @@
       <debug svd="Device/ARM/SVD/ARMCM0.svd"/>  <!-- SVD files do not contain any peripheral -->
       <memory id="IROM1" start="0x00000000" size="0x00040000" startup="1" default="1"/>
       <memory id="IRAM1" start="0x20000000" size="0x00020000" uninit="1" default="1"/>
-
+      <environment name="VELA">
+        <file name="scripts/vela/vela_subfamilyLevel.ini" type="ini"/>
+      </environment>
       <device Dname="RteTest_ARMCM0">
         <processor Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" Dendian="Configurable" Dclock="10000000"/>
         <compile header="Device/ARM/ARMCM0/Include/ARMCM0.h" define="ARMCM0"/>
@@ -159,10 +161,17 @@
         <flashinfo name="Internal Flash 16KB" start="0x0000F000" blankval="0x0000000000000000" filler="0xCCCCCCCCCCCCCCCC" pagesize="0x00000040" ptime="100000" etime="1000000" Pname="cm0_core1">
           <block count="64" size="0x100" arg="0"/>
         </flashinfo>
+        <feature type="NPU" n="Ethos-U55" m="128MACs" Pname="cm0_core0"/>
+        <feature type="NPU" n="Ethos-U55" m="256MACs" Pname="cm0_core1"/>
+        <feature type="NPU" n="Ethos-U85" m="512MACs"/> 
+        <environment name="VELA">
+          <file name="scripts/vela/vela_deviceLevel.ini" type="ini"/>
+        </environment>
       </device>
       <device Dname="RteTest_ARMCM0_Single">
         <processor Pname="cm0_core1" Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" Dendian="Configurable" Dclock="10000000"/>
         <compile header="Device/ARM/ARMCM0/Include/ARMCM0.h" define="ARMCM0"/>
+        <feature type="NPU" n="Ethos-U55" m="128MACs"/>
       </device>
       <device Dname="RteTest_ARMCM0_Test">
         <processor Pname="cm0_core2" Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" Dendian="Configurable" Dclock="10000000"/>
@@ -188,6 +197,7 @@
       <device Dname="RteTest_ARMCM3">
         <processor Dcore="Cortex-M3" DcoreVersion="r2p1" Dfpu="NO_FPU" Dmpu="MPU" Dendian="Configurable" Dclock="10000000"/>
         <compile header="Device/ARM/ARMCM3/Include/ARMCM3.h" define="ARMCM3"/>
+        <feature type="NPU" n="Ethos-U55" m="128MACs"/>
       </device>
     </subFamily>
 

--- a/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/ARM.RteTest_DFP.pdsc
@@ -163,7 +163,7 @@
         </flashinfo>
         <feature type="NPU" n="Ethos-U55" m="128MACs" Pname="cm0_core0"/>
         <feature type="NPU" n="Ethos-U55" m="256MACs" Pname="cm0_core1"/>
-        <feature type="NPU" n="Ethos-U85" m="512MACs"/> 
+        <feature type="NPU" n="Ethos-U85"/> 
         <environment name="VELA">
           <file name="scripts/vela/vela_deviceLevel.ini" type="ini"/>
         </environment>
@@ -197,7 +197,6 @@
       <device Dname="RteTest_ARMCM3">
         <processor Dcore="Cortex-M3" DcoreVersion="r2p1" Dfpu="NO_FPU" Dmpu="MPU" Dendian="Configurable" Dclock="10000000"/>
         <compile header="Device/ARM/ARMCM3/Include/ARMCM3.h" define="ARMCM3"/>
-        <feature type="NPU" n="Ethos-U55" m="128MACs"/>
       </device>
     </subFamily>
 

--- a/test/packs/ARM/RteTest_DFP/0.2.0/Scripts/vela/vela_deviceLevel.ini
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/Scripts/vela/vela_deviceLevel.ini
@@ -1,0 +1,1 @@
+// TEST File

--- a/test/packs/ARM/RteTest_DFP/0.2.0/Scripts/vela/vela_subfamilyLevel.ini
+++ b/test/packs/ARM/RteTest_DFP/0.2.0/Scripts/vela/vela_subfamilyLevel.ini
@@ -1,0 +1,1 @@
+// TEST File

--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -104,6 +104,24 @@ protected:
   int ProcessCommands();
 
   /**
+   * @brief process requested list arguments specified in command line
+   * @return program exit code as an integer, 0 for success
+  */
+  int ProcessListCommand();
+
+  /**
+   * @brief helper method to execute common list commands
+   * @param pointer to ProjMgrWorker list method
+   * @param error message to display on failure
+   * @param true to always populate contexts
+   * @return true if executed successfully
+  */
+  bool RunListCommand(
+    bool (ProjMgrWorker::* listMethod)(std::vector<std::string>&, const std::string&),
+    const std::string& errorMessage,
+    bool alwaysPopulate);
+
+  /**
    * @brief print usage
    * @param cmdOptionsDict map of command and options
    * @param cmd command for which usage is to be generated
@@ -209,6 +227,7 @@ protected:
   bool RunListPacks();
   bool RunListBoards();
   bool RunListDevices();
+  bool RunListNpus();
   bool RunListComponents();
   bool RunListConfigs();
   bool RunListDependencies();

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -654,6 +654,14 @@ public:
   bool ListDevices(std::vector<std::string>& devices, const std::string& filter = RteUtils::EMPTY_STRING);
 
   /**
+   * @brief list available NPUs
+   * @param reference to list of NPUs
+   * @param filter words to filter results
+   * @return true if executed successfully
+  */
+  bool ListNpus(std::vector<std::string>& npus, const std::string& filter = RteUtils::EMPTY_STRING);
+
+  /**
    * @brief list available components
    * @param reference to list of components
    * @param filter words to filter results

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -146,7 +146,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
 
   cxxopts::Option solution("s,solution", "Input csolution.yml file", cxxopts::value<string>());
   cxxopts::Option context("c,context", "Input context names [<project-name>][.<build-type>][+<target-type>]", cxxopts::value<std::vector<std::string>>());
-  cxxopts::Option filter("f,filter", "Filter words", cxxopts::value<string>());
+  cxxopts::Option filter("f,filter", "Filter words", cxxopts::value<vector<string>>());
   cxxopts::Option help("h,help", "Print usage");
   cxxopts::Option generator("g,generator", "Code generator identifier", cxxopts::value<string>());
   cxxopts::Option load("l,load", "Set policy for packs loading [latest | all | required]", cxxopts::value<string>());
@@ -279,7 +279,14 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
       m_context = parseResult["context"].as<vector<string>>();
     }
     if (parseResult.count("filter")) {
-      m_filter = parseResult["filter"].as<string>();
+      const auto filters = parseResult["filter"].as<vector<string>>();
+      m_filter.clear();
+      for (const auto& f : filters) {
+        if (!m_filter.empty()) {
+          m_filter += " ";
+        }
+        m_filter += f;
+      }
     }
     if (parseResult.count("generator")) {
       m_codeGenerator = parseResult["generator"].as<string>();

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -48,7 +48,7 @@ Options:\n\
   -d, --debug                   Enable debug messages\n\
   -D, --dry-run                 Enable dry-run\n\
   -e, --export arg              Set suffix for exporting <context><suffix>.cprj retaining only specified versions\n\
-  -f, --filter arg              Filter words\n\
+  -f, --filter arg [...]        Filter words, repeat options or quote for words\n\
   -g, --generator arg           Code generator identifier\n\
   -l, --load arg                Set policy for packs loading [latest | all | required]\n\
   -L, --clayer-path arg         Set search path for external clayers\n\
@@ -146,7 +146,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
 
   cxxopts::Option solution("s,solution", "Input csolution.yml file", cxxopts::value<string>());
   cxxopts::Option context("c,context", "Input context names [<project-name>][.<build-type>][+<target-type>]", cxxopts::value<std::vector<std::string>>());
-  cxxopts::Option filter("f,filter", "Filter words", cxxopts::value<vector<string>>());
+  cxxopts::Option filter("f,filter", "Filter words, repeat options or quote for words", cxxopts::value<vector<string>>());
   cxxopts::Option help("h,help", "Print usage");
   cxxopts::Option generator("g,generator", "Code generator identifier", cxxopts::value<string>());
   cxxopts::Option load("l,load", "Set policy for packs loading [latest | all | required]", cxxopts::value<string>());

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -35,6 +35,7 @@ Commands:\n\
   list templates                Print list of templates\n\
   list generators               Print list of code generators of a given context\n\
   list layers                   Print list of available, referenced and compatible layers\n\
+  list npus                     Print list of available NPUs\n\
   list packs                    Print list of used packs from the pack repository\n\
   list target-sets              Print list of target-sets in a <name>.csolution.yml\n\
   list toolchains               Print list of supported toolchains\n\
@@ -181,6 +182,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
     {"list packs",        { true,  {context, contextSet, activeTargetSet, debug, filter, load, missing, locked, quiet, schemaCheck, toolchain, verbose}}},
     {"list boards",       { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list devices",      { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list npus",         { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list configs",      { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list components",   { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list dependencies", { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
@@ -355,75 +357,7 @@ int ProjMgr::RunProjMgr(int argc, char** argv, char** envp) {
 
 int ProjMgr::ProcessCommands() {
   if (m_command == "list") {
-    // Process 'list' command
-    if (m_args.empty()) {
-      ProjMgrLogger::Get().Error("list <args> was not specified");
-      return ErrorCode::ERROR;
-    }
-    // Process argument
-    if (m_args == "packs") {
-      if (!RunListPacks()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "boards") {
-      if (!RunListBoards()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "devices") {
-      if (!RunListDevices()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "components") {
-      if (!RunListComponents()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "configs") {
-      if (!RunListConfigs()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "dependencies") {
-      if (!RunListDependencies()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "examples") {
-      if (!RunListExamples()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "templates") {
-      if (!RunListTemplates()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "contexts") {
-      if (!RunListContexts()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "target-sets") {
-      if (!RunListTargetSets()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "debuggers") {
-      if (!RunListDebuggers()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "generators") {
-      if (!RunListGenerators()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "layers") {
-      if (!RunListLayers()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "toolchains") {
-      if (!RunListToolchains()) {
-        return ErrorCode::ERROR;
-      }
-    } else if (m_args == "environment") {
-      RunListEnvironment();
-    }
-    else {
-      ProjMgrLogger::Get().Error("list <args> was not found");
-      return ErrorCode::ERROR;
-    }
+    return ProcessListCommand();
   } else if (m_command == "update-rte") {
     // Process 'update-rte' command
     if (!RunConfigure()) {
@@ -461,6 +395,40 @@ int ProjMgr::ProcessCommands() {
     return ErrorCode::ERROR;
   }
   return ErrorCode::SUCCESS;
+}
+
+int ProjMgr::ProcessListCommand() {
+  // Process 'list' command
+  if (m_args.empty()) {
+    ProjMgrLogger::Get().Error("list <args> was not specified");
+    return ErrorCode::ERROR;
+  }
+  // Process argument
+  const std::map<std::string, std::function<bool()>> handlers = {
+    { "packs",        [this]() { return RunListPacks(); } },
+    { "boards",       [this]() { return RunListBoards(); } },
+    { "devices",      [this]() { return RunListDevices(); } },
+    { "npus",         [this]() { return RunListNpus(); } },
+    { "components",   [this]() { return RunListComponents(); } },
+    { "configs",      [this]() { return RunListConfigs(); } },
+    { "dependencies", [this]() { return RunListDependencies(); } },
+    { "examples",     [this]() { return RunListExamples(); } },
+    { "templates",    [this]() { return RunListTemplates(); } },
+    { "contexts",     [this]() { return RunListContexts(); } },
+    { "target-sets",  [this]() { return RunListTargetSets(); } },
+    { "debuggers",    [this]() { return RunListDebuggers(); } },
+    { "generators",   [this]() { return RunListGenerators(); } },
+    { "layers",       [this]() { return RunListLayers(); } },
+    { "toolchains",   [this]() { return RunListToolchains(); } },
+    { "environment",  [this]() { RunListEnvironment(); return true; } }
+  };
+  const auto it = handlers.find(m_args);
+  if (it == handlers.end()) {
+    ProjMgrLogger::Get().Error("list <args> was not found");
+    return ErrorCode::ERROR;
+  }
+
+  return it->second() ? ErrorCode::SUCCESS : ErrorCode::ERROR;
 }
 
 // Set load packs policy
@@ -828,152 +796,44 @@ bool ProjMgr::RunListPacks(void) {
 }
 
 bool ProjMgr::RunListBoards(void) {
-  if (!m_csolutionFile.empty()) {
-    // Parse all input files and create contexts
-    if (!PopulateContexts()) {
-      return false;
-    }
-  }
-
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> boards;
-  if (!m_worker.ListBoards(boards, m_filter)) {
-    ProjMgrLogger::Get().Error("processing boards list failed");
-    return false;
-  }
-  for (const auto& device : boards) {
-    ProjMgrLogger::out() << device << endl;
-  }
-  return true;
+  return RunListCommand(&ProjMgrWorker::ListBoards, "processing boards list failed", false);
 }
 
 bool ProjMgr::RunListDevices(void) {
-  if (!m_csolutionFile.empty()) {
-    // Parse all input files and create contexts
-    if (!PopulateContexts()) {
-      return false;
-    }
-  }
+  return RunListCommand(&ProjMgrWorker::ListDevices, "processing devices list failed", false);
+}
 
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> devices;
-  if (!m_worker.ListDevices(devices, m_filter)) {
-    ProjMgrLogger::Get().Error("processing devices list failed");
-    return false;
-  }
-  for (const auto& device : devices) {
-    ProjMgrLogger::out() << device << endl;
-  }
-  return true;
+bool ProjMgr::RunListNpus(void) {
+  return RunListCommand(&ProjMgrWorker::ListNpus, "processing NPUs list failed", false);
 }
 
 bool ProjMgr::RunListComponents(void) {
-  if (!m_csolutionFile.empty()) {
-    // Parse all input files and create contexts
-    if (!PopulateContexts()) {
-      return false;
-    }
-  }
-
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> components;
-  if (!m_worker.ListComponents(components, m_filter)) {
-    ProjMgrLogger::Get().Error("processing components list failed");
-    return false;
-  }
-
-  for (const auto& component : components) {
-    ProjMgrLogger::out() << component << endl;
-  }
-  return true;
+  return RunListCommand(&ProjMgrWorker::ListComponents, "processing components list failed", false);
 }
 
-bool ProjMgr::RunListConfigs() {
-  // Parse all input files and create contexts
-  if (!PopulateContexts()) {
-    return false;
-  }
-
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> configFiles;
-  if (!m_worker.ListConfigs(configFiles, m_filter)) {
-    ProjMgrLogger::Get().Error("processing config list failed");
-    return false;
-  }
-
-  for (const auto& configFile : configFiles) {
-    ProjMgrLogger::out() << configFile << endl;
-  }
-  return true;
+bool ProjMgr::RunListConfigs(void) {
+  return RunListCommand(&ProjMgrWorker::ListConfigs, "processing config list failed", true);
 }
 
 bool ProjMgr::RunListDependencies(void) {
-  // Parse all input files and create contexts
-  if (!PopulateContexts()) {
-    return false;
-  }
-
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> dependencies;
-  if (!m_worker.ListDependencies(dependencies, m_filter)) {
-    ProjMgrLogger::Get().Error("processing dependencies list failed");
-    return false;
-  }
-
-  for (const auto& dependency : dependencies) {
-    ProjMgrLogger::out() << dependency << endl;
-  }
-  return true;
+  return RunListCommand(&ProjMgrWorker::ListDependencies, "processing dependencies list failed", true);
 }
 
 bool ProjMgr::RunListExamples(void) {
-  if (!m_csolutionFile.empty()) {
-    // Parse all input files and create contexts
-    if (!PopulateContexts()) {
-      return false;
-    }
-  }
-
-  // Parse context selection
-  if (!ParseAndValidateContexts()) {
-    return false;
-  }
-
-  vector<string> examples;
-  if (!m_worker.ListExamples(examples, m_filter)) {
-    ProjMgrLogger::Get().Error("processing examples list failed");
-    return false;
-  }
-
-  for (const auto& example : examples) {
-    ProjMgrLogger::out() << example << endl;
-  }
-  return true;
+  return RunListCommand(&ProjMgrWorker::ListExamples, "processing examples list failed", false);
 }
 
 bool ProjMgr::RunListTemplates(void) {
-  if (!m_csolutionFile.empty()) {
-    // Parse all input files and create contexts
+  return RunListCommand(&ProjMgrWorker::ListTemplates, "processing templates list failed", false);
+}
+
+bool ProjMgr::RunListCommand(
+  bool (ProjMgrWorker::* listMethod)(vector<string>&, const string&),
+  const string& errorMessage,
+  bool alwaysPopulate)
+{
+  // Parse all input files and create contexts
+  if (alwaysPopulate || !m_csolutionFile.empty()) {
     if (!PopulateContexts()) {
       return false;
     }
@@ -984,14 +844,14 @@ bool ProjMgr::RunListTemplates(void) {
     return false;
   }
 
-  vector<string> csolutionTemplates;
-  if (!m_worker.ListTemplates(csolutionTemplates, m_filter)) {
-    ProjMgrLogger::Get().Error("processing templates list failed");
+  vector<string> items;
+  if (!(m_worker.*listMethod)(items, m_filter)) {
+    ProjMgrLogger::Get().Error(errorMessage);
     return false;
   }
 
-  for (const auto& csolutionTemplate : csolutionTemplates) {
-    ProjMgrLogger::out() << csolutionTemplate << endl;
+  for (const auto& item : items) {
+    ProjMgrLogger::out() << item << endl;
   }
   return true;
 }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4178,7 +4178,7 @@ bool ProjMgrWorker::ListBoards(vector<string>& boards, const string& filter) {
   if (boardsSet.empty()) {
     ProjMgrLogger::Get().Error("no installed board was found");
     return false;
-}
+  }
   vector<string> boardsVec(boardsSet.begin(), boardsSet.end());
   if (!filter.empty()) {
     vector<string> matchedBoards;
@@ -4309,6 +4309,7 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
     ProjMgrLogger::Get().Error("no installed NPU was found");
     return false;
   }
+
   vector<string> npusVec;
   // build and append one formatted NPU output entry consisting of the NPU info and its associated device info lines.
   auto AddEntry = [&npusVec](const string& npuString, const auto& deviceInfos) {
@@ -4327,7 +4328,7 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
     const auto filterSet = RteUtils::SplitStringToSet(filter);
     for (const auto& [npuString, deviceInfoSet] : npuInfos) {
       set<string> remainingFilterSet;
-      // Apply Filter words matched by the NPU info are considered already satisfied. Only the remaining filter words must be matched by device lines.
+      // Apply Filter words matched by the NPU info are considered already satisfied. Only the remaining Filter words must be matched by device lines.
       for (const auto& filterWord : filterSet) {
         if (filterWord.empty()) {
           continue;

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4292,8 +4292,8 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
           }
           string nType = feature->GetAttribute("n");
           string mType = feature->GetAttribute("m");
-          if (nType.empty()) { nType = "Unknown nType"; }
-          if (mType.empty()) { mType = "Unknown mType"; }
+          if (nType.empty()) { nType = "Unknown NPU"; }
+          if (mType.empty()) { mType = "Unknown MACs"; }
 
           string npuString = nType + " (" + mType + "):";
           string deviceInfoString = "  " + deviceItem->GetVendorName() + "::" + deviceItem->GetFullDeviceName() + ",";

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4239,7 +4239,7 @@ bool ProjMgrWorker::ListDevices(vector<string>& devices, const string& filter) {
 }
 
 bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
-  map<string, pair<vector<string>, string>> deviceNpuMap;
+  map<string, set<string>> npuInfos;
   for (const auto& selectedContext : m_selectedContexts) {
     ContextItem& context = m_contexts[selectedContext];
     if (!LoadPacks(context)) {
@@ -4252,29 +4252,9 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
         // skip not end-leaf item
         continue;
       }
-      const string deviceFullName = deviceItem->GetVendorName() + "::" + deviceItem->GetFullDeviceName();
-      auto& [npuInfos, velaConfig] = deviceNpuMap[deviceFullName];
-      // collect NPU features for each processor
-      for (const auto& [pname, processor] : deviceItem->GetProcessors()) {
-        const auto& features = deviceItem->GetEffectiveProperties("feature", pname);
-        for (const auto& feature : features) {
-          if (feature->GetAttribute("type") != "NPU") {
-            continue;
-          }
-          const string& npuPname = feature->GetAttribute("Pname");
-          if (!npuPname.empty() && npuPname != pname) {
-            // Skip if this NPU pname is for a different processor pname
-            continue;
-          }
-          string npuInfo = feature->GetAttribute("n") + ", " + feature->GetAttribute("m");
-          if (!pname.empty()) {
-            npuInfo += ", [" + pname + "] " + processor->GetAttribute("Dcore");
-          }
-          npuInfos.push_back(npuInfo);
-        }
-      }
-      // Only process VELA if this device has NPU features, and skip if one VELA config is already found
-      if (!npuInfos.empty() && velaConfig.empty()) {
+      // find VELA config for this device (only once per device)
+      string velaConfig;
+      if (m_verbose) {
         const auto& envList = deviceItem->GetEffectiveProperties("environment", "");
         for (auto env : envList) {
           if (env->GetAttribute("name") != "VELA") {
@@ -4293,39 +4273,73 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
           break;
         }
       }
+      // collect NPU features for each processor
+      for (const auto& [pname, processor] : deviceItem->GetProcessors()) {
+        const auto& features = deviceItem->GetEffectiveProperties("feature", pname);
+        for (const auto& feature : features) {
+          if (feature->GetAttribute("type") != "NPU") {
+            continue;
+          }
+          const string& npuPname = feature->GetAttribute("Pname");
+          if (!npuPname.empty() && npuPname != pname) {
+            // Skip if this NPU pname is for a different processor pname
+            continue;
+          }
+          string nType = feature->GetAttribute("n");
+          string mType = feature->GetAttribute("m");
+          if (nType.empty()) { nType = "Unknown nType"; }
+          if (mType.empty()) { mType = "Unknown mType"; }
+
+          string npuString = nType + " (" + mType + "):";
+          string deviceInfoString = "  " + deviceItem->GetVendorName() + "::" + deviceItem->GetFullDeviceName() + ",";
+          if (!pname.empty()) {
+            deviceInfoString += " [" + pname + "]";
+          }
+          deviceInfoString += " " + processor->GetAttribute("Dcore");
+          if (!velaConfig.empty()) {
+            deviceInfoString += "\n    VELA config: " + velaConfig;
+          }
+          npuInfos[npuString].insert(deviceInfoString);
+        }
+      }
     }
-  }
-  set<string> npusSet;
-  for (const auto& [deviceFullName, npuVelaPair] : deviceNpuMap) {
-    const auto& npuInfos = npuVelaPair.first;
-    const auto& velaConfig = npuVelaPair.second;
-    if (npuInfos.empty()) {
-      // Skip devices without NPU
-      continue;
-    }
-    string entry = deviceFullName + ":";
-    for (const auto& npuInfo : npuInfos) {
-      entry += "\n  " + npuInfo;
-    }
-    if (!velaConfig.empty()) {
-      entry += "\n  VELA config: " + velaConfig;
-    }
-    npusSet.insert(entry);
   }
 
-  if (npusSet.empty()) {
+  if (npuInfos.empty()) {
     ProjMgrLogger::Get().Error("no installed NPU was found");
     return false;
   }
-  vector<string> npusVec(npusSet.begin(), npusSet.end());
-  if (!filter.empty()) {
-    vector<string> matchedNpus;
-    RteUtils::ApplyFilter(npusVec, RteUtils::SplitStringToSet(filter), matchedNpus);
-    if (matchedNpus.empty()) {
-      ProjMgrLogger::Get().Error("no NPU was found with filter '" + filter + "'");
-      return false;
+
+  vector<string> npusVec;
+  auto AddEntry = [&npusVec](const string& npuString, const auto& deviceInfos) {
+    string entry = npuString;
+    for (const auto& deviceInfoString : deviceInfos) { entry += "\n" + deviceInfoString; }
+    npusVec.push_back(entry);
+    };
+  if (filter.empty()) {
+    for (const auto& [npuString, deviceInfoSet] : npuInfos) {
+      AddEntry(npuString, deviceInfoSet);
     }
-    npusVec = matchedNpus;
+  } else {
+    const auto filterSet = RteUtils::SplitStringToSet(filter);
+    for (const auto& [npuString, deviceInfoSet] : npuInfos) {
+      vector<string> matchedNpus;
+      RteUtils::ApplyFilter(vector<string>{ npuString }, filterSet, matchedNpus);
+      if (!matchedNpus.empty()) {
+        AddEntry(npuString, deviceInfoSet);
+        continue;
+      }
+      vector<string> deviceInfoVec(deviceInfoSet.begin(), deviceInfoSet.end());
+      vector<string> matchedDevices;
+      RteUtils::ApplyFilter(deviceInfoVec, filterSet, matchedDevices);
+      if (!matchedDevices.empty()) {
+        AddEntry(npuString, matchedDevices);
+      }
+    }
+  }
+  if (npusVec.empty()) {
+    ProjMgrLogger::Get().Error("no NPU was found with filter '" + filter + "'");
+    return false;
   }
   npus.assign(npusVec.begin(), npusVec.end());
   return true;

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4178,7 +4178,7 @@ bool ProjMgrWorker::ListBoards(vector<string>& boards, const string& filter) {
   if (boardsSet.empty()) {
     ProjMgrLogger::Get().Error("no installed board was found");
     return false;
-  }
+}
   vector<string> boardsVec(boardsSet.begin(), boardsSet.end());
   if (!filter.empty()) {
     vector<string> matchedBoards;
@@ -4235,6 +4235,99 @@ bool ProjMgrWorker::ListDevices(vector<string>& devices, const string& filter) {
     devicesVec = matchedDevices;
   }
   devices.assign(devicesVec.begin(), devicesVec.end());
+  return true;
+}
+
+bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
+  map<string, pair<vector<string>, string>> deviceNpuMap;
+  for (const auto& selectedContext : m_selectedContexts) {
+    ContextItem& context = m_contexts[selectedContext];
+    if (!LoadPacks(context)) {
+      return false;
+    }
+    list<RteDevice*> filteredModelDevices;
+    context.rteFilteredModel->GetDevices(filteredModelDevices, "", "", RteDeviceItem::VARIANT);
+    for (const auto& deviceItem : filteredModelDevices) {
+      if (!deviceItem->GetDeviceItems().empty()) {
+        // skip not end-leaf item
+        continue;
+      }
+      const string deviceFullName = deviceItem->GetVendorName() + "::" + deviceItem->GetFullDeviceName();
+      auto& [npuInfos, velaConfig] = deviceNpuMap[deviceFullName];
+      // collect NPU features for each processor
+      for (const auto& [pname, processor] : deviceItem->GetProcessors()) {
+        const auto& features = deviceItem->GetEffectiveProperties("feature", pname);
+        for (const auto& feature : features) {
+          if (feature->GetAttribute("type") != "NPU") {
+            continue;
+          }
+          const string& npuPname = feature->GetAttribute("Pname");
+          if (!npuPname.empty() && npuPname != pname) {
+            // Skip if this NPU pname is for a different processor pname
+            continue;
+          }
+          string npuInfo = feature->GetAttribute("n") + ", " + feature->GetAttribute("m");
+          if (!pname.empty()) {
+            npuInfo += ", [" + pname + "] " + processor->GetAttribute("Dcore");
+          }
+          npuInfos.push_back(npuInfo);
+        }
+      }
+      // Only process VELA if this device has NPU features, and skip if one VELA config is already found
+      if (!npuInfos.empty() && velaConfig.empty()) {
+        const auto& envList = deviceItem->GetEffectiveProperties("environment", "");
+        for (auto env : envList) {
+          if (env->GetAttribute("name") != "VELA") {
+            continue;
+          }
+          for (auto child : env->GetChildren()) {
+            const string fileName = child->GetAttribute("name");
+            if (child->GetTag() == "file" && child->GetAttribute("type") == "ini" && !fileName.empty()) {
+              const string velaPath = child->GetOriginalAbsolutePath(fileName);
+              if (RteFsUtils::Exists(velaPath)) {
+                velaConfig = velaPath;
+              }
+              break;
+            }
+          }
+          break;
+        }
+      }
+    }
+  }
+  set<string> npusSet;
+  for (const auto& [deviceFullName, npuVelaPair] : deviceNpuMap) {
+    const auto& npuInfos = npuVelaPair.first;
+    const auto& velaConfig = npuVelaPair.second;
+    if (npuInfos.empty()) {
+      // Skip devices without NPU
+      continue;
+    }
+    string entry = deviceFullName + ":";
+    for (const auto& npuInfo : npuInfos) {
+      entry += "\n  " + npuInfo;
+    }
+    if (!velaConfig.empty()) {
+      entry += "\n  VELA config: " + velaConfig;
+    }
+    npusSet.insert(entry);
+  }
+
+  if (npusSet.empty()) {
+    ProjMgrLogger::Get().Error("no installed NPU was found");
+    return false;
+  }
+  vector<string> npusVec(npusSet.begin(), npusSet.end());
+  if (!filter.empty()) {
+    vector<string> matchedNpus;
+    RteUtils::ApplyFilter(npusVec, RteUtils::SplitStringToSet(filter), matchedNpus);
+    if (matchedNpus.empty()) {
+      ProjMgrLogger::Get().Error("no NPU was found with filter '" + filter + "'");
+      return false;
+    }
+    npusVec = matchedNpus;
+  }
+  npus.assign(npusVec.begin(), npusVec.end());
   return true;
 }
 

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4311,7 +4311,7 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
   }
 
   vector<string> npusVec;
-  // build and append one formatted NPU output entry consisting of the NPU info and its associated device info lines.
+  // build and append one formatted NPU output entry consisting of the NPU info and its associated device info lines
   auto AddEntry = [&npusVec](const string& npuString, const auto& deviceInfos) {
     string entry = npuString;
     for (const auto& deviceInfoString : deviceInfos) {
@@ -4328,7 +4328,7 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
     const auto filterSet = RteUtils::SplitStringToSet(filter);
     for (const auto& [npuString, deviceInfoSet] : npuInfos) {
       set<string> remainingFilterSet;
-      // Apply Filter words matched by the NPU info are considered already satisfied. Only the remaining Filter words must be matched by device lines.
+      // Apply Filter words matched by the NPU info are considered already satisfied. Only the remaining Filter words must be matched by device lines
       for (const auto& filterWord : filterSet) {
         if (filterWord.empty()) {
           continue;

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4309,13 +4309,16 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
     ProjMgrLogger::Get().Error("no installed NPU was found");
     return false;
   }
-
   vector<string> npusVec;
+  // build and append one formatted NPU output entry consisting of the NPU info and its associated device info lines.
   auto AddEntry = [&npusVec](const string& npuString, const auto& deviceInfos) {
     string entry = npuString;
-    for (const auto& deviceInfoString : deviceInfos) { entry += "\n" + deviceInfoString; }
+    for (const auto& deviceInfoString : deviceInfos) {
+      entry += "\n" + deviceInfoString;
+    }
     npusVec.push_back(entry);
     };
+
   if (filter.empty()) {
     for (const auto& [npuString, deviceInfoSet] : npuInfos) {
       AddEntry(npuString, deviceInfoSet);
@@ -4323,15 +4326,29 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
   } else {
     const auto filterSet = RteUtils::SplitStringToSet(filter);
     for (const auto& [npuString, deviceInfoSet] : npuInfos) {
-      vector<string> matchedNpus;
-      RteUtils::ApplyFilter(vector<string>{ npuString }, filterSet, matchedNpus);
-      if (!matchedNpus.empty()) {
+      set<string> remainingFilterSet;
+      // Apply Filter words matched by the NPU info are considered already satisfied. Only the remaining filter words must be matched by device lines.
+      for (const auto& filterWord : filterSet) {
+        if (filterWord.empty()) {
+          continue;
+        }
+        if (RteUtils::ToLower(npuString).find(RteUtils::ToLower(filterWord)) == string::npos) {
+          remainingFilterSet.insert(filterWord);
+        }
+      }
+      if (remainingFilterSet.empty()) {
         AddEntry(npuString, deviceInfoSet);
         continue;
       }
-      vector<string> deviceInfoVec(deviceInfoSet.begin(), deviceInfoSet.end());
       vector<string> matchedDevices;
-      RteUtils::ApplyFilter(deviceInfoVec, filterSet, matchedDevices);
+      for (const auto& deviceInfoString : deviceInfoSet) {
+        vector<string> deviceVec = { deviceInfoString };
+        vector<string> matched;
+        RteUtils::ApplyFilter(deviceVec, remainingFilterSet, matched);
+        if (!matched.empty()) {
+          matchedDevices.push_back(deviceInfoString);
+        }
+      }
       if (!matchedDevices.empty()) {
         AddEntry(npuString, matchedDevices);
       }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -4260,8 +4260,8 @@ bool ProjMgrWorker::ListNpus(vector<string>& npus, const string& filter) {
           if (env->GetAttribute("name") != "VELA") {
             continue;
           }
-          for (auto child : env->GetChildren()) {
-            const string fileName = child->GetAttribute("name");
+          for (auto child : env->GetEffectiveContent()) {
+            const string& fileName = child->GetAttribute("name");
             if (child->GetTag() == "file" && child->GetAttribute("type") == "ini" && !fileName.empty()) {
               const string velaPath = child->GetOriginalAbsolutePath(fileName);
               if (RteFsUtils::Exists(velaPath)) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -581,7 +581,7 @@ Ethos-U55 \\(128MACs\\):\n\
   ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n\
 Ethos-U55 \\(256MACs\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n\
-Ethos-U85 \\(Unknown mType\\):\n\
+Ethos-U85 \\(Unknown MACs\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n")));
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -567,7 +567,7 @@ ARM::RteTest_ARMCM4_NOFP (ARM::RteTest_DFP@0.2.0)\n"
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_ListNpus) {
-  char* argv[3];
+  char* argv[8];
   StdStreamRedirect streamRedirect;
 
   // list npus
@@ -576,17 +576,37 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListNpus) {
   EXPECT_EQ(0, RunProjMgr(3, argv, 0));
   auto outStr = streamRedirect.GetOutString();
   EXPECT_TRUE(regex_search(outStr, regex("\
-ARM::RteTest_ARMCM0_Dual:\n\
-  Ethos-U55, 128MACs, \\[cm0_core0\\] Cortex-M0\n\
-  Ethos-U85, 512MACs, \\[cm0_core0\\] Cortex-M0\n\
-  Ethos-U55, 256MACs, \\[cm0_core1\\] Cortex-M0\n\
-  Ethos-U85, 512MACs, \\[cm0_core1\\] Cortex-M0\n\
-  VELA config: .*vela_deviceLevel\\.ini\n\
-ARM::RteTest_ARMCM0_Single:\n\
-  Ethos-U55, 128MACs, \\[cm0_core1\\] Cortex-M0\n\
-  VELA config: .*vela_subfamilyLevel\\.ini\n\
-ARM::RteTest_ARMCM3:\n\
-  Ethos-U55, 128MACs\n")));
+Ethos-U55 \\(128MACs\\):\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
+  ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n\
+Ethos-U55 \\(256MACs\\):\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n\
+Ethos-U85 \\(Unknown mType\\):\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n")));
+
+  streamRedirect.ClearStringStreams();
+  argv[3] = (char*)"-f";
+  argv[4] = (char*)"Ethos-U55";
+  argv[5] = (char*)"-f";
+  argv[6] = (char*)"128MACs";
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+Ethos-U55 \\(128MACs\\):\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
+  ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n")));
+
+  streamRedirect.ClearStringStreams();
+  argv[7] = (char*)"-v";
+  EXPECT_EQ(0, RunProjMgr(8, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+Ethos-U55 \\(128MACs\\):\n\
+  ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
+    VELA config: .*Scripts/vela/vela_deviceLevel.ini\n\
+  ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n\
+    VELA config: .*Scripts/vela/vela_subfamilyLevel.ini\n")));
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_ListComponents) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -566,6 +566,29 @@ ARM::RteTest_ARMCM4_NOFP (ARM::RteTest_DFP@0.2.0)\n"
   );
 }
 
+TEST_F(ProjMgrUnitTests, RunProjMgr_ListNpus) {
+  char* argv[3];
+  StdStreamRedirect streamRedirect;
+
+  // list npus
+  argv[1] = (char*)"list";
+  argv[2] = (char*)"npus";
+  EXPECT_EQ(0, RunProjMgr(3, argv, 0));
+  auto outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+ARM::RteTest_ARMCM0_Dual:\n\
+  Ethos-U55, 128MACs, \\[cm0_core0\\] Cortex-M0\n\
+  Ethos-U85, 512MACs, \\[cm0_core0\\] Cortex-M0\n\
+  Ethos-U55, 256MACs, \\[cm0_core1\\] Cortex-M0\n\
+  Ethos-U85, 512MACs, \\[cm0_core1\\] Cortex-M0\n\
+  VELA config: .*vela_deviceLevel\\.ini\n\
+ARM::RteTest_ARMCM0_Single:\n\
+  Ethos-U55, 128MACs, \\[cm0_core1\\] Cortex-M0\n\
+  VELA config: .*vela_subfamilyLevel\\.ini\n\
+ARM::RteTest_ARMCM3:\n\
+  Ethos-U55, 128MACs\n")));
+}
+
 TEST_F(ProjMgrUnitTests, RunProjMgr_ListComponents) {
   char* argv[3];
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -570,7 +570,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListNpus) {
   char* argv[8];
   StdStreamRedirect streamRedirect;
 
-  // verify full NPU listing without any filter.
+  // verify full NPU listing without any filter
   argv[1] = (char*)"list";
   argv[2] = (char*)"npus";
   EXPECT_EQ(0, RunProjMgr(3, argv, 0));
@@ -585,7 +585,7 @@ Ethos-U85 \\(Unknown mType\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n")));
 
-  // verify filtering with two filter words that are both matched by the NPU info.
+  // verify filtering with two filter words that are both matched by the NPU info
   streamRedirect.ClearStringStreams();
   argv[3] = (char*)"-f";
   argv[4] = (char*)"Ethos-U55";
@@ -606,11 +606,11 @@ Ethos-U55 \\(128MACs\\):\n\
   EXPECT_TRUE(regex_search(outStr, regex("\
 Ethos-U55 \\(128MACs\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
-    VELA config: .*Scripts/vela/vela_deviceLevel.ini\n\
+    VELA config: .*Scripts/vela/vela_deviceLevel\\.ini\n\
   ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n\
-    VELA config: .*Scripts/vela/vela_subfamilyLevel.ini\n")));
+    VELA config: .*Scripts/vela/vela_subfamilyLevel\\.ini\n")));
 
-  // verify mixed npu/device infos filtering.
+  // verify mixed npu/device infos filtering
   streamRedirect.ClearStringStreams();
   argv[6] = (char*)"RteTest_ARMCM0_Single";
   EXPECT_EQ(0, RunProjMgr(7, argv, 0));

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -570,7 +570,7 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListNpus) {
   char* argv[8];
   StdStreamRedirect streamRedirect;
 
-  // list npus
+  // verify full NPU listing without any filter.
   argv[1] = (char*)"list";
   argv[2] = (char*)"npus";
   EXPECT_EQ(0, RunProjMgr(3, argv, 0));
@@ -585,6 +585,7 @@ Ethos-U85 \\(Unknown mType\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core1\\] Cortex-M0\n")));
 
+  // verify filtering with two filter words that are both matched by the NPU info.
   streamRedirect.ClearStringStreams();
   argv[3] = (char*)"-f";
   argv[4] = (char*)"Ethos-U55";
@@ -597,6 +598,7 @@ Ethos-U55 \\(128MACs\\):\n\
   ARM::RteTest_ARMCM0_Dual, \\[cm0_core0\\] Cortex-M0\n\
   ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n")));
 
+  // verify verbose mode for config files
   streamRedirect.ClearStringStreams();
   argv[7] = (char*)"-v";
   EXPECT_EQ(0, RunProjMgr(8, argv, 0));
@@ -607,6 +609,15 @@ Ethos-U55 \\(128MACs\\):\n\
     VELA config: .*Scripts/vela/vela_deviceLevel.ini\n\
   ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n\
     VELA config: .*Scripts/vela/vela_subfamilyLevel.ini\n")));
+
+  // verify mixed npu/device infos filtering.
+  streamRedirect.ClearStringStreams();
+  argv[6] = (char*)"RteTest_ARMCM0_Single";
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
+  outStr = streamRedirect.GetOutString();
+  EXPECT_TRUE(regex_search(outStr, regex("\
+Ethos-U55 \\(128MACs\\):\n\
+  ARM::RteTest_ARMCM0_Single, \\[cm0_core1\\] Cortex-M0\n")));
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_ListComponents) {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2431

## Changes
<!-- List the changes this PR introduces -->
- Introduce new `list npus` command to the `projmgr` tool, allowing users to list available NPUs along with associated device/processor information.
- Refactor and simplify the implementation of the `List` and `RunList` commands, making them more maintainable and extensible.
- Update the `--filter` option to accept multiple filter words, as `RteUtils::ApplyFilter` used in multiple places supports applying more than one filter.

Here is an example output:
```
>csolution list npus -f ethos-u85 -f "AE8 LS0" -v
Ethos-U85 (256MACs):
  Alif Semiconductor::AE822FA0E5597LS0, [M55_HE] Cortex-M55
    VELA config: C:/.../packs/AlifSemiconductor/Ensemble/2.2.0-dev/Device/core/common/scripts/vela/ensemble_vela.ini
  Alif Semiconductor::AE822FA0E5597LS0, [M55_HP] Cortex-M55
    VELA config: C:/.../packs/AlifSemiconductor/Ensemble/2.2.0-dev/Device/core/common/scripts/vela/ensemble_vela.ini
```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
