### PR TITLE
Add possibility to use piped attributes for comparison

### DIFF
--- a/libs/rtemodel/src/RteCondition.cpp
+++ b/libs/rtemodel/src/RteCondition.cpp
@@ -235,7 +235,7 @@ RteItem::ConditionResult RteConditionExpression::EvaluateExpression(RteTarget* t
         continue;
       }
       // all other attributes
-      if(!WildCards::Match(va, v))
+      if(!WildCards::MatchAny(va, v))
         return FAILED;
     } else if(GetExpressionType() == DENY) {
       return FAILED; // for denied attributes, all must be given

--- a/libs/rtemodel/test/src/RteConditionTest.cpp
+++ b/libs/rtemodel/test/src/RteConditionTest.cpp
@@ -47,6 +47,49 @@ TEST(RteConditionValidateTest, Validate)
   EXPECT_FALSE(deviceExpression.Validate());
 }
 
+TEST_F(RteConditionTest, PipeSeparatedWildcardEvaluation) {
+  RteKernelSlim rteKernel;
+  rteKernel.SetCmsisPackRoot(RteModelTestConfig::CMSIS_PACK_ROOT);
+  RteCprjProject* loadedCprjProject = rteKernel.LoadCprj(RteTestM3_cprj);
+  ASSERT_NE(loadedCprjProject, nullptr);
+  EXPECT_TRUE(loadedCprjProject->Validate());
+
+  RteTarget* activeTarget = loadedCprjProject->GetActiveTarget();
+  ASSERT_NE(activeTarget, nullptr);
+  RteConditionContext* filterContext = activeTarget->GetFilterContext();
+  ASSERT_NE(filterContext, nullptr);
+
+  RteRequireExpression deviceExpression(nullptr);
+  deviceExpression.AddAttribute("Dname", "DoesNotMatch|RteTest_ARMCM?");
+  deviceExpression.ConstructID();
+  EXPECT_EQ(deviceExpression.Evaluate(filterContext), RteItem::FULFILLED);
+
+  deviceExpression.SetAttribute("Dname", "DoesNotMatch|RteTest_ARMCM4");
+  EXPECT_EQ(deviceExpression.Evaluate(filterContext), RteItem::FAILED);
+
+  activeTarget->SetAttribute("Tcompiler", "ARMCC|GCC");
+
+  RteRequireExpression armccExpression(nullptr);
+  armccExpression.AddAttribute("Tcompiler", "ARMCC");
+  armccExpression.ConstructID();
+  EXPECT_EQ(armccExpression.Evaluate(filterContext), RteItem::FULFILLED);
+
+  RteRequireExpression gccExpression(nullptr);
+  gccExpression.AddAttribute("Tcompiler", "GCC");
+  gccExpression.ConstructID();
+  EXPECT_EQ(gccExpression.Evaluate(filterContext), RteItem::FULFILLED);
+
+  RteRequireExpression alternativeCompilerExpression(nullptr);
+  alternativeCompilerExpression.AddAttribute("Tcompiler", "XC|GCC");
+  alternativeCompilerExpression.ConstructID();
+  EXPECT_EQ(alternativeCompilerExpression.Evaluate(filterContext), RteItem::FULFILLED);
+
+  RteRequireExpression unsupportedCompilerExpression(nullptr);
+  unsupportedCompilerExpression.AddAttribute("Tcompiler", "XC");
+  unsupportedCompilerExpression.ConstructID();
+  EXPECT_EQ(unsupportedCompilerExpression.Evaluate(filterContext), RteItem::FAILED);
+}
+
 TEST_F(RteConditionTest, MissingIgnoredFulfilledSelectable) {
   // load project to get a working target and condition contexts
   RteKernelSlim rteKernel;

--- a/libs/rteutils/include/WildCards.h
+++ b/libs/rteutils/include/WildCards.h
@@ -43,6 +43,14 @@ public:
   static bool Match(const std::string& s1, const std::string& s2);
 
   /**
+   * @brief match any pair of non-empty, pipe-separated strings
+   * @param s1 pipe-separated strings to be matched, can contain wild card patterns
+   * @param s2 pipe-separated strings to be matched, can contain wild card patterns
+   * @return true if any pair of strings matches, otherwise false
+  */
+  static bool MatchAny(const std::string& s1, const std::string& s2);
+
+  /**
    * @brief converts "*" to ".*" and "?" to "."
    * @param s string to be converted
    * @return converted string

--- a/libs/rteutils/src/WildCards.cpp
+++ b/libs/rteutils/src/WildCards.cpp
@@ -13,6 +13,8 @@
 /******************************************************************************/
 
 #include "WildCards.h"
+#include "RteUtils.h"
+
 #include <regex>
 
 
@@ -34,6 +36,39 @@ bool WildCards::Match(const std::string& s1, const std::string& s2)
   // swap the arguments if s2 is a pattern
   if (IsWildcardPattern(s2) && MatchToPattern(s1, s2)) {
     return true;
+  }
+  return false;
+}
+
+bool WildCards::MatchAny(const std::string& s1, const std::string& s2)
+{
+  // first compare strings as is to save time by further match
+  if (s1 == s2) {
+    return true;
+  }
+
+  if (s1.empty() || s2.empty()) {
+    return false;
+  }
+
+
+  std::list<std::string> alternatives1;
+  std::list<std::string> alternatives2;
+  RteUtils::SplitString(alternatives1, s1, '|');
+  RteUtils::SplitString(alternatives2, s2, '|');
+
+  for (const auto& alternative1 : alternatives1) {
+    if (alternative1.empty()) {
+      continue;
+    }
+    for (const auto& alternative2 : alternatives2) {
+      if (alternative2.empty()) {
+        continue;
+      }
+      if (Match(alternative1, alternative2)) {
+        return true;
+      }
+    }
   }
   return false;
 }

--- a/libs/rteutils/test/src/RteUtilsTest.cpp
+++ b/libs/rteutils/test/src/RteUtilsTest.cpp
@@ -226,6 +226,7 @@ TEST(RteUtilsTest, WildCardsTo) {
 }
 
 TEST(RteUtilsTest, WildCardMatch) {
+  EXPECT_EQ(true, WildCards::Match("", ""));
   EXPECT_EQ(true, WildCards::Match("a", "a"));
   EXPECT_EQ(false, WildCards::Match("a", ""));
   EXPECT_EQ(false, WildCards::Match("", "d"));
@@ -284,6 +285,29 @@ TEST(RteUtilsTest, WildCardMatch) {
   for (auto iter = inputStr.cbegin(); iter != inputStr.cend() - 1; iter++) {
     EXPECT_TRUE(WildCards::Match(*iter, *(iter + 1))) << "Failed for " << (*iter) << " & " << *(iter + 1);
   }
+}
+
+TEST(RteUtilsTest, WildCardMatchAny) {
+  EXPECT_TRUE(WildCards::MatchAny("", ""));
+  EXPECT_TRUE(WildCards::MatchAny("*", "*"));
+  EXPECT_TRUE(WildCards::MatchAny("foo", "foo"));
+  EXPECT_TRUE(WildCards::MatchAny("foo*", "foo"));
+  EXPECT_TRUE(WildCards::MatchAny("foo*", "foo*"));
+  EXPECT_TRUE(WildCards::MatchAny("foo|bar", "bar"));
+  EXPECT_TRUE(WildCards::MatchAny("bar", "foo|bar"));
+  EXPECT_FALSE(WildCards::MatchAny("foo|bar", "baz|qux"));
+
+  EXPECT_TRUE(WildCards::MatchAny("foo*|bar", "food|baz"));
+  EXPECT_TRUE(WildCards::MatchAny("food|baz", "foo*|bar"));
+  EXPECT_TRUE(WildCards::MatchAny("foo?|bar", "f*|baz"));
+  EXPECT_TRUE(WildCards::MatchAny("foo", "foo"));
+
+  EXPECT_TRUE(WildCards::MatchAny("|foo||bar|", "||bar|"));
+  EXPECT_FALSE(WildCards::MatchAny("|foo||bar|", "||baz|"));
+  EXPECT_FALSE(WildCards::MatchAny("", "foo"));
+  EXPECT_FALSE(WildCards::MatchAny("foo", ""));
+
+  EXPECT_FALSE(WildCards::Match("foo|bar", "bar"));
 }
 
 TEST(RteUtilsTest, AlnumCmp_Char) {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->

This address possibility to use aliases for target attributes, e.g. for a compiler.
Considering csolution.yml:

```
compiler: XC
alias: GCC
```

This change will allow to set RteTarget` attribute Tcompiler to "XC|GCC" effectively to accept all components for GCC and XC compilers


## Changes
<!-- List the changes this PR introduces -->
- Add` WildCard::MatchAny()` method to compare alternatives from both arguments "A|B|C"
- Use `MatchAny` when evaluating generic target attributes in `RteConditionExpression`.
- Ad corresponding tests

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
