### PR TITLE
Defer missing clayer file handling during context parsing

### DIFF
--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -310,6 +310,8 @@ bool ProjMgrWorker::ParseContextLayers(ContextItem& context) {
           m_undefLayerVars.insert(string(variable));
           continue;
         }
+        m_missingFiles.insert({ clayerFile, FileNode() });
+        continue;
       }
       if (m_parser->ParseClayer(clayerFile, m_checkSchema)) {
         context.clayers[clayerFile] = &m_parser->GetClayers().at(clayerFile);

--- a/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrWorkerUnitTests.cpp
@@ -208,6 +208,24 @@ TEST_F(ProjMgrWorkerUnitTests, ProcessDeviceUndefLayerVar) {
   EXPECT_FALSE(ProcessDevice(context));
 }
 
+TEST_F(ProjMgrWorkerUnitTests, ParseContextLayersDefersMissingClayer) {
+  ContextItem context;
+  CsolutionItem csolution;
+  CprojectItem cproject;
+  cproject.directory = testinput_folder;
+  cproject.clayers.push_back({ "missing.clayer.yml", "", false, {} });
+  context.csolution = &csolution;
+  context.cproject = &cproject;
+
+  string missingClayer = "missing.clayer.yml";
+  RteFsUtils::NormalizePath(missingClayer, cproject.directory);
+  ASSERT_FALSE(RteFsUtils::Exists(missingClayer));
+
+  EXPECT_TRUE(ParseContextLayers(context));
+  EXPECT_TRUE(context.clayers.empty());
+  EXPECT_NE(m_missingFiles.end(), m_missingFiles.find(missingClayer));
+}
+
 TEST_F(ProjMgrWorkerUnitTests, ProcessComponents) {
   set<string> expected = {
     "ARM::Device:Startup&RteTest Startup@2.0.3",


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/devtools/issues/2578

## Changes
- Record missing `.clayer.yml` files in `m_missingFiles` instead of attempting to parse them.
- Skip "to-be-generated" file: do not report error if missing layer file is listed as an output of an execute node.
- Add unit-test coverage verifying missing clayer files are deferred and do not fail context-layer parsing.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).