### PR TITLE
Preserve the expected cgen path when the generated layer is absent

### DIFF
--- a/tools/projmgr/src/ProjMgrExtGenerator.cpp
+++ b/tools/projmgr/src/ProjMgrExtGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2020-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -71,14 +71,16 @@ ClayerItem* ProjMgrExtGenerator::GetGeneratorImport(const string& contextId, boo
   success = true;
   for (const auto& [options, contexts] : GetUsedGenerators()) {
     if (find(contexts.begin(), contexts.end(), contextId) != contexts.end()) {
-      if (!RteFsUtils::Exists(options.name)) {
+      if (RteFsUtils::Exists(options.name)) {
+        if (!m_parser->ParseClayer(options.name, m_checkSchema)) {
+          success = false;
+          return nullptr;
+        }
+      } else {
         ProjMgrLogger::Get().Error("cgen file was not found, run generator '" + options.id + "' for context '" + contextId + "'", contextId, options.name);
         success = false;
-        return nullptr;
-      }
-      if (!m_parser->ParseClayer(options.name, m_checkSchema)) {
-        success = false;
-        return nullptr;
+        // store cgen path also when the file does not exist
+        m_parser->GetClayers()[options.name].path = options.name;
       }
       return &m_parser->GetClayers().at(options.name);
     }

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -5856,11 +5856,11 @@ bool ProjMgrWorker::ExecuteExtGenerator(std::string& generatorId) {
 bool ProjMgrWorker::ProcessGeneratedLayers(ContextItem& context) {
   bool success;
   ClayerItem* cgen = m_extGenerator->GetGeneratorImport(context.name, success);
-  if (!success) {
-    return false;
-  }
   if (cgen) {
     context.clayers[cgen->path] = cgen;
+    if (!success) {
+      return false;
+    }
     if (cgen->packs.size() > 0) {
       vector<PackItem> packRequirements;
       InsertPackRequirements(cgen->packs, packRequirements, cgen->directory);
@@ -5884,7 +5884,7 @@ bool ProjMgrWorker::ProcessGeneratedLayers(ContextItem& context) {
       return false;
     }
   }
-  return true;
+  return success;
 }
 
 void ProjMgrWorker::PrintContextErrors(const string& contextName) {

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -5934,6 +5934,8 @@ TEST_F(ProjMgrUnitTests, ExternalGenerator_NoCgenFile) {
   StdStreamRedirect streamRedirect;
   char* argv[5];
   const string& csolution = testinput_folder + "/ExternalGenerator/extgen.csolution.yml";
+  const string& cbuildIdxFile = testinput_folder + "/ExternalGenerator/extgen.cbuild-idx.yml";
+  RteFsUtils::RemoveFile(cbuildIdxFile);
   argv[1] = (char*)csolution.c_str();
   argv[2] = (char*)"convert";
   argv[3] = (char*)"-c";
@@ -5941,6 +5943,11 @@ TEST_F(ProjMgrUnitTests, ExternalGenerator_NoCgenFile) {
   EXPECT_EQ(1, RunProjMgr(5, argv, 0));
   auto errStr = streamRedirect.GetErrorString();
   EXPECT_TRUE(errStr.find("error csolution: cgen file was not found, run generator 'RteTestExternalGenerator' for context 'core0.Debug+MultiCore'") != string::npos);
+
+  const YAML::Node& cbuildIdx = YAML::LoadFile(cbuildIdxFile);
+  const YAML::Node& clayers = cbuildIdx["build-idx"]["cbuilds"][0]["clayers"];
+  ASSERT_EQ(1, clayers.size());
+  EXPECT_EQ("generated/MultiCore/core0.cgen.yml", clayers[0]["clayer"].as<string>());
 
   RteFsUtils::RemoveFile(dstGlobalGenerator);
 }


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/394

## Changes
<!-- List the changes this PR introduces -->
- Preserve the expected cgen path when a generated layer file is absent. The missing cgen is registered as a `clayer` before context processing returns an error. This allows the generated `*.cbuild-idx.yml` file to identify the missing generator output while conversion still fails with the existing diagnostic.
- Extended `ExternalGenerator_NoCgenFile` test case to verify that the missing cgen path is listed under `clayers` in the generated cbuild index.

## Risk
Low. The successful generator-import path is unchanged; only missing cgen handling and its partial index output are affected.


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
