### PR TITLE
Add solution-level compiler aliases

### DIFF
--- a/tools/projmgr/include/ProjMgrParser.h
+++ b/tools/projmgr/include/ProjMgrParser.h
@@ -642,6 +642,7 @@ struct CsolutionItem {
   std::string directory;
   std::string createdFor;
   DirectoriesItem directories;
+  std::vector<std::string> compilerAlias;
   std::vector<std::string> selectableCompilers;
   BuildTypes buildTypes;
   TargetTypes targetTypes;

--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -541,6 +541,7 @@ struct ContextItem {
   StrVec unusedPacks;
   std::vector<std::pair<ComponentItem, std::string>> componentRequirements;
   std::string compiler;
+  std::vector<std::string> compilerAlias;
   ToolchainItem toolchain;
   std::map<std::string, std::string> targetAttributes;
   std::map<std::string, RtePackage*> packages;

--- a/tools/projmgr/include/ProjMgrYamlParser.h
+++ b/tools/projmgr/include/ProjMgrYamlParser.h
@@ -72,6 +72,7 @@ static constexpr const char* YAML_CURRENT_GENERATOR = "current-generator";
 static constexpr const char* YAML_CONSUMES = "consumes";
 static constexpr const char* YAML_COMMAND = "command";
 static constexpr const char* YAML_COMPILER = "compiler";
+static constexpr const char* YAML_COMPILER_ALIAS = "compiler-alias";
 static constexpr const char* YAML_COMPONENT = "component";
 static constexpr const char* YAML_COMPONENTS = "components";
 static constexpr const char* YAML_CONDITION = "condition";

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -1187,7 +1187,8 @@
           "type": "null",
           "description": "Enables use of cdefault.yml file for compiler controls."
         },
-        "compiler":        { "$ref": "#/definitions/CompilerType" },        
+        "compiler":        { "$ref": "#/definitions/CompilerType" },
+        "compiler-alias":  { "$ref": "#/definitions/CompilersType" },
         "created-by": {
           "title": "created-by:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#solution",
           "$ref": "#/definitions/CreatedInfoType",

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -190,6 +190,10 @@
       "pattern": "^(GCC|CLANG|AC6|IAR|CLANG_TI|XC)(@(>=)?([0-9]+\\.[0-9]+\\.[0-9]+((\\+|\\-)[a-zA-Z0-9_\\.\\+-]+)?))?$",
       "description": "Compiler toolchain to be used, optionally with version, for example AC6@6.23.0."
     },
+    "CompilerAliasType": {
+      "type": "string",
+      "pattern": "^(GCC|CLANG|AC6|IAR|CLANG_TI|XC)$"
+    },
     "ConsumesProvidesType": {
       "oneOf": [
         {"type": "string" },
@@ -221,6 +225,18 @@
         {"$ref": "#/definitions/CompilerType" }
       ],
       "description": "Include node for a list of compilers."
+    },
+    "CompilerAliasesType": {
+      "oneOf": [
+        {
+          "type": "array",
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/CompilerAliasType" }
+        },
+        { "$ref": "#/definitions/CompilerAliasType" }
+      ],
+      "description": "List of compiler aliases."
     },
     "ArrayOfBuildContextWithProjectName": {
       "type": "array",
@@ -1188,7 +1204,7 @@
           "description": "Enables use of cdefault.yml file for compiler controls."
         },
         "compiler":        { "$ref": "#/definitions/CompilerType" },
-        "compiler-alias":  { "$ref": "#/definitions/CompilersType" },
+        "compiler-alias":  { "$ref": "#/definitions/CompilerAliasesType" },
         "created-by": {
           "title": "created-by:\nDocumentation: https://open-cmsis-pack.github.io/cmsis-toolbox/YML-Input-Format/#solution",
           "$ref": "#/definitions/CreatedInfoType",

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -178,6 +178,7 @@ void ProjMgrWorker::AddContext(ContextDesc& descriptor, const TypePair& type, Co
     const string& buildType = (!type.build.empty() ? "." : "") + type.build;
     const string& targetType = (!type.target.empty() ? "+" : "") + type.target;
     context.name = context.cproject->name + buildType + targetType;
+    context.compilerAlias = context.csolution->compilerAlias;
     context.precedences = false;
 
     // default directories
@@ -1943,6 +1944,18 @@ bool ProjMgrWorker::ProcessToolchain(ContextItem& context) {
     context.targetAttributes["Toptions"] = context.toolchain.name;
   } else {
     context.targetAttributes["Tcompiler"] = context.toolchain.name;
+  }
+
+  // compiler alias
+  set<string> compilers = { context.targetAttributes["Tcompiler"] };
+  for (const auto& compilerAlias : context.compilerAlias) {
+    const string canonicalAlias = compilerAlias == "AC6" ? "ARMCC" : compilerAlias;
+    if (compilers.insert(canonicalAlias).second) {
+      context.targetAttributes["Tcompiler"] += '|' + canonicalAlias;
+    }
+    if (compilerAlias == "AC6") {
+      context.targetAttributes["Toptions"] = compilerAlias;
+    }
   }
   return true;
 }

--- a/tools/projmgr/src/ProjMgrYamlParser.cpp
+++ b/tools/projmgr/src/ProjMgrYamlParser.cpp
@@ -86,6 +86,7 @@ bool ProjMgrYamlParser::ParseCsolution(const string& input,
     const YAML::Node& solutionNode = root[YAML_SOLUTION];
     ParseString(solutionNode, YAML_DESCRIPTION, csolution.description);
     ParseString(solutionNode, YAML_CREATED_FOR, csolution.createdFor);
+    ParseVectorOrString(solutionNode, YAML_COMPILER_ALIAS, csolution.compilerAlias);
     if (!ParseContexts(solutionNode, csolution)) {
       return false;
     }
@@ -1227,6 +1228,7 @@ const set<string> solutionKeys = {
   YAML_PACKS,
   YAML_PROCESSOR,
   YAML_COMPILER,
+  YAML_COMPILER_ALIAS,
   YAML_SELECT_COMPILER,
   YAML_OPTIMIZE,
   YAML_DEBUG,

--- a/tools/projmgr/test/data/TestSolution/test.csolution.yml
+++ b/tools/projmgr/test/data/TestSolution/test.csolution.yml
@@ -2,6 +2,7 @@
 
 solution:
   description: test description string
+  compiler-alias: CLANG
   target-types:
     - type: CM0
       device: RteTest_ARMCM0

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -51,14 +51,18 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessToolchain) {
   ContextDesc descriptor;
   const string& filename = testinput_folder + "/TestProject/test.cproject.yml";
   EXPECT_TRUE(parser.ParseCproject(filename, true));
+  parser.GetCsolution().compilerAlias = { "AC6", "CLANG" };
   EXPECT_TRUE(AddContexts(parser, descriptor, filename));
   map<string, ContextItem>* contexts;
   GetContexts(contexts);
   ContextItem context = contexts->begin()->second;
+  EXPECT_EQ(context.compilerAlias, (vector<string>{ "AC6", "CLANG" }));
   EXPECT_TRUE(ProcessPrecedences(context));
   EXPECT_TRUE(ProcessToolchain(context));
   EXPECT_EQ(expected.name, context.toolchain.name);
   EXPECT_EQ(expected.version, context.toolchain.version);
+  EXPECT_EQ(context.targetAttributes["Tcompiler"], "ARMCC|CLANG");
+  EXPECT_EQ(context.targetAttributes["Toptions"], "AC6");
 }
 
 TEST_F(ProjMgrWorkerUnitTests, ProcessToolchainNoToolchainRegistered) {
@@ -112,6 +116,18 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessToolchainOptions) {
     EXPECT_EQ(input.second.compiler, context.targetAttributes["Tcompiler"]);
     EXPECT_EQ(input.second.version, context.toolchain.version);
   }
+}
+
+TEST_F(ProjMgrWorkerUnitTests, ProcessToolchainDeduplicatesCanonicalAliases) {
+  ContextItem context;
+  CsolutionItem csolution;
+  context.csolution = &csolution;
+  context.compiler = "AC6";
+  context.compilerAlias = { "ARMCC", "AC6", "CLANG", "CLANG" };
+
+  EXPECT_TRUE(ProcessToolchain(context));
+  EXPECT_EQ(context.targetAttributes["Tcompiler"], "ARMCC|CLANG");
+  EXPECT_EQ(context.targetAttributes["Toptions"], "AC6");
 }
 
 TEST_F(ProjMgrWorkerUnitTests, ProcessDevice) {

--- a/tools/projmgr/test/src/ProjMgrYamlParserUnitTest.cpp
+++ b/tools/projmgr/test/src/ProjMgrYamlParserUnitTest.cpp
@@ -33,6 +33,24 @@ TEST_F(ProjMgrYamlParserUnitTests, ParseCbuildSet) {
   EXPECT_FALSE(ParseCbuildSet("unkownfile.cbuild-set.yml", buildSetItem, true));
 }
 
+TEST_F(ProjMgrYamlParserUnitTests, ParseCompilerAlias) {
+  const string csolutionFile = testinput_folder + "/TestSolution/test.csolution.yml";
+  CsolutionItem csolution;
+
+  EXPECT_TRUE(ParseCsolution(csolutionFile, csolution, true, false));
+  ASSERT_EQ(csolution.compilerAlias.size(), 1);
+  EXPECT_EQ(csolution.compilerAlias.front(), "CLANG");
+
+  YAML::Node solutionNode;
+  solutionNode[YAML_COMPILER_ALIAS].push_back("AC6");
+  solutionNode[YAML_COMPILER_ALIAS].push_back("GCC");
+  vector<string> compilerAliases;
+  ParseVectorOrString(solutionNode, YAML_COMPILER_ALIAS, compilerAliases);
+  ASSERT_EQ(compilerAliases.size(), 2);
+  EXPECT_EQ(compilerAliases[0], "AC6");
+  EXPECT_EQ(compilerAliases[1], "GCC");
+}
+
 TEST_F(ProjMgrYamlParserUnitTests, ValidateCbuildSet) {
   string cbuildSetFile = testinput_folder + "/TestSolution/invalid_keys_test.cbuild-set.yml";
   YAML::Node root = YAML::LoadFile(cbuildSetFile);


### PR DESCRIPTION
## Fixes
- Enables solutions to declare compiler aliases for compatible toolchain selection.

Examples:
```yml
solution:
  compiler: XC
  compiler-alias: GCC # also accept software components written for GCC with the XC compiler
```
It accepts multiple aliases:
```yml
solution:
  compiler: XC
  compiler-alias:
    - GCC
    - CLANG
```
## Changes
- Added `compiler-alias` to the solution schema and YAML parser, supporting scalar and list forms.
- Propagated configured aliases into build contexts.
- Added aliases to generated `Tcompiler` attributes, canonicalizing `AC6` as `ARMCC` and deduplicating entries.
- Sets `Toptions=AC6` when the AC6 alias is configured.
- Added parser and worker unit coverage for alias parsing, propagation, canonicalization, and deduplication.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).