### PR TITLE
[projmgr] Set target-set specific `tmpdir` as default

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -157,13 +157,14 @@ bool ProjMgrWorker::AddContexts(ProjMgrParser& parser, ContextDesc& descriptor, 
 void ProjMgrWorker::UpdateTmpDir() {
   auto& tmpdir = m_parser->GetCsolution().directories.tmpdir;
   auto& base = m_outputDir.empty() ? m_parser->GetCsolution().directory : m_outputDir;
-  if (!tmpdir.empty()) {
-    if (!m_activeTargetType.empty()) {
-      tmpdir = RteUtils::ExpandAccessSequences(tmpdir, {
+  if (!m_activeTargetType.empty()) {
+    const auto& targetSet = m_activeTargetSet.set.empty() ? "default" : m_activeTargetSet.set;
+    // default tmpdir: tmp/$TargetType$/$TargetSet$
+    tmpdir = tmpdir.empty() ? "tmp/" + m_activeTargetType + "/" + targetSet :
+      RteUtils::ExpandAccessSequences(tmpdir, {
         { RteConstants::AS_TARGET_TYPE, m_activeTargetType },
-        { RteConstants::AS_TARGET_SET, m_activeTargetSet.set.empty() ? "default" : m_activeTargetSet.set } }
+        { RteConstants::AS_TARGET_SET, targetSet } }
       );
-    }
   }
   tmpdir = base + "/" + (tmpdir.empty() ? "tmp" : tmpdir);
 }

--- a/tools/projmgr/test/data/ImageOnly/ref/image-only.cbuild-idx.yml
+++ b/tools/projmgr/test/data/ImageOnly/ref/image-only.cbuild-idx.yml
@@ -2,7 +2,7 @@ build-idx:
   generated-by: csolution version 0.0.0
   csolution: image-only.csolution.yml
   cbuild-run: out/image-only+CM0.cbuild-run.yml
-  tmpdir: tmp
+  tmpdir: tmp/CM0/default
   image-only: true
   cbuilds:
     - cbuild: out/image-only/CM0/image-only+CM0.cbuild.yml

--- a/tools/projmgr/test/data/TestSolution/tmpdir-default-active.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/tmpdir-default-active.csolution.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  compiler: AC6
+
+  target-types:
+    - type: TypeA
+      target-set:
+        - set: Set1
+          images:
+            - project-context: test1.Debug
+
+  build-types:
+    - type: Debug
+
+  projects:
+    - project: ./TestProject1/test1.cproject.yml

--- a/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
@@ -2,7 +2,7 @@ build-idx:
   generated-by: csolution version 0.0.0
   csolution: solution.csolution.yml
   cbuild-run: out/solution+CM0.cbuild-run.yml
-  tmpdir: tmp
+  tmpdir: tmp/CM0/default
   cbuilds:
     - cbuild: out/core0/CM0/Debug/core0.Debug+CM0.cbuild.yml
       west: true

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4388,6 +4388,20 @@ TEST_F(ProjMgrUnitTests, OutputDirsTmpdirAccessSequence) {
   EXPECT_EQ("tmp/TypeA/Set1", cbuild["build-idx"]["tmpdir"].as<string>());
 }
 
+TEST_F(ProjMgrUnitTests, OutputDirsTmpdirDefault) {
+  char* argv[5];
+  const string& csolution = testinput_folder + "/TestSolution/tmpdir-default-active.csolution.yml";
+  argv[1] = (char*)"convert";
+  argv[2] = (char*)csolution.c_str();
+  argv[3] = (char*)"--active";
+  argv[4] = (char*)"TypeA@Set1";
+  EXPECT_EQ(0, RunProjMgr(5, argv, m_envp));
+
+  // Check default tmp directory for active target type and target set
+  const YAML::Node& cbuild = YAML::LoadFile(testinput_folder + "/TestSolution/tmpdir-default-active.cbuild-idx.yml");
+  EXPECT_EQ("tmp/TypeA/Set1", cbuild["build-idx"]["tmpdir"].as<string>());
+}
+
 TEST_F(ProjMgrUnitTests, OutputDirsAbsolutePath) {
   StdStreamRedirect streamRedirect;
   char* argv[5];


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/102#issuecomment-4801120405
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/633

## Changes

Set a target-set specific default for build index tmpdir when an active target is selected.
This aligns default tmpdir behavior with active target context and avoids collisions across target sets.

<!-- List the changes this PR introduces -->
- Updated tmpdir defaulting logic in ProjMgr worker:
  - If active target type is present and tmpdir is not explicitly set, use target-specific default path.
  - If tmpdir is explicitly set, still expand target access sequences as before.
  - Final tmpdir remains rooted at solution/output base path.
- Updated reference outputs for scenarios now expected to generate target-specific tmpdir.
- Added a new unit test covering default tmpdir behavior with an active target selection.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
