### PR TITLE
Add generated debug-adapter schema to gitignore

### DIFF
--- a/tools/projmgr/.gitignore
+++ b/tools/projmgr/.gitignore
@@ -1,1 +1,2 @@
 templates/debug-adapters.yml
+schemas/debug-adapters.schema.json


### PR DESCRIPTION
## Changes
- Add `schemas/debug-adapters.schema.json` to the ignore list to prevent generated schema output from being tracked.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).