### PR TITLE
[csolution-rpc] Clean active target set before loading a solution

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -1242,6 +1242,7 @@ public:
     m_missingFiles.clear();
     m_types = {};
     m_activeTargetType.clear();
+    m_activeTargetSet = {};
     m_missingToolchains.clear();
     m_undefCompiler = false;
     m_isSetupCommand = false;

--- a/tools/projmgr/test/data/TestRpc/minimal2.cproject.yml
+++ b/tools/projmgr/test/data/TestRpc/minimal2.cproject.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/cproject.schema.json
+
+project:
+
+  components:
+    - component: Startup
+    - component: CORE

--- a/tools/projmgr/test/data/TestRpc/minimal2.csolution.yml
+++ b/tools/projmgr/test/data/TestRpc/minimal2.csolution.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  compiler: AC6
+
+  target-types:
+    - type: TestHW
+      device: RteTest_ARMCM4_NOFP
+
+  projects:
+    - project: minimal2.cproject.yml
+
+  packs:
+    - pack: ARM::RteTest_DFP

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -160,6 +160,18 @@ TEST_F(ProjMgrRpcTests, RpcLoadUndefinedSolution) {
   EXPECT_TRUE(msg.find("failed to load and process solution") == 0);
 }
 
+TEST_F(ProjMgrRpcTests, RpcLoadSolutionResetActiveTargetSet) {
+  auto csolutionPath = testinput_folder + "/TestRpc/minimal.csolution.yml";
+  auto csolutionPath2 = testinput_folder + "/TestRpc/minimal2.csolution.yml";
+  const auto requests =
+    FormatRequest(1, "LoadPacks") +
+    FormatRequest(2, "LoadSolution", json({{ "solution", csolutionPath }, { "activeTarget", "TestHW" }})) +
+    FormatRequest(3, "LoadSolution", json({{ "solution", csolutionPath2 }, { "activeTarget", "TestHW" }}));
+  const auto& responses = RunRpcMethods(requests);
+  // ensure loading 'minimal2' solution does fail due to m_activeTargetSet set when previously loading 'minimal'
+  EXPECT_TRUE(responses[2]["result"]["success"]);
+}
+
 TEST_F(ProjMgrRpcTests, RpcLoadNotSolution) {
   const auto& requests = CreateLoadRequests("/TestRpc/undefined.yml");
   const auto& responses = RunRpcMethods(requests);


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/302

## Changes
<!-- List the changes this PR introduces -->
- Clean active target set before loading a solution, ensuring a previously loaded target set (and its project-context selection) is not inadvertently reused.
- Add test case.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
