### PR TITLE
Fix MLOps documentation links

### DIFF
--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2666,7 +2666,7 @@
       "additionalProperties": false
     },
     "MlopsType": {
-      "title": "mlops:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/Experimental-Features/#mlops-management",
+      "title": "mlops:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#mlops-management",
       "description": "Configuration for MLOps features.",
       "type": ["null", "object"],
       "properties": {
@@ -2706,7 +2706,7 @@
       "additionalProperties": false
     },
     "MlopsDescType": {
-      "title": "cbuild-mlops:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/Experimental-Features/#mlops-management",
+      "title": "cbuild-mlops:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-CBuild-Format/#cbuild-mlopsyml",
       "type": ["null", "object"],
       "properties": {
         "description": { "type": "string", "description": "Brief description of the MLOps configuration." },


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/pull/601

## Changes
<!-- List the changes this PR introduces -->
- Update MLOps schema documentation links to their new input and build format locations

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
