### PR TITLE
[svdconv] Correct enum combo width warning

### DIFF
--- a/tools/svdconv/SVDGenerator/src/SfdData_SingleItems.cpp
+++ b/tools/svdconv/SVDGenerator/src/SfdData_SingleItems.cpp
@@ -954,7 +954,11 @@ bool SfdData::CreateFieldItem(SvdField* field)
   if(bitWidth > MAX_BITWIDTH_FOR_COMBO && firstContHasChilds) {
     string msg = "Enumerated values list for field '";
     msg += field->GetNameCalculated();
-    msg += "' exceeds maximum of 256 elements. List will not be generated.";
+    msg += "' will not be generated: field width ";
+    msg += to_string(bitWidth);
+    msg += " exceeds the maximum of ";
+    msg += to_string(MAX_BITWIDTH_FOR_COMBO);
+    msg += " bits.";
     LogMsg("M227", MSG(msg), field->GetLineNumber());
   }
 

--- a/tools/svdconv/test/data/enumComboWidth/EnumComboWidth.svd
+++ b/tools/svdconv/test/data/enumComboWidth/EnumComboWidth.svd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+
+<device schemaVersion="1.1"
+xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+  <name>EnumComboWidth</name>
+  <version>1.0</version>
+  <description>Test the SFD combo field width limit</description>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>0x20</size>
+  <resetValue>0x0</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+
+  <cpu>
+    <name>CM4</name>
+    <revision>r0p0</revision>
+    <endian>little</endian>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>4</nvicPrioBits>
+    <deviceNumInterrupts>16</deviceNumInterrupts>
+  </cpu>
+
+  <peripherals>
+    <peripheral>
+      <name>TEST</name>
+      <description>Test peripheral</description>
+      <groupName>Enum Combo Width</groupName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x4</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Test control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0</resetValue>
+          <fields>
+            <field>
+              <name>SIX_BIT</name>
+              <description>Six bit field</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ONE</name>
+                  <description>Value one</description>
+                  <value>1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SEVEN_BIT</name>
+              <description>Seven bit field</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>NINE</name>
+                  <description>Value nine</description>
+                  <value>9</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/tools/svdconv/test/integtests/src/SvdConvIntegTests.cpp
+++ b/tools/svdconv/test/integtests/src/SvdConvIntegTests.cpp
@@ -252,3 +252,53 @@ TEST_F(SvdConvIntegTests, CheckPosMaskDimFields) {
   EXPECT_EQ(string::npos, buf.find("#define TIM_DATA_PIN_Pos"));
   EXPECT_EQ(string::npos, buf.find("#define TIM_DATA_PIN_Msk"));
 }
+
+TEST_F(SvdConvIntegTests, CheckEnumComboWidthLimit) {
+  const string& inFile = SvdConvIntegTestEnv::localtestdata_dir + "/enumComboWidth/EnumComboWidth.svd";
+  const string testOut = SvdConvIntegTestEnv::testoutput_dir + "/enumComboWidth";
+  ASSERT_TRUE(RteFsUtils::Exists(inFile));
+
+  Arguments args("SVDConv.exe", inFile);
+  args.add({ "-o", testOut, "--generate=sfd", "--create-folder" });
+
+  SvdConv svdConv;
+  EXPECT_EQ(1, svdConv.Check(args, args, nullptr));
+
+  const auto msgs = ErrLog::Get()->GetLogMessages();
+  size_t m227Count = 0;
+  string allMessages;
+  for(const auto& msg : msgs) {
+    allMessages += msg;
+    if(msg.find("M227") != string::npos) {
+      ++m227Count;
+    }
+  }
+  EXPECT_EQ(1U, m227Count);
+  EXPECT_NE(string::npos, allMessages.find("field 'SEVEN_BIT'"));
+  EXPECT_NE(string::npos, allMessages.find("field width 7"));
+  EXPECT_NE(string::npos, allMessages.find("maximum of 6 bits"));
+
+  const string testOutSfd = testOut + "/EnumComboWidth.sfd";
+  ASSERT_TRUE(RteFsUtils::Exists(testOutSfd));
+
+  string buf;
+  RteFsUtils::ReadFile(testOutSfd, buf);
+  ASSERT_FALSE(buf.empty());
+
+  const auto sixBitField = buf.find("SFDITEM_FIELD__TEST_CTRL_SIX_BIT");
+  const auto sevenBitField = buf.find("SFDITEM_FIELD__TEST_CTRL_SEVEN_BIT");
+  ASSERT_NE(string::npos, sixBitField);
+  ASSERT_NE(string::npos, sevenBitField);
+  ASSERT_LT(sixBitField, sevenBitField);
+
+  const auto sixBitCombo = buf.find("//    <combo>", sixBitField);
+  EXPECT_NE(string::npos, sixBitCombo);
+  EXPECT_LT(sixBitCombo, sevenBitField);
+  const auto sixBitLastValue = buf.find("//        <63=>", sixBitCombo);
+  EXPECT_NE(string::npos, sixBitLastValue);
+  EXPECT_LT(sixBitLastValue, sevenBitField);
+
+  const auto sevenBitEdit = buf.find("//    <edit>", sevenBitField);
+  EXPECT_NE(string::npos, sevenBitEdit);
+  EXPECT_EQ(string::npos, buf.find("//    <combo>", sevenBitField));
+}


### PR DESCRIPTION
## Fixes

Report the actual field width and the six-bit combo limit instead of the incorrect 256-element maximum. Add integration coverage for the six- and seven-bit boundary.
See https://github.com/Open-CMSIS-Pack/devtools/issues/2569

## Changes
- Message M227

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
