### PR TITLE
Add `project` optional node to generated cbuild-run `output` files

### DIFF
--- a/tools/projmgr/include/ProjMgrRunDebug.h
+++ b/tools/projmgr/include/ProjMgrRunDebug.h
@@ -103,6 +103,7 @@ struct FilesType {
   std::string load;
   std::string offset;
   std::string pname;
+  std::string project;
 };
 
 /**

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2187,6 +2187,7 @@
         "info":        { "type": "string", "description": "Brief description of the file." },
         "load":        { "$ref": "#/definitions/TargetSetLoadType" },
         "load-offset": { "type": "number", "description": "Offset applied in *.csolution.yml when loading the image file." },
+        "project":     { "type": "string", "description": "Project context that generated the output artifact." },
         "pname":       { "type": "string", "description": "Image belongs to processor in a multi-core system." }
       },
       "additionalProperties": false,

--- a/tools/projmgr/src/ProjMgrCbuildRun.cpp
+++ b/tools/projmgr/src/ProjMgrCbuildRun.cpp
@@ -121,6 +121,7 @@ void ProjMgrCbuildRun::SetFilesNode(YAML::Node node, const std::vector<FilesType
     SetNodeValue(fileNode[YAML_FILE], FormatPath(item.file, m_directory));
     SetNodeValue(fileNode[YAML_INFO], item.info);
     SetNodeValue(fileNode[YAML_TYPE], item.type);
+    SetNodeValue(fileNode[YAML_PROJECT], item.project);
     SetNodeValue(fileNode[YAML_LOAD], item.load);
     if (!item.offset.empty()) {
       fileNode[YAML_LOAD_OFFSET] = ProjMgrUtils::ULLToHex(RteUtils::StringToULL(item.offset));

--- a/tools/projmgr/src/ProjMgrRunDebug.cpp
+++ b/tools/projmgr/src/ProjMgrRunDebug.cpp
@@ -336,7 +336,7 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
         item.load = item.type == RteConstants::OUTPUT_TYPE_ELF ? LOAD_IMAGE_SYMBOLS :
           item.type == RteConstants::OUTPUT_TYPE_LIB ? LOAD_NONE : LOAD_IMAGE;
       }
-      m_runDebug.outputs.push_back({ item.image, item.info, item.type, item.load, item.offset, item.pname });
+      m_runDebug.outputs.push_back({ item.image, item.info, item.type, item.load, item.offset, item.pname, RteUtils::EMPTY_STRING });
     }
   }
 
@@ -726,6 +726,7 @@ void ProjMgrRunDebug::AddGeneratedImage(const ContextItem* context, const string
     image.type = type;
     image.load = load;
     image.pname = context->deviceItem.pname;
+    image.project = context->cproject->name;
     image.offset = type == RteConstants::OUTPUT_TYPE_BIN ? context->loadOffset : RteUtils::EMPTY_STRING;
     m_runDebug.outputs.push_back(image);
   }

--- a/tools/projmgr/test/data/TestRunDebug/ref/custom+TestHW.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/custom+TestHW.cbuild-run.yml
@@ -11,6 +11,7 @@ cbuild-run:
     - file: custom/TestHW/custom.axf
       info: generate by custom+TestHW
       type: elf
+      project: custom
       load: image+symbols
   system-resources:
     memory:

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
@@ -14,14 +14,17 @@ cbuild-run:
     - file: run-debug/TestHW/run-debug.axf
       info: generate by run-debug+TestHW
       type: elf
+      project: run-debug
       load: none
     - file: run-debug/TestHW/run-debug.hex
       info: generate by run-debug+TestHW
       type: hex
+      project: run-debug
       load: none
     - file: run-debug/TestHW/run-debug.bin
       info: generate by run-debug+TestHW
       type: bin
+      project: run-debug
       load: image
       load-offset: 0x0000A000
     - file: ../../data/TestRunDebug/customImage.bin

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW2.cbuild-run.yml
@@ -14,14 +14,17 @@ cbuild-run:
     - file: run-debug/TestHW2/run-debug.axf
       info: generate by run-debug+TestHW2
       type: elf
+      project: run-debug
       load: symbols
     - file: run-debug/TestHW2/run-debug.hex
       info: generate by run-debug+TestHW2
       type: hex
+      project: run-debug
       load: image
     - file: run-debug/TestHW2/run-debug.bin
       info: generate by run-debug+TestHW2
       type: bin
+      project: run-debug
       load: none
     - file: ../../data/TestRunDebug/customLibrary.x
       type: lib

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW3.cbuild-run.yml
@@ -11,21 +11,25 @@ cbuild-run:
     - file: core0/TestHW3/core0.axf
       info: generate by core0+TestHW3
       type: elf
+      project: core0
       load: none
       pname: cm0_core0
     - file: core1/TestHW3/core1.axf
       info: generate by core1+TestHW3
       type: elf
+      project: core1
       load: symbols
       pname: cm0_core1
     - file: core1/TestHW3/core1.hex
       info: generate by core1+TestHW3
       type: hex
+      project: core1
       load: image
       pname: cm0_core1
     - file: core1/TestHW3/core1.bin
       info: generate by core1+TestHW3
       type: bin
+      project: core1
       load: none
       pname: cm0_core1
   system-resources:

--- a/tools/projmgr/test/data/WestSupport/ref/solution+CM0.cbuild-run.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/solution+CM0.cbuild-run.yml
@@ -14,21 +14,25 @@ cbuild-run:
     - file: core0/CM0/Debug/zephyr/zephyr.elf
       info: generate by core0.Debug+CM0
       type: elf
+      project: core0
       load: symbols
       pname: cm0_core0
     - file: core0/CM0/Debug/zephyr/zephyr.hex
       info: generate by core0.Debug+CM0
       type: hex
+      project: core0
       load: image
       pname: cm0_core0
     - file: core1/CM0/Debug/zephyr/zephyr.elf
       info: generate by core1.Debug+CM0
       type: elf
+      project: core1
       load: symbols
       pname: cm0_core1
     - file: core1/CM0/Debug/zephyr/zephyr.hex
       info: generate by core1.Debug+CM0
       type: hex
+      project: core1
       load: image
       pname: cm0_core1
   system-resources:


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/644

## Changes
- add a `project` field to the cbuild-run file schema for output artifacts
- populate `project` when generating `cbuild-run.yml` entries from project outputs
- serialize the new field in `ProjMgrCbuildRun::SetFilesNode`
- keep existing collected external/custom output entries unchanged by setting `project` to empty when not applicable
- update run/debug and West support reference `*.cbuild-run.yml` files to include the new metadata

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

### Notes
- This change improves traceability of generated artifacts in `cbuild-run.yml`, especially for multi-project and multi-core solutions where outputs come from different project contexts.
- Risk is low and mainly limited to consumers of `cbuild-run.yml` that validate or parse file entries; they may need to tolerate the additional optional `project` property.
- Non-generated/custom file entries do not gain a project value.