### PR TITLE
Dev pcsampling

### DIFF
--- a/tools/ctrace/docs/architecture.md
+++ b/tools/ctrace/docs/architecture.md
@@ -13,10 +13,11 @@ backend-independent semantic events. Output backends consume these events to cre
 
 The first release profile supports SWO data containing ITM and DWT packets. The command line accepts the stable type
 names `itm`, `dwt`, `event`, `pmu`, `exception`, `pcsample`, `global_ts`, `overflow`, and `error`. Output semantics are
-currently implemented for `itm`, `dwt`, `exception`, `global_ts`, `overflow`, and `error`. DWT event-counter and PMU
-packets are retained internally but are not mapped to their selectors yet; periodic PC samples remain disabled. Trace
-Bus input is discovered so that a complete trace directory can be inspected, but `*.TB.raw` files are reported and
-skipped until a decoder is implemented.
+currently implemented for `itm`, `dwt`, `exception`, `pcsample`, `global_ts`, `overflow`, and `error`. DWT event-counter
+and PMU packets are retained internally but are not mapped to their selectors yet. Periodic PC samples reach CSV and
+CTF as semantic events; the CTF event distinguishes a sampled PC from a processor-sleep indication, and Trace Compass
+shows processor-sleep intervals as a timeline. Trace Bus input is discovered so that a complete trace directory can be
+inspected, but `*.TB.raw` files are reported and skipped until a decoder is implemented.
 
 The architecture separates protocol decoding, semantic interpretation, and output generation. This keeps output
 formats independent of OpenCSD and allows another raw trace channel to reuse the event model and output backends.

--- a/tools/ctrace/docs/todo.md
+++ b/tools/ctrace/docs/todo.md
@@ -12,7 +12,6 @@
 - [ ] Add Armv8-M and Armv8.1-M DWT decoding.
 - [ ] Add `event` output in its own PR.
 - [ ] Add `pmu` output in its own PR.
-- [ ] Add PC Sampling in its own PR after agreeing the sleep/`PC_SAMPLE` CTF contract.
 
 ## Multiple streams
 

--- a/tools/ctrace/src/decode/DwtPacketDecoder.cpp
+++ b/tools/ctrace/src/decode/DwtPacketDecoder.cpp
@@ -102,10 +102,31 @@ std::vector<TraceEvent> DwtPacketDecoder::decode(const DwtPayloadPacket& payload
   }
 
   if (source == DwtPacketSource::PeriodicPcSample) {
-    // PC samples need a dedicated output event. Until that event is
-    // defined, flush preceding data trace but do not expose the sample as
-    // an address event.
     output = flush(payload.quality, payload.tcyc);
+    const auto isPc = payload.size == 4U;
+    const auto isSleeping = payload.size == 1U && payload.value == 0U;
+    if (!isPc && !isSleeping) {
+      TraceEvent error{TraceIssueEvent{
+          TraceIssueCode::UnsupportedDwtPcSamplePayload,
+          TraceIssueSeverity::Error,
+          "unsupported DWT PC-sample payload size " + std::to_string(payload.size) +
+              "; expected a 4-byte PC or 1-byte zero sleep indication",
+          std::nullopt,
+          std::nullopt,
+      }};
+      error.index = payload.index;
+      error.traceBusId = payload.traceBusId;
+      error.tcyc = payload.tcyc;
+      error.quality = payload.quality;
+      output.push_back(std::move(error));
+      return output;
+    }
+    TraceEvent packet{PcSampleTraceEvent{payload.value, isSleeping}};
+    packet.index = payload.index;
+    packet.traceBusId = payload.traceBusId;
+    packet.tcyc = payload.tcyc;
+    packet.quality = payload.quality;
+    output.push_back(std::move(packet));
     return output;
   }
 

--- a/tools/ctrace/src/decode/DwtPacketDecoder.cpp
+++ b/tools/ctrace/src/decode/DwtPacketDecoder.cpp
@@ -109,8 +109,9 @@ std::vector<TraceEvent> DwtPacketDecoder::decode(const DwtPayloadPacket& payload
       TraceEvent error{TraceIssueEvent{
           TraceIssueCode::UnsupportedDwtPcSamplePayload,
           TraceIssueSeverity::Error,
-          "unsupported DWT PC-sample payload size " + std::to_string(payload.size) +
-              "; expected a 4-byte PC or 1-byte zero sleep indication",
+          "unsupported DWT PC-sample payload: size " + std::to_string(payload.size) +
+              ", value " + std::to_string(payload.value) +
+              "; expected a 4-byte PC or a 1-byte zero sleep indication",
           std::nullopt,
           std::nullopt,
       }};

--- a/tools/ctrace/src/diagnostics/TraceIssueReporter.cpp
+++ b/tools/ctrace/src/diagnostics/TraceIssueReporter.cpp
@@ -45,6 +45,7 @@ static std::string displayErrorMessage(const TraceEvent& event, const TraceIssue
   case TraceIssueCode::DecodeError:
   case TraceIssueCode::InvalidExceptionAction:
   case TraceIssueCode::UnsupportedDwtAddressPayload:
+  case TraceIssueCode::UnsupportedDwtPcSamplePayload:
   case TraceIssueCode::OpenCsdDecodeError:
     return atRawOffset("trace decode error", event);
   }

--- a/tools/ctrace/src/model/TraceEvent.h
+++ b/tools/ctrace/src/model/TraceEvent.h
@@ -40,6 +40,7 @@ enum class TraceIssueCode {
   DataLoss,
   InvalidExceptionAction,
   UnsupportedDwtAddressPayload,
+  UnsupportedDwtPcSamplePayload,
   OpenCsdDecodeError,
   OpenCsdBadPacketSequence,
   OpenCsdInvalidPacketHeader,
@@ -135,6 +136,12 @@ struct PmuTraceEvent {
   std::uint32_t value = 0;
 };
 
+/** @brief Contains a periodic DWT PC sample or its processor-sleep indication. */
+struct PcSampleTraceEvent {
+  std::uint32_t pc = 0;
+  bool sleeping = false;
+};
+
 /** @brief Marks a decoded local timestamp packet. */
 struct LocalTimestampTraceEvent {};
 
@@ -163,7 +170,7 @@ struct TraceIssueEvent {
 
 /** @brief Stores the semantic payload of a decoded trace event. */
 using TraceEventPayload = std::variant<SoftwareTraceEvent, DwtDataTraceEvent, DwtAddressTraceEvent, ExceptionTraceEvent,
-                                       DwtEventTraceEvent, PmuTraceEvent, LocalTimestampTraceEvent,
+                                       DwtEventTraceEvent, PmuTraceEvent, PcSampleTraceEvent, LocalTimestampTraceEvent,
                                        GlobalTimestampTraceEvent, OverflowTraceEvent, SyncTraceEvent, TraceIssueEvent>;
 
 /** @brief Describes timestamp and data-loss quality at an event. */

--- a/tools/ctrace/src/model/TraceSelection.cpp
+++ b/tools/ctrace/src/model/TraceSelection.cpp
@@ -54,6 +54,12 @@ static std::optional<TraceEventType> typeFor(const PmuTraceEvent&)
   return std::nullopt;
 }
 
+/** @brief Exposes periodic DWT PC samples through their public output selector. */
+static std::optional<TraceEventType> typeFor(const PcSampleTraceEvent&)
+{
+  return TraceEventType::PcSample;
+}
+
 /** @brief Excludes local timestamp control packets from type selection. */
 static std::optional<TraceEventType> typeFor(const LocalTimestampTraceEvent&)
 {

--- a/tools/ctrace/src/output/csv/CsvRowMapper.cpp
+++ b/tools/ctrace/src/output/csv/CsvRowMapper.cpp
@@ -159,6 +159,10 @@ static CsvRow eventToCsvRow(const TraceEvent& event)
   } else if (const auto* exception = traceEventPayload<ExceptionTraceEvent>(event)) {
     row[column(CsvColumn::Source)] = std::to_string(exception->number);
     row[column(CsvColumn::Value)] = exceptionActionCsvValue(exception->action);
+  } else if (const auto* sample = traceEventPayload<PcSampleTraceEvent>(event)) {
+    if (!sample->sleeping) {
+      row[column(CsvColumn::Pc)] = hexValue(sample->pc, 4);
+    }
   } else if (const auto* timestamp = traceEventPayload<GlobalTimestampTraceEvent>(event)) {
     row[column(CsvColumn::Cycles)] = std::to_string(timestamp->value);
   } else if (const auto* overflow = traceEventPayload<OverflowTraceEvent>(event)) {

--- a/tools/ctrace/src/output/ctf/CtfEncoder.cpp
+++ b/tools/ctrace/src/output/ctf/CtfEncoder.cpp
@@ -200,6 +200,10 @@ void CtfEncoder::writeEvent(const TraceEvent& event)
     if (selected) {
       writeDwtAddrEvent(event, *address);
     }
+  } else if (const auto* sample = traceEventPayload<PcSampleTraceEvent>(event)) {
+    if (selected) {
+      writePcSampleEvent(event, *sample);
+    }
   } else if (isTraceEvent<OverflowTraceEvent>(event)) {
     auto& streamState = m_streamStates[event.traceBusId];
     if (event.quality.has_value()) {
@@ -229,6 +233,25 @@ void CtfEncoder::writeEvent(const TraceEvent& event)
       }
     }
   }
+}
+
+void CtfEncoder::writePcSampleEvent(const TraceEvent& event, const PcSampleTraceEvent& sample)
+{
+  const auto pcSize = sample.sleeping ? 0U : 4U;
+  const auto payloadSize = 1U + pcSize + 1U + 4U;
+  const auto eventTimestamp = allocateEventTimestamp(event.traceBusId);
+  const auto quality = computeSampleQuality(event);
+  const auto state = CtfSchema::value(sample.sleeping ? CtfSchema::PcSampleState::Sleep
+                                                       : CtfSchema::PcSampleState::Pc);
+  m_stream.writeRecord(CtfSchema::value(CtfSchema::EventId::PcSample), eventTimestamp, event.traceBusId, payloadSize,
+                       [&](CtfStreamWriter::Record& record) {
+                         record.writeU8(state);
+                         if (!sample.sleeping) {
+                           record.writeU32(sample.pc);
+                         }
+                         record.writeU8(quality.first);
+                         record.writeU32(quality.second);
+                       });
 }
 
 std::uint64_t CtfEncoder::allocateEventTimestamp(std::uint8_t traceBusId)

--- a/tools/ctrace/src/output/ctf/CtfEncoder.h
+++ b/tools/ctrace/src/output/ctf/CtfEncoder.h
@@ -75,6 +75,8 @@ private:
   void reportDwtSizeMismatch(const TraceEvent& event, const DwtDataTraceEvent& data, const ResolvedTraceSource* source);
   /** @brief Encodes one DWT address event. */
   void writeDwtAddrEvent(const TraceEvent& event, const DwtAddressTraceEvent& address);
+  /** @brief Encodes one periodic PC-sample or processor-sleep event. */
+  void writePcSampleEvent(const TraceEvent& event, const PcSampleTraceEvent& sample);
   /** @brief Encodes one reconstructed global timestamp event. */
   void writeGlobalTimestampEvent(const TraceEvent& event, const GlobalTimestampTraceEvent& timestamp);
   /** @brief Applies one exception transition to its CTF lane state. */

--- a/tools/ctrace/src/output/ctf/CtfMetadataWriter.cpp
+++ b/tools/ctrace/src/output/ctf/CtfMetadataWriter.cpp
@@ -418,6 +418,27 @@ event {
 )";
 }
 
+/** @brief Writes the periodic PC-sample event declaration. */
+static void writePcSampleEvent(std::ostream& out)
+{
+  out << R"(
+event {
+    id = )"
+      << CtfSchema::value(CtfSchema::EventId::PcSample) << R"(;
+    name = ")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample) << R"(";
+    stream_id = )"
+      << CtfSchema::SwoStreamId << R"(;
+    fields := struct {
+        uint8_t cmsis_pc_sample_state;
+        uint32_t cmsis_pc[cmsis_pc_sample_state];
+        uint8_t cmsis_sample_flags;
+        uint32_t cmsis_overflow_count;
+    };
+};
+)";
+}
+
 /** @brief Writes status, exception, and global timestamp declarations. */
 static void writeStatusEvents(std::ostream& out)
 {
@@ -482,6 +503,7 @@ void CtfMetadataWriter::write(const std::filesystem::path& outputDir, const std:
   writeDwtValueEvent(out);
   writeDwtAddressEvent(out);
   writeStatusEvents(out);
+  writePcSampleEvent(out);
   out.close();
   if (!out) {
     throw std::runtime_error("Failed to write CTF metadata " + metadataPath.string());

--- a/tools/ctrace/src/output/ctf/CtfSchema.h
+++ b/tools/ctrace/src/output/ctf/CtfSchema.h
@@ -26,6 +26,7 @@ enum class EventId : std::uint32_t {
   TraceStatus = 3U,
   Exception = 4U,
   GlobalTimestamp = 5U,
+  PcSample = 6U,
 };
 
 /** @brief Classifies CTF trace-status records. */
@@ -47,6 +48,12 @@ enum class DwtAccess : std::uint8_t {
 enum class ExceptionAction : std::uint8_t {
   Entered = 0U,
   Exited = 1U,
+};
+
+/** @brief Identifies whether a periodic PC sample carries a PC or reports processor sleep. */
+enum class PcSampleState : std::uint8_t {
+  Sleep = 0U,
+  Pc = 1U,
 };
 
 /** @brief Identifies the supported CTF sample value encodings. */
@@ -147,6 +154,12 @@ constexpr std::uint8_t value(ExceptionAction action)
   return static_cast<std::uint8_t>(action);
 }
 
+/** @brief Returns the integer representation of a PC-sample state. */
+constexpr std::uint8_t value(PcSampleState state)
+{
+  return static_cast<std::uint8_t>(state);
+}
+
 /** @brief Returns the stable schema name of a CTF event ID. */
 constexpr std::string_view eventName(EventId id)
 {
@@ -163,6 +176,8 @@ constexpr std::string_view eventName(EventId id)
     return "EXCEPTION";
   case EventId::GlobalTimestamp:
     return "GLOBAL_TIMESTAMP";
+  case EventId::PcSample:
+    return "PC_SAMPLE";
   }
   return "UNKNOWN";
 }

--- a/tools/ctrace/src/output/ctf/TraceCompassXmlWriter.cpp
+++ b/tools/ctrace/src/output/ctf/TraceCompassXmlWriter.cpp
@@ -79,6 +79,8 @@ static std::string valueHandlers(CtfSchema::EventId eventId, const char* prefix,
 /** @brief Generates the Trace Compass state-provider definition. */
 static std::string stateProviderXml()
 {
+  // Numeric time-graph states are exposed as TSP style keys; string states are
+  // serialized without a style and appear as gaps in compatible clients.
   std::ostringstream xml;
   xml << R"(    <stateProvider version="__SWO_ANALYSIS_VERSION__" id="arm.cmsis.swo.analysis.v1">
         <head><label value="SWO Trace Analysis" /></head>
@@ -135,12 +137,66 @@ static std::string stateProviderXml()
             </stateChange>
         </eventHandler>
         <eventHandler eventName=")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample) << R"(">
+            <stateChange>
+                <if>
+                    <condition>
+                        <stateValue type="eventField" value="cmsis_pc_sample_state" />
+                        <stateValue type="long" value=")"
+      << static_cast<unsigned>(CtfSchema::value(CtfSchema::PcSampleState::Sleep)) << R"(" />
+                    </condition>
+                </if>
+                <then>
+                    <stateAttribute type="constant" value=")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample) << R"(" />
+                    <stateAttribute type="constant" value="Sleep" />
+                    <stateValue type="int" value=")"
+      << static_cast<unsigned>(CtfSchema::value(CtfSchema::PcSampleState::Sleep)) << R"(" />
+                </then>
+            </stateChange>
+            <stateChange>
+                <if>
+                    <condition>
+                        <stateValue type="eventField" value="cmsis_pc_sample_state" />
+                        <stateValue type="long" value=")"
+      << static_cast<unsigned>(CtfSchema::value(CtfSchema::PcSampleState::Pc)) << R"(" />
+                    </condition>
+                </if>
+                <then>
+                    <stateAttribute type="constant" value=")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample) << R"(" />
+                    <stateAttribute type="constant" value="Sleep" />
+                    <stateValue type="null" />
+                </then>
+            </stateChange>
+        </eventHandler>
+        <eventHandler eventName=")"
       << CtfSchema::eventName(CtfSchema::EventId::TraceStatus) << R"(">
             <stateChange>
                 <stateAttribute type="constant" value=")"
       << CtfSchema::eventName(CtfSchema::EventId::TraceStatus) << R"(" />
                 <stateAttribute type="eventField" value="cmsis_trace_status_reason" />
                 <stateValue type="eventField" value="cmsis_trace_status_reason" />
+            </stateChange>
+            <stateChange>
+                <if>
+                    <or>
+                        <condition>
+                            <stateValue type="eventField" value="cmsis_trace_status_reason" />
+                            <stateValue type="string" value="overflow" />
+                        </condition>
+                        <condition>
+                            <stateValue type="eventField" value="cmsis_trace_status_reason" />
+                            <stateValue type="string" value="data_loss" />
+                        </condition>
+                    </or>
+                </if>
+                <then>
+                    <stateAttribute type="constant" value=")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample) << R"(" />
+                    <stateAttribute type="constant" value="Sleep" />
+                    <stateValue type="null" />
+                </then>
             </stateChange>
         </eventHandler>
     </stateProvider>
@@ -186,6 +242,14 @@ static std::string viewsXml()
         <entry path=")"
       << CtfSchema::eventName(CtfSchema::EventId::TraceStatus)
       << R"(/*" displayText="true"><display type="self" /><name type="self" /></entry>
+    </timeGraphView>
+    <timeGraphView id="arm.cmsis.swo.tg.pc_sample.v1">
+        <head><analysis id="arm.cmsis.swo.analysis.v1" /><label value="PC Sampling" /></head>
+        <definedValue name="Sleep" value=")"
+      << static_cast<unsigned>(CtfSchema::value(CtfSchema::PcSampleState::Sleep)) << R"(" color="#5B8FF9" />
+        <entry path=")"
+      << CtfSchema::eventName(CtfSchema::EventId::PcSample)
+      << R"(/*" displayText="true"><display type="self" /></entry>
     </timeGraphView>
 )";
   return xml.str();

--- a/tools/ctrace/src/output/ctf/TraceCompassXmlWriter.cpp
+++ b/tools/ctrace/src/output/ctf/TraceCompassXmlWriter.cpp
@@ -249,7 +249,7 @@ static std::string viewsXml()
       << static_cast<unsigned>(CtfSchema::value(CtfSchema::PcSampleState::Sleep)) << R"(" color="#5B8FF9" />
         <entry path=")"
       << CtfSchema::eventName(CtfSchema::EventId::PcSample)
-      << R"(/*" displayText="true"><display type="self" /></entry>
+      << '/' << R"(*" displayText="true"><display type="self" /></entry>
     </timeGraphView>
 )";
   return xml.str();

--- a/tools/ctrace/test/integration/src/CtraceIntegTests.cpp
+++ b/tools/ctrace/test/integration/src/CtraceIntegTests.cpp
@@ -125,12 +125,13 @@ TEST_F(CtraceIntegTests, GeneratesAllOutputs)
   ctrace-refs: []
 )yml");
 
-  const std::string raw{"\0\0\0\0\0\x80\x09\x41", 8U};
+  const std::string raw{"\0\0\0\0\0\x80\x17\x34\x12\x00\x08\x09\x41", 13U};
   writeFile(workDirectory() / "Minimal.SWO.raw", raw);
 
   const auto result = run({"ctrace", workDirectory().string(), "--target", "Minimal", "--all"});
   EXPECT_EQ(0, result.exitCode) << result.stderrText;
   EXPECT_EQ("cycles,stream,type,source,value,pc,offset,note\n"
+            "0,,pcsample,,,0x08001234,,\n"
             "0,,itm,1,0x41,,,\n",
             readTextFile(workDirectory() / "Minimal.SWO.csv"));
   expectNonEmptyFile(workDirectory() / "Minimal.ctf" / "metadata");

--- a/tools/ctrace/test/unit/src/decode/DecodePipelineTests.cpp
+++ b/tools/ctrace/test/unit/src/decode/DecodePipelineTests.cpp
@@ -581,6 +581,28 @@ TEST(CtraceUnitTests, testDecodePipelinePreservesDwtEventAndPmuPackets)
   ASSERT_TRUE(foundPmu) << "OpenCSD PMU-overflow packet must survive post-decoding";
 }
 
+TEST(CtraceUnitTests, testDecodePipelinePreservesPeriodicPcSamples)
+{
+  const std::uint8_t trace[] = {
+      0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x80U,
+      0x17U, 0x34U, 0x12U, 0x00U, 0x08U,
+      0x15U, 0x00U,
+  };
+  const auto decoded = decodeTrace({rawBytes(trace)});
+
+  std::vector<PcSampleTraceEvent> samples;
+  for (const auto& event : decoded.events) {
+    if (const auto* sample = traceEventPayload<PcSampleTraceEvent>(event)) {
+      samples.push_back(*sample);
+    }
+  }
+  ASSERT_EQ(samples.size(), 2U) << "OpenCSD periodic PC-sample packet count mismatch";
+  EXPECT_EQ(samples[0].pc, 0x08001234U) << "OpenCSD periodic PC sample payload mismatch";
+  EXPECT_FALSE(samples[0].sleeping) << "OpenCSD periodic PC sample payload mismatch";
+  EXPECT_EQ(samples[1].pc, 0U) << "OpenCSD periodic PC sleep indication mismatch";
+  EXPECT_TRUE(samples[1].sleeping) << "OpenCSD periodic PC sleep indication mismatch";
+}
+
 TEST(CtraceUnitTests, testDecodePipelineDoesNotInjectSync)
 {
   const std::uint8_t validWithoutAsync[] = {0x01U, static_cast<std::uint8_t>('A')};

--- a/tools/ctrace/test/unit/src/decode/DwtPacketDecoderTests.cpp
+++ b/tools/ctrace/test/unit/src/decode/DwtPacketDecoderTests.cpp
@@ -25,14 +25,50 @@ static DwtPayloadPacket dwtPayload(std::uint8_t discriminator, std::uint8_t size
   return {index, traceBusId, discriminator, size, value, tcyc, {}};
 }
 
-TEST(CtraceUnitTests, testDwtPcSampleIsSuppressedUntilDedicatedEventExists)
+TEST(CtraceUnitTests, testDwtPcSampleProducesDedicatedEvent)
 {
   DwtPacketDecoder decoder;
   auto payload = dwtPayload(2U, 4U, 0x08001234U, 19U, 3U, 949339000U);
   payload.quality.timestampReliable = true;
 
   const auto packets = decoder.decode(payload);
-  ASSERT_TRUE(packets.empty()) << "DWT PC samples must remain suppressed until their output event is defined";
+  ASSERT_EQ(packets.size(), 1U) << "DWT PC sample event count mismatch";
+  const auto* sample = traceEventPayload<PcSampleTraceEvent>(packets.front());
+  ASSERT_NE(sample, nullptr);
+  EXPECT_EQ(sample->pc, 0x08001234U) << "DWT PC sample payload mismatch";
+  EXPECT_FALSE(sample->sleeping) << "DWT PC sample payload mismatch";
+  EXPECT_EQ(packets.front().index, 19U) << "DWT PC sample identity mismatch";
+  EXPECT_EQ(packets.front().traceBusId, 3U) << "DWT PC sample identity mismatch";
+  EXPECT_EQ(packets.front().tcyc, std::optional<std::uint64_t>(949339000U))
+      << "DWT PC sample identity mismatch";
+  ASSERT_TRUE(packets.front().quality.has_value()) << "DWT PC sample quality mismatch";
+  EXPECT_TRUE(packets.front().quality->timestampReliable) << "DWT PC sample quality mismatch";
+  EXPECT_EQ(traceEventType(packets.front()), TraceEventType::PcSample)
+      << "DWT PC sample selector mapping mismatch";
+}
+
+TEST(CtraceUnitTests, testDwtPcSamplePreservesProcessorSleep)
+{
+  DwtPacketDecoder decoder;
+  const auto packets = decoder.decode(dwtPayload(2U, 1U, 0U, 20U, 4U, 949339100U));
+  ASSERT_EQ(packets.size(), 1U) << "DWT PC sleep event count mismatch";
+  const auto* sample = traceEventPayload<PcSampleTraceEvent>(packets.front());
+  ASSERT_NE(sample, nullptr);
+  EXPECT_EQ(sample->pc, 0U) << "DWT PC sleep indication mismatch";
+  EXPECT_TRUE(sample->sleeping) << "DWT PC sleep indication mismatch";
+}
+
+TEST(CtraceUnitTests, testDwtPcSampleRejectsUnsupportedPayloads)
+{
+  for (const auto payload : {dwtPayload(2U, 1U, 1U), dwtPayload(2U, 2U, 0x1234U)}) {
+    DwtPacketDecoder decoder;
+    const auto packets = decoder.decode(payload);
+    ASSERT_EQ(packets.size(), 1U) << "unsupported DWT PC sample must emit one error";
+    const auto* issue = traceEventPayload<TraceIssueEvent>(packets.front());
+    ASSERT_NE(issue, nullptr);
+    EXPECT_EQ(issue->code, TraceIssueCode::UnsupportedDwtPcSamplePayload)
+        << "unsupported DWT PC sample error mismatch";
+  }
 }
 
 TEST(CtraceUnitTests, testDwtCounterPacketsArePreservedUntilOutputSemanticsExist)

--- a/tools/ctrace/test/unit/src/decode/DwtPacketDecoderTests.cpp
+++ b/tools/ctrace/test/unit/src/decode/DwtPacketDecoderTests.cpp
@@ -60,7 +60,7 @@ TEST(CtraceUnitTests, testDwtPcSamplePreservesProcessorSleep)
 
 TEST(CtraceUnitTests, testDwtPcSampleRejectsUnsupportedPayloads)
 {
-  for (const auto payload : {dwtPayload(2U, 1U, 1U), dwtPayload(2U, 2U, 0x1234U)}) {
+  const auto verify = [](const DwtPayloadPacket& payload, const char* expectedMessage) {
     DwtPacketDecoder decoder;
     const auto packets = decoder.decode(payload);
     ASSERT_EQ(packets.size(), 1U) << "unsupported DWT PC sample must emit one error";
@@ -68,7 +68,14 @@ TEST(CtraceUnitTests, testDwtPcSampleRejectsUnsupportedPayloads)
     ASSERT_NE(issue, nullptr);
     EXPECT_EQ(issue->code, TraceIssueCode::UnsupportedDwtPcSamplePayload)
         << "unsupported DWT PC sample error mismatch";
-  }
+    EXPECT_EQ(issue->message, expectedMessage) << "unsupported DWT PC sample diagnostic mismatch";
+  };
+
+  verify(dwtPayload(2U, 1U, 1U),
+         "unsupported DWT PC-sample payload: size 1, value 1; expected a 4-byte PC or a 1-byte zero sleep indication");
+  verify(dwtPayload(2U, 2U, 0x1234U),
+         "unsupported DWT PC-sample payload: size 2, value 4660; expected a 4-byte PC or a 1-byte zero sleep "
+         "indication");
 }
 
 TEST(CtraceUnitTests, testDwtCounterPacketsArePreservedUntilOutputSemanticsExist)

--- a/tools/ctrace/test/unit/src/model/TraceSelectionTests.cpp
+++ b/tools/ctrace/test/unit/src/model/TraceSelectionTests.cpp
@@ -70,4 +70,10 @@ TEST(CtraceUnitTests, testTraceSelection)
   TraceEvent exception{ExceptionTraceEvent{11U, ExceptionAction::Entered}};
   ASSERT_TRUE(traceEventSelectedForOutput(exception, TraceSelection{{"exception"}, {}}))
       << "TraceSelection exception type mismatch";
+
+  TraceEvent pcSample{PcSampleTraceEvent{0x08001234U, false}};
+  ASSERT_TRUE(traceEventSelectedForOutput(pcSample, TraceSelection{{"pcsample"}, {}}))
+      << "TraceSelection PC-sample type mismatch";
+  ASSERT_FALSE(traceEventSelectedForOutput(pcSample, TraceSelection{{"dwt"}, {}}))
+      << "TraceSelection must keep PC samples separate from DWT data trace";
 }

--- a/tools/ctrace/test/unit/src/output/csv/CsvFileOutputTests.cpp
+++ b/tools/ctrace/test/unit/src/output/csv/CsvFileOutputTests.cpp
@@ -133,15 +133,17 @@ TEST(CtraceUnitTests, testCsvFileOutputMatchesSpecification)
                             }},
                             949338400U));
   output.writeEvent(atCycle(TraceEvent{ExceptionTraceEvent{11U, ExceptionAction::Entered}}, 950364820U));
+  output.writeEvent(atCycle(TraceEvent{PcSampleTraceEvent{0x08000100U, false}}, 950364900U));
 
   output.stop();
 
   const auto lines = readTestLines(csvPath);
 
-  ASSERT_TRUE(lines.size() == 3U) << "CSV specification row count mismatch";
+  ASSERT_TRUE(lines.size() == 4U) << "CSV specification row count mismatch";
   ASSERT_TRUE(lines[0] == "cycles,stream,type,source,value,pc,offset,note") << "CSV specification header mismatch";
   ASSERT_TRUE(lines[1] == "949338400,,dwt,2,0xfffffdf9,0x08001234,0xfdf9,") << "CSV DWT row schema mismatch";
   ASSERT_TRUE(lines[2] == "950364820,,exception,11,0x1,,,") << "CSV exception state schema mismatch";
+  ASSERT_TRUE(lines[3] == "950364900,,pcsample,,,0x08000100,,") << "CSV PC-sample row schema mismatch";
 }
 
 TEST(CtraceUnitTests, testCsvFileOutputWritesTraceIssues)

--- a/tools/ctrace/test/unit/src/output/csv/CsvRowMapperTests.cpp
+++ b/tools/ctrace/test/unit/src/output/csv/CsvRowMapperTests.cpp
@@ -42,6 +42,7 @@ TEST(CtraceUnitTests, testCsvRowMapperAndTraceEventSchema)
       {TraceEvent{ExceptionTraceEvent{}}, TraceEventType::Exception},
       {TraceEvent{DwtEventTraceEvent{}}, std::nullopt},
       {TraceEvent{PmuTraceEvent{}}, std::nullopt},
+      {TraceEvent{PcSampleTraceEvent{}}, TraceEventType::PcSample},
       {TraceEvent{LocalTimestampTraceEvent{}}, std::nullopt},
       {TraceEvent{GlobalTimestampTraceEvent{}}, TraceEventType::GlobalTimestamp},
       {TraceEvent{OverflowTraceEvent{}}, TraceEventType::Overflow},
@@ -64,6 +65,12 @@ TEST(CtraceUnitTests, testCsvRowMapperAndTraceEventSchema)
       << "CSV must render the raw hexadecimal DWT value with the two-byte SWO width";
   ASSERT_TRUE(CsvRowMapper::row(softwarePacket(1U)) == ",,itm,1,0x00,,,")
       << "CSV must leave the stream field empty for unformatted input";
+  ASSERT_TRUE(CsvRowMapper::row(atCycle(TraceEvent{PcSampleTraceEvent{0x08001234U, false}}, 949339000U)) ==
+              "949339000,,pcsample,,,0x08001234,,")
+      << "CSV PC-sample row mismatch";
+  ASSERT_TRUE(CsvRowMapper::row(atCycle(TraceEvent{PcSampleTraceEvent{0U, true}}, 949339100U)) ==
+              "949339100,,pcsample,,,,,")
+      << "CSV PC-sample sleep row mismatch";
 }
 
 TEST(CtraceUnitTests, testCsvRowMapperCoversAddressAndExceptionVariants)

--- a/tools/ctrace/test/unit/src/output/ctf/CtfEncoderTests.cpp
+++ b/tools/ctrace/test/unit/src/output/ctf/CtfEncoderTests.cpp
@@ -98,6 +98,51 @@ TEST(CtraceUnitTests, testCtfEncoderWritesOnlyIntoProvidedDirectory)
       << "CtfEncoder abort must not delete a directory owned by its caller";
 }
 
+TEST(CtraceUnitTests, testCtfEncoderPcSampleEncoding)
+{
+  const TemporaryTestPath temporaryPath("ctrace-ctf-pc-sample-test");
+  const auto& outputDirectory = temporaryPath.createDirectory();
+
+  CtfEncoder encoder(CtfEncoderConfig{
+      1000000U,
+      TraceSelection{{"pcsample"}, {}},
+      {},
+  });
+  encoder.start(outputDirectory);
+  auto pc = onStream(atCycle(TraceEvent{PcSampleTraceEvent{0x08001234U, false}}, 10U), 3U);
+  pc.quality = TraceQuality{false, true, 0U};
+  encoder.writeEvent(pc);
+  auto sleep = onStream(atCycle(TraceEvent{PcSampleTraceEvent{0x12345678U, true}}, 11U), 3U);
+  sleep.quality = TraceQuality{true, false, 7U};
+  encoder.writeEvent(sleep);
+  encoder.stop();
+
+  const auto records = readCtfRecords(outputDirectory / "stream_0");
+  ASSERT_EQ(records.size(), 2U);
+  for (const auto& record : records) {
+    EXPECT_EQ(record.id, CtfSchema::value(CtfSchema::EventId::PcSample));
+    EXPECT_EQ(record.traceBusId, 3U);
+  }
+  ASSERT_EQ(records[0].payload.size(), 10U);
+  EXPECT_EQ(records[0].timestamp, 10U);
+  EXPECT_EQ(records[0].payload[0U], CtfSchema::value(CtfSchema::PcSampleState::Pc));
+  EXPECT_EQ(readLe32(records[0].payload, 1U), 0x08001234U);
+  EXPECT_EQ(records[0].payload[5U], CtfSchema::SampleFlagTimestampReliable);
+  EXPECT_EQ(readLe32(records[0].payload, 6U), 0U);
+
+  ASSERT_EQ(records[1].payload.size(), 6U);
+  EXPECT_EQ(records[1].timestamp, 11U);
+  EXPECT_EQ(records[1].payload[0U], CtfSchema::value(CtfSchema::PcSampleState::Sleep));
+  EXPECT_EQ(records[1].payload[1U], CtfSchema::SampleFlagOverflow);
+  EXPECT_EQ(readLe32(records[1].payload, 2U), 7U);
+
+  const auto metadata = readTestTextFile(outputDirectory / "metadata");
+  EXPECT_NE(metadata.find("name = \"PC_SAMPLE\""), std::string::npos);
+  EXPECT_NE(metadata.find("uint8_t cmsis_pc_sample_state"), std::string::npos);
+  EXPECT_EQ(metadata.find("cmsis_pc_sample_state_t"), std::string::npos);
+  EXPECT_NE(metadata.find("uint32_t cmsis_pc[cmsis_pc_sample_state]"), std::string::npos);
+}
+
 TEST(CtraceUnitTests, testCtfEncoderPacketBoundaryAndUuid)
 {
   const TemporaryTestPath temporaryPath("ctrace-ctf-encoder-packet-boundary-test");

--- a/tools/ctrace/test/unit/src/output/ctf/CtfMetadataWriterTests.cpp
+++ b/tools/ctrace/test/unit/src/output/ctf/CtfMetadataWriterTests.cpp
@@ -97,7 +97,7 @@ TEST(CtraceUnitTests, testTraceCompassXmlUsesCurrentCtfEvents)
   EXPECT_NE(xml.find("<label value=\"PC Sampling\" />"), std::string::npos);
   EXPECT_NE(xml.find("<definedValue name=\"Sleep\" value=\"0\""), std::string::npos);
   EXPECT_EQ(xml.find("<definedValue name=\"Running\""), std::string::npos);
-  EXPECT_NE(xml.find("<entry path=\"PC_SAMPLE/*\" displayText=\"true\"><display type=\"self\" /></entry>"),
+  EXPECT_NE(xml.find("<entry path=\"PC_SAMPLE/" "*\" displayText=\"true\"><display type=\"self\" /></entry>"),
             std::string::npos);
   EXPECT_NE(xml.find("<stateValue type=\"string\" value=\"overflow\" />"), std::string::npos);
   EXPECT_NE(xml.find("<stateValue type=\"string\" value=\"data_loss\" />"), std::string::npos);

--- a/tools/ctrace/test/unit/src/output/ctf/CtfMetadataWriterTests.cpp
+++ b/tools/ctrace/test/unit/src/output/ctf/CtfMetadataWriterTests.cpp
@@ -82,14 +82,25 @@ TEST(CtraceUnitTests, testTraceCompassXmlUsesCurrentCtfEvents)
   const TemporaryTestPath path("ctrace-trace-compass-schema.xml");
   TraceCompassXmlWriter::writeFile(path.path());
   const auto xml = readTestTextFile(path.path());
-  constexpr std::array<CtfSchema::EventId, 5U> visualizedEvents{
+  constexpr std::array<CtfSchema::EventId, 6U> visualizedEvents{
       CtfSchema::EventId::Itm,       CtfSchema::EventId::DwtValue,    CtfSchema::EventId::DwtAddress,
-      CtfSchema::EventId::Exception, CtfSchema::EventId::TraceStatus,
+      CtfSchema::EventId::Exception, CtfSchema::EventId::TraceStatus, CtfSchema::EventId::PcSample,
   };
 
   for (const auto eventId : visualizedEvents) {
     EXPECT_NE(xml.find("eventName=\"" + std::string(CtfSchema::eventName(eventId)) + "\""), std::string::npos);
   }
+  EXPECT_NE(xml.find("value=\"cmsis_pc_sample_state\""), std::string::npos);
+  EXPECT_NE(xml.find("<stateAttribute type=\"constant\" value=\"Sleep\" />"), std::string::npos);
+  EXPECT_NE(xml.find("<stateValue type=\"int\" value=\"0\" />"), std::string::npos);
+  EXPECT_EQ(xml.find("<stateValue type=\"string\" value=\"Sleep\" />"), std::string::npos);
+  EXPECT_NE(xml.find("<label value=\"PC Sampling\" />"), std::string::npos);
+  EXPECT_NE(xml.find("<definedValue name=\"Sleep\" value=\"0\""), std::string::npos);
+  EXPECT_EQ(xml.find("<definedValue name=\"Running\""), std::string::npos);
+  EXPECT_NE(xml.find("<entry path=\"PC_SAMPLE/*\" displayText=\"true\"><display type=\"self\" /></entry>"),
+            std::string::npos);
+  EXPECT_NE(xml.find("<stateValue type=\"string\" value=\"overflow\" />"), std::string::npos);
+  EXPECT_NE(xml.find("<stateValue type=\"string\" value=\"data_loss\" />"), std::string::npos);
 }
 
 TEST(CtraceUnitTests, testCtfTextWritersReportDeviceWriteFailures)

--- a/tools/ctrace/test/unit/src/output/ctf/CtfSchemaTests.cpp
+++ b/tools/ctrace/test/unit/src/output/ctf/CtfSchemaTests.cpp
@@ -21,10 +21,11 @@
 
 TEST(CtraceUnitTests, testCtfSchemaUsesDenseIdentifiers)
 {
-  constexpr std::array<std::uint32_t, 6U> eventIds{
+  constexpr std::array<std::uint32_t, 7U> eventIds{
       CtfSchema::value(CtfSchema::EventId::Itm),        CtfSchema::value(CtfSchema::EventId::DwtValue),
       CtfSchema::value(CtfSchema::EventId::DwtAddress), CtfSchema::value(CtfSchema::EventId::TraceStatus),
       CtfSchema::value(CtfSchema::EventId::Exception),  CtfSchema::value(CtfSchema::EventId::GlobalTimestamp),
+      CtfSchema::value(CtfSchema::EventId::PcSample),
   };
   constexpr std::array<std::uint8_t, 5U> statusReasons{
       CtfSchema::value(CtfSchema::TraceStatusReason::TraceStart),
@@ -36,6 +37,10 @@ TEST(CtraceUnitTests, testCtfSchemaUsesDenseIdentifiers)
   constexpr std::array<std::uint8_t, 2U> exceptionActions{
       CtfSchema::value(CtfSchema::ExceptionAction::Entered),
       CtfSchema::value(CtfSchema::ExceptionAction::Exited),
+  };
+  constexpr std::array<std::uint8_t, 2U> pcSampleStates{
+      CtfSchema::value(CtfSchema::PcSampleState::Sleep),
+      CtfSchema::value(CtfSchema::PcSampleState::Pc),
   };
   constexpr std::array<std::uint8_t, 7U> valueTags{
       CtfSchema::value(CtfSchema::ValueTag::Signed8),  CtfSchema::value(CtfSchema::ValueTag::Unsigned8),
@@ -52,6 +57,9 @@ TEST(CtraceUnitTests, testCtfSchemaUsesDenseIdentifiers)
   }
   for (std::size_t index = 0U; index < exceptionActions.size(); ++index) {
     EXPECT_EQ(exceptionActions[index], static_cast<std::uint8_t>(index));
+  }
+  for (std::size_t index = 0U; index < pcSampleStates.size(); ++index) {
+    EXPECT_EQ(pcSampleStates[index], static_cast<std::uint8_t>(index));
   }
   for (std::size_t index = 0U; index < valueTags.size(); ++index) {
     EXPECT_EQ(valueTags[index], static_cast<std::uint8_t>(index));

--- a/tools/ctrace/test/unit/support/CtfTestSupport.h
+++ b/tools/ctrace/test/unit/support/CtfTestSupport.h
@@ -110,6 +110,13 @@ inline std::size_t ctfPayloadSize(const std::vector<unsigned char>& bytes, std::
   if (eventId == CtfSchema::value(CtfSchema::EventId::GlobalTimestamp)) {
     return 9U;
   }
+  if (eventId == CtfSchema::value(CtfSchema::EventId::PcSample)) {
+    requirePayload(1U);
+    const auto state = bytes[payloadOffset];
+    require(state <= CtfSchema::value(CtfSchema::PcSampleState::Pc),
+            "CTF test parser encountered an invalid PC-sample state");
+    return 1U + (state == CtfSchema::value(CtfSchema::PcSampleState::Pc) ? 4U : 0U) + 5U;
+  }
   require(false, "CTF test parser encountered an unknown event ID");
   return 0U;
 }


### PR DESCRIPTION
## Fixes

- Adds periodic DWT PC-sample and processor-sleep output to ctrace.

## Changes

- Decode 4-byte PC samples and 1-byte processor-sleep indications.
- Report unsupported PC-sample payloads as trace issues.
- Add PC samples to CSV output.
- Add a compact `PC_SAMPLE` CTF event with sample-quality and overflow information.
- Add a Trace Compass timeline showing processor-sleep intervals.
- End sleep intervals on PC samples, overflow, and data loss.
- Avoid ambiguous `/*` sequences for the copyright comment parser.
- Update documentation and add unit and integration coverage.

## Validation

- All ctrace test groups pass.
- Patch line coverage is 100% (139/139).
- Generated CTF validates with Babeltrace.
- Generated Trace Compass XML validates against its XSD.
- Copyright and cppcheck validation pass.

## Checklist

- [x] 🤖 This change is covered by unit tests.
- [x] 🤹 Manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [x] 📖 Documentation updates are complete.
- [x] 🧠 Third-party dependencies and TPIP were considered; no updates are required.