### PR TITLE
Allow board layer matching without a selected device

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3900,8 +3900,8 @@ bool ProjMgrWorker::CheckBoardDeviceInLayer(const ContextItem& context, const Cl
     DeviceItem forDevice, device;
     GetDeviceItem(clayer.forDevice, forDevice);
     GetDeviceItem(context.device, device);
-    // Skip the device name comparison against 'for-device' when no device is specified
-    // This is the case during layer discovery when only the board is specified
+    // Skip comparing the layer's 'for-device' name when the context has no device name
+    // (e.g. during layer discovery when only the board is specified)
     if ((!forDevice.name.empty() && !device.name.empty() && (forDevice.name != device.name)) ||
         (!forDevice.vendor.empty() && !device.vendor.empty() && (forDevice.vendor != device.vendor)) ||
         (!forDevice.pname.empty()  && !device.pname.empty()  && (forDevice.pname != device.pname))) {

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -3900,7 +3900,9 @@ bool ProjMgrWorker::CheckBoardDeviceInLayer(const ContextItem& context, const Cl
     DeviceItem forDevice, device;
     GetDeviceItem(clayer.forDevice, forDevice);
     GetDeviceItem(context.device, device);
-    if ((!forDevice.name.empty() && (forDevice.name != device.name)) ||
+    // Skip the device name comparison against 'for-device' when no device is specified
+    // This is the case during layer discovery when only the board is specified
+    if ((!forDevice.name.empty() && !device.name.empty() && (forDevice.name != device.name)) ||
         (!forDevice.vendor.empty() && !device.vendor.empty() && (forDevice.vendor != device.vendor)) ||
         (!forDevice.pname.empty()  && !device.pname.empty()  && (forDevice.pname != device.pname))) {
       return false;

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -1786,7 +1786,7 @@ TEST_F(ProjMgrWorkerUnitTests, CheckBoardDeviceInLayer) {
   {"DeviceVendor::DeviceName:ProcessorName", "OtherVendor::DeviceName:ProcessorName" , false},
   {"DeviceVendor::DeviceName:ProcessorName", "DeviceVendor::OtherName:ProcessorName" , false},
   {"DeviceVendor::DeviceName:ProcessorName", "DeviceVendor::DeviceName:OtherName"    , false},
-  {""                                      ,               "DeviceName"              , false},
+  {""                                      ,               "DeviceName"              ,  true},
   {"DeviceVendor::DeviceName:ProcessorName", "DeviceVendor::DeviceName:ProcessorName",  true},
   {"DeviceVendor::DeviceName:ProcessorName", "DeviceVendor::DeviceName"              ,  true},
   {"DeviceVendor::DeviceName:ProcessorName",               "DeviceName"              ,  true},


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/devtools/issues/2527

## Changes
- Skip comparing the layer's `for-device` name when the current context does not specify a `device`. This supports layer discovery when only the `board` is specified while preserving `processor` checks when available.
- Update the unit test to expect successful matching for a board-only context with a device-name constraint.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).