### PR TITLE
RPC `DiscoverLayers`: consider layers from all packs

### DIFF
--- a/tools/projmgr/src/ProjMgrRpcServer.cpp
+++ b/tools/projmgr/src/ProjMgrRpcServer.cpp
@@ -930,9 +930,15 @@ RpcArgs::DiscoverLayersInfo RpcHandler::DiscoverLayers(const string& solution, c
     return result;
   }
   m_worker.SetUpCommand(true);
+
+  // discover compatible layers considering all packs
   StrVec layers;
   StrSet fails;
-  if(!m_worker.ListLayers(layers, "", fails) || !m_worker.ElaborateVariablesConfigurations()) {
+  m_worker.SetLoadPacksPolicy(LoadPacksPolicy::ALL);
+  auto listLayersSuccess = m_worker.ListLayers(layers, "", fails);
+  m_worker.SetLoadPacksPolicy(LoadPacksPolicy::DEFAULT);
+
+  if(!listLayersSuccess || !m_worker.ElaborateVariablesConfigurations()) {
     result.message = "No compatible software layer was found in the installed packs.\nInstall additional packs containing suitable layers before restarting the 'Create Solution' flow.";
     return result;
   } else {

--- a/tools/projmgr/test/data/TestLayers/config-discover-all-packs.csolution.yml
+++ b/tools/projmgr/test/data/TestLayers/config-discover-all-packs.csolution.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/main/tools/projmgr/schemas/csolution.schema.json
+
+solution:
+
+  build-types:
+    - type: CompatibleLayers
+
+  target-types:
+    - type: RteTest_ARMCM3
+      device: RteTest_ARMCM3
+
+  projects:
+    - project: config.cproject.yml
+
+  packs:
+    - pack: ARM::RteTest
+    - pack: ARM::RteTest_DFP@0.1.1

--- a/tools/projmgr/test/src/ProjMgrRpcTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrRpcTests.cpp
@@ -1677,6 +1677,16 @@ TEST_F(ProjMgrRpcTests, RpcDiscoverLayers) {
   EXPECT_EQ(responses[0]["result"]["message"], "No compatible software layer was found in the installed packs.\nInstall additional packs containing suitable layers before restarting the 'Create Solution' flow.");
 }
 
+TEST_F(ProjMgrRpcTests, RpcDiscoverLayersFromAllPacks) {
+  const auto csolutionPath = testinput_folder + "/TestLayers/config-discover-all-packs.csolution.yml";
+  const auto requests = FormatRequest(1, "DiscoverLayers",
+    json({{ "solution", csolutionPath }, { "activeTarget", "" }}));
+  const auto responses = RunRpcMethods(requests);
+
+  EXPECT_TRUE(CompareRpcResponse(responses[0], testinput_folder + "/TestLayers/ref/rpc-discover-layers.json"))
+    << "json response:\n" << ProjMgrTestEnv::StripAbsoluteFunc(responses[0].dump(2));
+}
+
 TEST_F(ProjMgrRpcTests, RpcListMissingPacks) {
   auto csolutionPath = testinput_folder + "/TestSolution/pack_missing.csolution.yml";
   auto requests =


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/351

## Changes
- Ensures `DiscoverLayers` considers compatible layers from packs not selected by the solution.
- Temporarily use the `ALL` pack-loading policy while listing compatible layers, then restore the default policy.
- Add a solution fixture and RPC regression test covering discovery across all installed packs.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing is not necessary.
- [x] 🛡️ Security impacts have been considered; no direct impact identified.
- [x] 📖 Documentation updates are not required.
- [x] 🧠 Third-party dependencies and TPIP updates are not required.