### PR TITLE
feat(ctrace): support diagnostic message lists

### DIFF
--- a/tools/ctrace/src/control/TraceDirectoryJob.cpp
+++ b/tools/ctrace/src/control/TraceDirectoryJob.cpp
@@ -45,24 +45,25 @@ static std::vector<std::pair<std::string, std::string>> referenceContext(const T
 static void reportConsumedReferenceDiagnostics(const TraceRunConfig& config, DiagnosticSink& diagnostics)
 {
   for (const auto& reference : config.references) {
-    const auto report = [&](DiagnosticSink::Severity severity, const std::optional<std::string>& message) {
-      if (!message.has_value() || message->empty()) {
-        return;
+    const auto report = [&](DiagnosticSink::Severity severity, const std::vector<std::string>& messages) {
+      for (const auto& message : messages) {
+        if (message.empty()) {
+          continue;
+        }
+        diagnostics.report({
+            severity,
+            message,
+            referenceContext(config, reference),
+        });
       }
-      diagnostics.report({
-          severity,
-          *message,
-          referenceContext(config, reference),
-      });
     };
     report(DiagnosticSink::Severity::Info, reference.info);
     report(DiagnosticSink::Severity::Warning, reference.warning);
-    if (reference.error.has_value()) {
-      auto context = referenceContext(config, reference);
+    for (const auto& error : reference.error) {
       diagnostics.report({
           DiagnosticSink::Severity::Error,
-          reference.error->empty() ? "trace generation setup failed without a diagnostic message" : *reference.error,
-          std::move(context),
+          error.empty() ? "trace generation setup failed without a diagnostic message" : error,
+          referenceContext(config, reference),
           DiagnosticSink::Impact::NonFailing,
       });
     }

--- a/tools/ctrace/src/tracerun/CtraceRunMeta.cpp
+++ b/tools/ctrace/src/tracerun/CtraceRunMeta.cpp
@@ -508,7 +508,7 @@ CtraceRunMeta CtraceRunMeta::fromConfig(const TraceRunConfig& config)
       continue;
     }
     const auto problem = TraceRunSchema::referenceProblem(reference);
-    if (problem != ReferenceProblem::None && !reference.error.has_value()) {
+    if (problem != ReferenceProblem::None && reference.error.empty()) {
       throw std::runtime_error(referenceProblemMessage(config, reference, problem));
     }
   }

--- a/tools/ctrace/src/tracerun/TraceRunConfig.h
+++ b/tools/ctrace/src/tracerun/TraceRunConfig.h
@@ -102,9 +102,9 @@ struct TraceRunReference {
   std::string ctraceRef;
   std::string type;
   std::optional<std::string> processorName;
-  std::optional<std::string> info;
-  std::optional<std::string> warning;
-  std::optional<std::string> error;
+  std::vector<std::string> info;
+  std::vector<std::string> warning;
+  std::vector<std::string> error;
   std::optional<std::uint64_t> address;
   std::optional<std::string> dataType;
   std::optional<std::uint64_t> dataSize;

--- a/tools/ctrace/src/tracerun/YmlTraceRunConfigReader.cpp
+++ b/tools/ctrace/src/tracerun/YmlTraceRunConfigReader.cpp
@@ -288,25 +288,41 @@ static std::vector<std::uint32_t> parseSources(const std::string& path, const No
 
 /** @brief Stores diagnostics copied from one parsed trace reference. */
 struct ReferenceDiagnostics {
-  std::optional<std::string> info;
-  std::optional<std::string> warning;
-  std::optional<std::string> error;
+  std::vector<std::string> info;
+  std::vector<std::string> warning;
+  std::vector<std::string> error;
 };
 
 /** @brief Parses optional informational diagnostics attached to a reference. */
 static ReferenceDiagnostics parseReferenceDiagnostics(const std::string& path, const Node& element)
 {
-  const auto message = [&](const std::string_view& name) {
-    const auto value = optionalAttribute(element, name);
-    if (childContainer(element, name)) {
-      fail(path, element, "'" + std::string(name) + "' must be a scalar message");
+  const auto messages = [&](const std::string_view& name) {
+    const auto node = childNode(element, name);
+    if (!node) {
+      return std::vector<std::string>{};
     }
-    return value;
+    if (node.IsNull()) {
+      return std::vector<std::string>{std::string{}};
+    }
+    if (node.IsScalar()) {
+      return std::vector<std::string>{node.Scalar()};
+    }
+    if (!node.IsSequence()) {
+      fail(path, node, "'" + std::string(name) + "' must be a string or list of strings");
+    }
+    std::vector<std::string> result;
+    for (const auto& item : node) {
+      if (!item.IsScalar()) {
+        fail(path, item, "each '" + std::string(name) + "' entry must be a string");
+      }
+      result.push_back(item.Scalar());
+    }
+    return result;
   };
   return {
-      message("info"),
-      message("warning"),
-      message("error"),
+      messages("info"),
+      messages("warning"),
+      messages("error"),
   };
 }
 
@@ -376,7 +392,7 @@ static std::optional<TraceRunReference> parseReference(const std::string& path, 
     return reference;
   }
 
-  if (diagnostics.error.has_value()) {
+  if (!diagnostics.error.empty()) {
     auto diagnosticReference = reference;
     diagnosticReference.processorName = bestEffortProcessorName(element);
     try {

--- a/tools/ctrace/test/integration/src/CtraceIntegTests.cpp
+++ b/tools/ctrace/test/integration/src/CtraceIntegTests.cpp
@@ -385,9 +385,13 @@ TEST_F(CtraceIntegTests, ReportsDiagnosticsFromConsumedTraceRunReferences)
       pname: core
       stream: 1
       source: 0
-      info: configured ITM channel zero
+      info:
+        - configured ITM channel zero
+        - retained secondary setup information
       warning: ITM channel zero uses fallback routing
-      error: target could not enable ITM channel zero
+      error:
+        - target could not enable ITM channel zero
+        - target rejected the fallback configuration
     - ctrace-ref: core/exceptions
       type: exception
       error: ignored reference diagnostic
@@ -397,8 +401,10 @@ TEST_F(CtraceIntegTests, ReportsDiagnosticsFromConsumedTraceRunReferences)
   const auto result = run({"ctrace", workDirectory().string(), "--target", "Diagnostics", "--all"});
   EXPECT_EQ(0, result.exitCode) << result.stderrText;
   expectContains(result.stderrText, "[info] configured ITM channel zero:");
+  expectContains(result.stderrText, "[info] retained secondary setup information:");
   expectContains(result.stderrText, "[warning] ITM channel zero uses fallback routing:");
   expectContains(result.stderrText, "[error] target could not enable ITM channel zero:");
+  expectContains(result.stderrText, "[error] target rejected the fallback configuration:");
   expectContains(result.stderrText, "ctraceRef=core/itm, type=itm, pname=core");
   expectNotContains(result.stderrText, "ignored reference diagnostic");
 

--- a/tools/ctrace/test/unit/src/control/TraceDirectoryJobTests.cpp
+++ b/tools/ctrace/test/unit/src/control/TraceDirectoryJobTests.cpp
@@ -169,22 +169,22 @@ TEST(CtraceUnitTests, testTraceDirectoryReportsGenerationDiagnosticsAndMissingSw
 
   TraceRunConfig config;
   auto reported = TraceRunTestSupport::makeReference("event", "core", 3U, {}, "core/event");
-  reported.info = "producer note";
-  reported.warning = "producer warning";
-  reported.error = "producer error";
+  reported.info = {"producer note", "second producer note"};
+  reported.warning = {"producer warning", "second producer warning"};
+  reported.error = {"producer error", "second producer error"};
   TraceRunReference emptyError = reported;
   emptyError.ctraceRef = "core/pmu";
   emptyError.type = "pmu";
-  emptyError.info.reset();
-  emptyError.warning = "";
-  emptyError.error = "";
+  emptyError.info.clear();
+  emptyError.warning = {""};
+  emptyError.error = {""};
   auto channelZero = TraceRunTestSupport::makeReference("itm", std::nullopt, std::nullopt, {0U}, "core/itm");
-  channelZero.error = "channel zero diagnostic";
+  channelZero.error = {"channel zero diagnostic"};
   TraceRunReference noStream = reported;
   noStream.ctraceRef = "core/no-stream";
   noStream.stream.reset();
-  noStream.warning.reset();
-  noStream.error.reset();
+  noStream.warning.clear();
+  noStream.error.clear();
   auto inconsistent = TraceRunTestSupport::makeReference("itm", "other", 3U, {1U}, "other/itm");
   config.setups.push_back(TraceRunTestSupport::makeTimestampSetup("core"));
   config.references = {reported, emptyError, channelZero, noStream, inconsistent};
@@ -196,8 +196,11 @@ TEST(CtraceUnitTests, testTraceDirectoryReportsGenerationDiagnosticsAndMissingSw
   TraceDirectoryJob(options, diagnostics, reader).run();
 
   EXPECT_TRUE(diagnostics.containsMessage("producer note"));
+  EXPECT_TRUE(diagnostics.containsMessage("second producer note"));
   EXPECT_TRUE(diagnostics.containsMessage("producer warning"));
+  EXPECT_TRUE(diagnostics.containsMessage("second producer warning"));
   EXPECT_TRUE(diagnostics.containsMessage("producer error"));
+  EXPECT_TRUE(diagnostics.containsMessage("second producer error"));
   EXPECT_TRUE(diagnostics.containsMessage("channel zero diagnostic"));
   EXPECT_TRUE(diagnostics.containsMessage("trace generation setup failed without a diagnostic message"));
   EXPECT_TRUE(diagnostics.containsMessage("does not match ctrace-setup pname"));
@@ -228,7 +231,7 @@ TEST(CtraceUnitTests, testTraceDirectoryChecksOutputRequirementsAfterReferenceEr
 
   TraceRunConfig config;
   auto reference = TraceRunTestSupport::makeReference("event", "core", 3U, {}, "core/event");
-  reference.error = "producer could not configure event trace";
+  reference.error = {"producer could not configure event trace"};
   config.references.push_back(std::move(reference));
 
   CliOptions options;

--- a/tools/ctrace/test/unit/src/tracerun/CtraceRunMetaTests.cpp
+++ b/tools/ctrace/test/unit/src/tracerun/CtraceRunMetaTests.cpp
@@ -76,14 +76,14 @@ TEST(CtraceUnitTests, testCtraceRunMetaRejectsInvalidReferences)
 
   TraceRunConfig diagnosed;
   diagnosed.references.push_back(makeReference("itm", std::nullopt, 0U, {99U}));
-  diagnosed.references.front().error = "producer rejected this route";
+  diagnosed.references.front().error = {"producer rejected this route"};
   EXPECT_NO_THROW((void)CtraceRunMeta::fromConfig(diagnosed));
 
   TraceRunConfig diagnosedBinding;
   diagnosedBinding.path = "trace.yml";
   diagnosedBinding.setups.push_back(makeTimestampSetup("core"));
   diagnosedBinding.references.push_back(makeReference("itm", "unusable", 0U, {99U}));
-  diagnosedBinding.references.front().error = "producer rejected this route";
+  diagnosedBinding.references.front().error = {"producer rejected this route"};
   const auto meta = CtraceRunMeta::fromConfig(diagnosedBinding);
   EXPECT_EQ(meta.processorCount(), 1U);
   EXPECT_TRUE(meta.sources().empty());
@@ -145,7 +145,7 @@ TEST(CtraceUnitTests, testCtraceRunMetaWarnsForCrossRootProcessorIdentityConflic
   multiUnnamed.references.push_back(makeReference("itm", std::nullopt, 1U, {1U}));
   multiUnnamed.references.front().line = 17U;
   auto diagnosedReference = makeReference("itm", "a", 0U, {99U});
-  diagnosedReference.error = "producer rejected this route";
+  diagnosedReference.error = {"producer rejected this route"};
   multiUnnamed.references.push_back(diagnosedReference);
   const auto unnamedMeta = CtraceRunMeta::fromConfig(multiUnnamed);
   EXPECT_EQ(unnamedMeta.processorCount(), 2U);

--- a/tools/ctrace/test/unit/src/tracerun/TraceRunConfigReaderTests.cpp
+++ b/tools/ctrace/test/unit/src/tracerun/TraceRunConfigReaderTests.cpp
@@ -295,9 +295,9 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedReferenceRoutes)
       {"source: [1, {}]", "each 'source' entry must be an unsigned integer"},
       {"source: [1, '']", "each 'source' entry must be an unsigned integer"},
       {"source: 1\n      source: 2", "map keys must be unique"},
-      {"source: 1\n      info: []", "'info' must be a scalar message"},
-      {"source: 1\n      warning: {}", "'warning' must be a scalar message"},
-      {"source: 1\n      error: []", "'error' must be a scalar message"},
+      {"source: 1\n      info: {}", "'info' must be a string or list of strings"},
+      {"source: 1\n      warning: [valid, {}]", "each 'warning' entry must be a string"},
+      {"source: 1\n      error: [valid, []]", "each 'error' entry must be a string"},
   };
   for (const auto& testCase : cases) {
     const auto yaml = std::string("ctrace-run:\n  ctrace-refs:\n    - type: itm\n      ctrace-ref: core/itm\n      ") +
@@ -311,12 +311,12 @@ TEST(CtraceUnitTests, TraceRunReaderPreservesDiagnosticReferences)
   TraceRunFixture file("ctrace-run-reader-diagnostic-references-test");
   const auto config = file.read(R"yml(ctrace-run:
   ctrace-refs:
-    - { type: event, ctrace-ref: core/event, pname: core0, info: note }
-    - { type: pmu, ctrace-ref: core/pmu, pname: core1, warning: warning }
+    - { type: event, ctrace-ref: core/event, pname: core0, info: [note, detail], warning: [] }
+    - { type: pmu, ctrace-ref: core/pmu, pname: core1, warning: [warning] }
     - { type: pcsample, ctrace-ref: core/pc, pname: null, error: unavailable }
-    - { type: dwt, ctrace-ref: core/data#, source: 0, address: invalid, error: diagnostic }
+    - { type: dwt, ctrace-ref: core/data#, source: 0, address: invalid, error: [diagnostic, detail] }
     - { type: dwt, ctrace-ref: core/data#x, stream: [], source: 0, error: malformed }
-    - { type: dwt, ctrace-ref: core/notdata#2, error: unrouted }
+    - { type: dwt, ctrace-ref: core/notdata#2, error: null }
     - { type: itm, ctrace-ref: core/itm0, source: 0, error: disabled }
     - { type: itm, ctrace-ref: core/itm1, source: 1, error: usable, label: null }
     - { type: exception, ctrace-ref: core/exceptions, error: ignored }
@@ -325,12 +325,18 @@ TEST(CtraceUnitTests, TraceRunReaderPreservesDiagnosticReferences)
 )yml");
   ASSERT_EQ(config.references.size(), 8U) << "reader must ignore diagnostic annotations on unconsumed reference types";
   EXPECT_EQ(config.references[0].processorName, std::optional<std::string>("core0"));
+  EXPECT_EQ(config.references[0].info, (std::vector<std::string>{"note", "detail"}));
+  EXPECT_TRUE(config.references[0].warning.empty());
   EXPECT_EQ(config.references[1].processorName, std::optional<std::string>("core1"));
+  EXPECT_EQ(config.references[1].warning, (std::vector<std::string>{"warning"}));
   EXPECT_FALSE(config.references[2].processorName.has_value());
+  EXPECT_EQ(config.references[2].error, (std::vector<std::string>{"unavailable"}));
+  EXPECT_EQ(config.references[3].error, (std::vector<std::string>{"diagnostic", "detail"}));
   EXPECT_FALSE(config.references[3].address.has_value());
   EXPECT_FALSE(config.references[3].dataSetupIndex.has_value());
   EXPECT_FALSE(config.references[4].stream.has_value());
   EXPECT_FALSE(config.references[4].dataSetupIndex.has_value());
+  EXPECT_EQ(config.references[5].error, (std::vector<std::string>{""}));
   EXPECT_TRUE(config.references[6].sources == std::vector<std::uint32_t>{0U});
   EXPECT_EQ(config.references[7].label, std::optional<std::string>(""));
 }


### PR DESCRIPTION
## Summary

Support the current `*.ctrace-run.yml` specification, where each `info`, `warning`, and `error` field accepts either a single string or a list of strings.

## Changes

- normalize scalar and sequence diagnostics to a shared list representation
- emit every diagnostic list entry separately with its original severity and reference context
- preserve scalar input compatibility
- accept empty lists without producing diagnostics
- preserve the existing fallback message for an empty error value
- keep diagnostics on unconsumed reference types ignored as before
- retain the existing reference validation and metadata behavior when an error is present

## Validation

- Release unit and integration tests passed
- Debug/coverage unit and integration tests passed
- integration coverage verifies scalar and list input plus separate diagnostic output
- unit coverage includes empty lists, empty values, and malformed list entries
- copyright checks pass for all changed files

Specification: https://open-cmsis-pack.github.io/cmsis-toolbox/Experimental-Features/#file-structure-of-ctrace-runyml

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).