### PR TITLE
[projmgr] Use `check pack-updates` instead of `check`

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -110,6 +110,12 @@ protected:
   int ProcessListCommand();
 
   /**
+   * @brief process requested check arguments specified in command line
+   * @return program exit code as an integer, 0 for success
+  */
+  int ProcessCheckCommand();
+
+  /**
    * @brief helper method to execute common list commands
    * @param pointer to ProjMgrWorker list method
    * @param error message to display on failure

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -22,7 +22,7 @@ static constexpr const char* USAGE = "\n\
 Usage:\n\
   csolution <command> [<name>.csolution.yml] [options]\n\n\
 Commands:\n\
-  check                         Check existing project for potential pack updates\n\
+  check pack-updates            Check existing project for potential pack updates\n\
   convert                       Convert user input *.yml files to *.cbuild.yml files\n\
   list boards                   Print list of available board names\n\
   list configs                  Print list of configuration files\n\
@@ -177,27 +177,27 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
   // command options dictionary
   map<string, std::pair<bool, vector<cxxopts::Option>>> optionsDict = {
     // command, optional args, options
-    {"update-rte",        { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose, frozenPacks}}},
-    {"convert",           { false, {context, contextSet, activeTargetSet, debug, exportSuffix, load, quiet, schemaCheck, noUpdateRte, output, outputAlt, toolchain, verbose, frozenPacks, cbuildgen}}},
-    {"run",               { false, {context, contextSet, activeTargetSet, debug, generator, load, quiet, schemaCheck, verbose, dryRun}}},
-    {"check",             { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, verbose}}},
-    {"list packs",        { true,  {context, contextSet, activeTargetSet, debug, filter, load, missing, locked, quiet, schemaCheck, toolchain, verbose}}},
-    {"list boards",       { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list devices",      { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list npus",         { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list configs",      { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list components",   { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list dependencies", { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list examples",     { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list templates",    { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list contexts",     { false, {debug, filter, quiet, schemaCheck, verbose, ymlOrder}}},
-    {"list target-sets",  { false, {debug, filter, quiet, schemaCheck, verbose}}},
-    {"list debuggers",    { false, {debug, filter, quiet, schemaCheck, verbose}}},
-    {"list generators",   { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose}}},
-    {"list layers",       { false, {context, contextSet, activeTargetSet, debug, load, clayerSearchPath, quiet, schemaCheck, toolchain, verbose, updateIdx}}},
-    {"list toolchains",   { false, {context, contextSet, activeTargetSet, debug, quiet, toolchain, verbose}}},
-    {"list environment",  { true,  {}}},
-    {"rpc",               { true,  {contentLength}}},
+    {"update-rte",         { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose, frozenPacks}}},
+    {"convert",            { false, {context, contextSet, activeTargetSet, debug, exportSuffix, load, quiet, schemaCheck, noUpdateRte, output, outputAlt, toolchain, verbose, frozenPacks, cbuildgen}}},
+    {"run",                { false, {context, contextSet, activeTargetSet, debug, generator, load, quiet, schemaCheck, verbose, dryRun}}},
+    {"check pack-updates", { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, verbose}}},
+    {"list packs",         { true,  {context, contextSet, activeTargetSet, debug, filter, load, missing, locked, quiet, schemaCheck, toolchain, verbose}}},
+    {"list boards",        { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list devices",       { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list npus",          { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list configs",       { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list components",    { true,  {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list dependencies",  { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list examples",      { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list templates",     { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list contexts",      { false, {debug, filter, quiet, schemaCheck, verbose, ymlOrder}}},
+    {"list target-sets",   { false, {debug, filter, quiet, schemaCheck, verbose}}},
+    {"list debuggers",     { false, {debug, filter, quiet, schemaCheck, verbose}}},
+    {"list generators",    { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose}}},
+    {"list layers",        { false, {context, contextSet, activeTargetSet, debug, load, clayerSearchPath, quiet, schemaCheck, toolchain, verbose, updateIdx}}},
+    {"list toolchains",    { false, {context, contextSet, activeTargetSet, debug, quiet, toolchain, verbose}}},
+    {"list environment",   { true,  {}}},
+    {"rpc",                { true,  {contentLength}}},
   };
 
   try {
@@ -367,6 +367,8 @@ int ProjMgr::RunProjMgr(int argc, char** argv, char** envp) {
 int ProjMgr::ProcessCommands() {
   if (m_command == "list") {
     return ProcessListCommand();
+  } else if (m_command == "check") {
+    return ProcessCheckCommand();
   } else if (m_command == "update-rte") {
     // Process 'update-rte' command
     if (!RunConfigure()) {
@@ -399,10 +401,6 @@ int ProjMgr::ProcessCommands() {
     if (!m_rpcServer.Run()) {
       return ErrorCode::ERROR;
     }
-  } else if (m_command == "check") {
-    if (!RunCheckPackVerCmd()) {
-      return ErrorCode::ERROR;
-    }
   } else {
     ProjMgrLogger::Get().Error("<command> was not found");
     return ErrorCode::ERROR;
@@ -417,7 +415,7 @@ int ProjMgr::ProcessListCommand() {
     return ErrorCode::ERROR;
   }
   // Process argument
-  const std::map<std::string, std::function<bool()>> handlers = {
+  const map<string, function<bool()>> handlers = {
     { "packs",        [this]() { return RunListPacks(); } },
     { "boards",       [this]() { return RunListBoards(); } },
     { "devices",      [this]() { return RunListDevices(); } },
@@ -438,6 +436,25 @@ int ProjMgr::ProcessListCommand() {
   const auto it = handlers.find(m_args);
   if (it == handlers.end()) {
     ProjMgrLogger::Get().Error("list <args> was not found");
+    return ErrorCode::ERROR;
+  }
+
+  return it->second() ? ErrorCode::SUCCESS : ErrorCode::ERROR;
+}
+
+int ProjMgr::ProcessCheckCommand() {
+  // Process 'check' command
+  if (m_args.empty()) {
+    ProjMgrLogger::Get().Error("check <args> was not specified");
+    return ErrorCode::ERROR;
+  }
+  // Process argument
+  const map<string, function<bool()>> handlers = {
+    { "pack-updates", [this]() { return RunCheckPackVerCmd(); } }
+  };
+  const auto it = handlers.find(m_args);
+  if (it == handlers.end()) {
+    ProjMgrLogger::Get().Error("check <args> was not found");
     return ErrorCode::ERROR;
   }
 

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -658,18 +658,19 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_ListDependencies) {
 }
 
 TEST_F(ProjMgrUnitTests, RunProjMgr_CheckPackVerCmd) {
-  char* argv[6];
+  char* argv[7];
   StdStreamRedirect streamRedirect;
   string csolutionFile = testinput_folder + "/TestSolution/CheckPackVerCmd/checkPackVerCmd.csolution.yml";
   // no csolution file provided
   argv[1] = (char*)"check";
-  EXPECT_EQ(1, RunProjMgr(2, argv, 0));
+  argv[2] = (char*)"pack-updates";
+  EXPECT_EQ(1, RunProjMgr(3, argv, 0));
   auto errStr = streamRedirect.GetErrorString();
   EXPECT_STREQ(errStr.c_str(), "error csolution: input csolution.yml was not specified\n");
 
   // standard check output
-  argv[2] = (char*)csolutionFile.c_str();
-  EXPECT_EQ(0, RunProjMgr(3, argv, 0));
+  argv[3] = (char*)csolutionFile.c_str();
+  EXPECT_EQ(0, RunProjMgr(4, argv, 0));
   auto outStr = streamRedirect.GetOutString();
   EXPECT_STREQ(outStr.c_str(), "\
 ARM::RteTest@0.1.0 (up-to-date)\n\
@@ -678,8 +679,8 @@ ARM::RteTest_DFP@0.1.1+metadata -> 0.2.0\n");
 
   // check verbose output
   streamRedirect.ClearStringStreams();
-  argv[3] = (char*)"--verbose";
-  EXPECT_EQ(0, RunProjMgr(4, argv, 0));
+  argv[4] = (char*)"--verbose";
+  EXPECT_EQ(0, RunProjMgr(5, argv, 0));
   outStr = streamRedirect.GetOutString();
   EXPECT_STREQ(outStr.c_str(), "\
 ARM::RteTest@0.1.0 (up-to-date)\n\
@@ -694,9 +695,9 @@ ARM::RteTest_DFP@0.1.1+metadata -> 0.2.0\n\
 
   // check verbose output with filtering
   streamRedirect.ClearStringStreams();
-  argv[4] = (char*)"-f";
-  argv[5] = (char*)"RteTestBoard";
-  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+  argv[5] = (char*)"-f";
+  argv[6] = (char*)"RteTestBoard";
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
   outStr = streamRedirect.GetOutString();
   EXPECT_STREQ(outStr.c_str(), "\
 ARM::RteTestBoard@0.0.1 -> 0.1.0\n\
@@ -708,8 +709,8 @@ ARM::RteTestBoard@0.0.1 -> 0.1.0\n\
   // check verbose output for a project-specified pack
   streamRedirect.ClearStringStreams();
   csolutionFile = testinput_folder + "/TestSolution/CheckPackVerCmd/checkPackVerCmd_my-packs.csolution.yml";
-  argv[2] = (char*)csolutionFile.c_str();
-  EXPECT_EQ(0, RunProjMgr(6, argv, 0));
+  argv[3] = (char*)csolutionFile.c_str();
+  EXPECT_EQ(0, RunProjMgr(7, argv, 0));
   outStr = streamRedirect.GetOutString();
   const string expectedStr = "\
 ARM::RteTestBoard@0.2.0-dev (up-to-date)\n\


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/1830

## Changes
<!-- List the changes this PR introduces -->
- Changed the `check` command to require a subcommand, currently supporting `check pack-updates`, and updated command-line parsing and help text to reflect this new structure.



## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
