### PR TITLE
Add optional `ram-start` and `ram-size` to target `memory`

### DIFF
--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -121,6 +121,8 @@ struct ProcessorItem {
  *        size
  *        algorithm
  *        pname
+ *        ram start
+ *        ram size
 */
 struct MemoryItem {
   std::string name;
@@ -129,6 +131,8 @@ struct MemoryItem {
   std::string size;
   std::string algorithm;
   std::string pname;
+  std::string ramStart;
+  std::string ramSize;
 };
 
 /**

--- a/tools/projmgr/include/ProjMgrRunDebug.h
+++ b/tools/projmgr/include/ProjMgrRunDebug.h
@@ -274,6 +274,7 @@ protected:
     const RteItem* item, const std::string pname);
   void AddGeneratedImage(const ContextItem* context, const std::string& filename, const std::string& type, const std::string& load);
   void AddGeneratedImages(const ContextItem* context);
+  bool CheckDefaultRam(const RamType& defaultRam);
   void SetAccessPorts(std::vector<AccessPortType>& parent, const std::map<unsigned int,
     std::vector<AccessPortType>>& childrenMap);
   void SetProtNodes(const RteDeviceProperty* item, AccessPortType& ap);

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2109,7 +2109,9 @@
         "start":    { "title": "start:", "type": "number", "description": "Base address of the memory." },
         "size":     { "title": "size:", "type": "number", "description": "Size of the memory." },
         "pname":    { "title": "pname:", "type": "string", "description": "Only accessible by the specified processor." },
-        "algorithm":{ "title": "algorithm:", "type": "string", "description": "Programming algorithm for download." }
+        "algorithm":{ "title": "algorithm:", "type": "string", "description": "Programming algorithm for download." },
+        "ram-start":{ "title": "ram-start:", "type": "number", "description": "Start address of RAM where the algorithm will be executed from." },
+        "ram-size": { "title": "ram-size:", "type": "number", "description": "Maximum size of RAM available for executing the programming algorithm." }
       },
       "additionalProperties": false,
       "required": ["name", "access", "start", "size"]

--- a/tools/projmgr/src/ProjMgrRunDebug.cpp
+++ b/tools/projmgr/src/ProjMgrRunDebug.cpp
@@ -150,10 +150,6 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
         break;
       }
     }
-    if (defaultRam.size == 0) {
-      ProjMgrLogger::Get().Error("no default rwx memory nor algorithm with ramstart/size was found");
-      return false;
-    }
   }
 
   // board collections
@@ -199,6 +195,9 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
       item.ram.size = algorithm->GetAttributeAsULL("RAMsize");
       item.ram.pname = algorithm->GetProcessorName();
     } else {
+      if (!CheckDefaultRam(defaultRam)) {
+        return false;
+      }
       item.ram.start = defaultRam.start;
       item.ram.size = defaultRam.size;
       item.ram.pname = defaultRam.pname;
@@ -236,9 +235,12 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
       algoItem.algorithm = memory.algorithm;
       algoItem.start = memItem.start;
       algoItem.size = memItem.size;
-      algoItem.ram.start = defaultRam.start;
-      algoItem.ram.size = defaultRam.size;
-      algoItem.ram.pname = defaultRam.pname;
+      if ((memory.ramStart.empty() || memory.ramSize.empty()) && !CheckDefaultRam(defaultRam)) {
+        return false;
+      }
+      algoItem.ram.start = memory.ramStart.empty() ? defaultRam.start : RteUtils::StringToULL(memory.ramStart);
+      algoItem.ram.size = memory.ramSize.empty() ? defaultRam.size : RteUtils::StringToULL(memory.ramSize);
+      algoItem.ram.pname = memory.pname.empty() ? defaultRam.pname : memory.pname;
       m_runDebug.algorithms.push_back(algoItem);
     }
   }
@@ -378,6 +380,14 @@ bool ProjMgrRunDebug::CollectSettings(const vector<ContextItem*>& contexts, cons
   CollectDebugTopology(*context0, debugs, pnames);
 
   return true;
+}
+
+bool ProjMgrRunDebug::CheckDefaultRam(const RamType& defaultRam) {
+  if (defaultRam.size != 0) {
+    return true;
+  }
+  ProjMgrLogger::Get().Error("no default rwx memory nor algorithm with ramstart/size was found");
+  return false;
 }
 
 void ProjMgrRunDebug::CollectDebuggerSettings(const ContextItem& context, const DebugAdaptersItem& adapters,

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -1101,6 +1101,8 @@ bool ProjMgrYamlParser::ParseTargetType(const YAML::Node& parent, const string& 
       ParseString(memoryEntry, YAML_ALGORITHM, memoryItem.algorithm);
       ParseNumber(memoryEntry, file, YAML_START, memoryItem.start);
       ParseNumber(memoryEntry, file, YAML_SIZE, memoryItem.size);
+      ParseNumber(memoryEntry, file, YAML_RAM_START, memoryItem.ramStart);
+      ParseNumber(memoryEntry, file, YAML_RAM_SIZE, memoryItem.ramSize);
       targetType.memory.push_back(memoryItem);
     }
   }

--- a/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
+++ b/tools/projmgr/test/data/TestRunDebug/ref/run-debug+TestHW.cbuild-run.yml
@@ -161,8 +161,8 @@ cbuild-run:
     - algorithm: ../../data/TestRunDebug/CustomAlgo.flm
       start: 0x80000000
       size: 0x00010000
-      ram-start: 0x20000000
-      ram-size: 0x00020000
+      ram-start: 0x80000000
+      ram-size: 0x00008000
   flash-info:
     - name: Family Flash
       start: 0x80000000

--- a/tools/projmgr/test/data/TestRunDebug/run-debug.csolution.yml
+++ b/tools/projmgr/test/data/TestRunDebug/run-debug.csolution.yml
@@ -14,6 +14,8 @@ solution:
           name: CustomMemory
           access: rwx
           algorithm: CustomAlgo.flm
+          ram-start: 0x80000000
+          ram-size: 0x00008000
       target-set:
         - set:
           info: Info target-set

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -145,6 +145,33 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessDevice) {
   EXPECT_TRUE(context.targetAttributes.find("Dendian") == context.targetAttributes.end());
 }
 
+TEST_F(ProjMgrWorkerUnitTests, CheckDefaultRam) {
+  ContextDesc descriptor;
+  const string& filename = testinput_folder + "/TestProject/test.cproject.yml";
+  ASSERT_TRUE(parser.ParseCproject(filename, true));
+  ASSERT_TRUE(AddContexts(parser, descriptor, filename));
+  map<string, ContextItem>* contextMap;
+  GetContexts(contextMap);
+  ContextItem context = contextMap->begin()->second;
+  ASSERT_TRUE(LoadPacks(context));
+  ASSERT_TRUE(ProcessPrecedences(context));
+  ASSERT_TRUE(ProcessDevice(context));
+
+  context.devicePack = nullptr;
+  context.boardPack = nullptr;
+  context.memory = {{ "CustomMemory", "rwx", "0x80000000", "0x00010000",
+    "CustomAlgo.flm", {}, "0x80000000", {} }};
+  const vector<ContextItem*> contexts = { &context };
+  ProjMgrRunDebug runDebug;
+
+  ProjMgrLogger::Get().Clear();
+  EXPECT_FALSE(runDebug.CollectSettings(contexts, parser.GetDebugAdaptersItem()));
+  const auto& errors = ProjMgrLogger::Get().GetErrorsForContext();
+  ASSERT_EQ(1, errors.size());
+  EXPECT_EQ("no default rwx memory nor algorithm with ramstart/size was found", errors.front());
+  ProjMgrLogger::Get().Clear();
+}
+
 TEST_F(ProjMgrWorkerUnitTests, ProcessDeviceUndefLayerVar) {
   ContextItem context;
   EXPECT_TRUE(LoadPacks(context));


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2467

## Changes
<!-- List the changes this PR introduces -->
- Add optional `ram-start` and `ram-size` properties to target `memory` entries.
- Parse custom RAM settings and include them in generated `.cbuild-run.yml` programming data.
- Fall back to the default RAM start or size when the corresponding custom value is omitted.
- Preserve validation when neither custom nor default RAM settings are available.
- Add unit and run/debug reference coverage for custom RAM settings and missing defaults.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
