### PR TITLE
Fix crash in LoadPacks RPC call

### DIFF
--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -304,6 +304,7 @@ RpcArgs::SuccessResult RpcHandler::LoadPacks(void) {
   RpcArgs::SuccessResult result = {false};
   m_manager.Clear();
   m_solutionLoaded = false;
+  ProjMgrKernel::Get()->GetGlobalModel()->Clear();
   m_worker.InitializeModel();
   m_worker.SetLoadPacksPolicy(LoadPacksPolicy::ALL);
   result.success = m_worker.LoadAllRelevantPacks();

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -74,7 +74,7 @@ bool ProjMgrWorker::PushImageOnlyTargetType(const string& targetType, const vect
     }
   }
   CollectionUtils::PushBackUniquely(imageOnlyTargetTypes, targetType);
-  return true;  
+  return true;
 }
 
 void ProjMgrWorker::AddImageOnlyContext() {
@@ -522,6 +522,7 @@ bool ProjMgrWorker::CollectAllRequiredPdscFiles() {
 }
 
 bool ProjMgrWorker::LoadAllRelevantPacks() {
+  m_loadedPacks.clear(); // the list will be updated, is should not contain dangling pointers
   // Get required pdsc files
   std::list<std::string> pdscFiles;
   for (const auto& context : m_selectedContexts) {
@@ -6064,7 +6065,7 @@ bool ProjMgrWorker::CheckPackVerAndCollectRelNotes(std::vector<std::string>& res
 
   vector<string> checkPackResults;
   for (const auto& [packId, packInfo] : usedPacks) {
-    const string& currentVersion = packInfo.first;  
+    const string& currentVersion = packInfo.first;
     auto latestPack = latestPacks.find(packId);
     if (latestPack == latestPacks.end()) {
       checkPackResults.push_back(packId + "@" + currentVersion + " (not found in CMSIS pack root or project-specified pack paths)");

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -522,7 +522,7 @@ bool ProjMgrWorker::CollectAllRequiredPdscFiles() {
 }
 
 bool ProjMgrWorker::LoadAllRelevantPacks() {
-  m_loadedPacks.clear(); // the list will be updated, is should not contain dangling pointers
+  m_loadedPacks.clear(); // the list will be updated, it should not contain dangling pointers
   // Get required pdsc files
   std::list<std::string> pdscFiles;
   for (const auto& context : m_selectedContexts) {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/250

## Changes
<!-- List the changes this PR introduces -->
- clear RTE model and cached list of loaded packs 
Note: pack registry is not cleared, only new and modified packs get loaded

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
