### PR TITLE
Add `list targets` command and clarify target terminology

### DIFF
--- a/tools/projmgr/include/ProjMgr.h
+++ b/tools/projmgr/include/ProjMgr.h
@@ -66,7 +66,7 @@ public:
   /**
    * @brief load solution
    * @param path to <solution>.csolution.yml file
-   * @param active target set in the format <target-type>[@<set>]
+   * @param active target set in the format <target-type>[@<target-set>]
    * @return processing status
   */
   bool LoadSolution(const std::string& csolution, const std::string& activeTargetSet);
@@ -74,7 +74,7 @@ public:
   /**
    * @brief setup contexts
    * @param path to <solution>.csolution.yml file
-   * @param active target set in the format <target-type>[@<set>]
+   * @param active target set in the format <target-type>[@<target-set>]
    * @return processing status
   */
   bool SetupContexts(const std::string& csolution, const std::string& activeTargetSet);  

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -2746,7 +2746,7 @@
       "type": "object",
       "description": "Target selection for hardware or simulator.",
       "properties": {
-        "target": { "type": "string", "description": "Explicit <target-type>[@<set>] selection." }
+        "target": { "type": "string", "description": "Explicit <target-type>[@<target-set>] selection." }
       },
       "additionalProperties": false
     },
@@ -2851,7 +2851,7 @@
       "type": "object",
       "description": "Run configuration.",
       "properties": {
-        "active":       { "type": "string", "description": "Active target-set in the form <target-type>[@<set>]." },
+        "active":       { "type": "string", "description": "Active target in the form <target-type>[@<target-set>]." },
         "cbuild-run":   { "type": "string", "description": "Path to the *.cbuild-run.yml file." },
         "output":       { "type": "array", "description": "List of output image files.", "items": { "$ref": "#/definitions/MlopsOutputType" } },
         "model":        { "type": "string", "description": "Simulator model executable (e.g. FVP_Corstone_SSE-320)." },

--- a/tools/projmgr/src/ProjMgr.cpp
+++ b/tools/projmgr/src/ProjMgr.cpp
@@ -38,13 +38,13 @@ Commands:\n\
   list layers                   Print list of available, referenced and compatible layers\n\
   list npus                     Print list of available NPUs\n\
   list packs                    Print list of used packs from the pack repository\n\
-  list target-sets              Print list of target-sets in a <name>.csolution.yml\n\
+  list targets                  Print list of targets (<target-type>[@<target-set>]) in a <name>.csolution.yml\n\
   list toolchains               Print list of supported toolchains\n\
   run                           Run code generator\n\
   rpc                           Run remote procedure call server\n\
   update-rte                    Create/update configuration files and validate solution\n\n\
 Options:\n\
-  -a, --active arg              Select active target-set: <target-type>[@<set>]\n\
+  -a, --active arg              Select active target: <target-type>[@<target-set>]\n\
   -c, --context arg [...]       Input context names [<project-name>][.<build-type>][+<target-type>]\n\
   -d, --debug                   Enable debug messages\n\
   -D, --dry-run                 Enable dry-run\n\
@@ -172,7 +172,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
   cxxopts::Option quiet("q,quiet", "Run silently, printing only error messages", cxxopts::value<bool>()->default_value("false"));
   cxxopts::Option cbuildgen("cbuildgen", "Generate legacy *.cprj files", cxxopts::value<bool>()->default_value("false"));
   cxxopts::Option contentLength("content-length", "Prepend 'Content-Length' header to JSON RPC requests and responses", cxxopts::value<bool>()->default_value("false"));
-  cxxopts::Option activeTargetSet("a,active", "Select active target-set: <target-type>[@<set>]", cxxopts::value<string>());
+  cxxopts::Option activeTargetSet("a,active", "Select active target: <target-type>[@<target-set>]", cxxopts::value<string>());
   cxxopts::Option locked("locked", "Print available update version for locked packs", cxxopts::value<bool>()->default_value("false"));
 
   // command options dictionary
@@ -192,6 +192,7 @@ int ProjMgr::ParseCommandLine(int argc, char** argv) {
     {"list examples",      { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list templates",     { false, {context, contextSet, activeTargetSet, debug, filter, load, quiet, schemaCheck, toolchain, verbose}}},
     {"list contexts",      { false, {debug, filter, quiet, schemaCheck, verbose, ymlOrder}}},
+    {"list targets",       { false, {debug, filter, quiet, schemaCheck, verbose}}},
     {"list target-sets",   { false, {debug, filter, quiet, schemaCheck, verbose}}},
     {"list debuggers",     { false, {debug, filter, quiet, schemaCheck, verbose}}},
     {"list generators",    { false, {context, contextSet, activeTargetSet, debug, load, quiet, schemaCheck, toolchain, verbose}}},
@@ -427,6 +428,7 @@ int ProjMgr::ProcessListCommand() {
     { "examples",     [this]() { return RunListExamples(); } },
     { "templates",    [this]() { return RunListTemplates(); } },
     { "contexts",     [this]() { return RunListContexts(); } },
+    { "targets",      [this]() { return RunListTargetSets(); } },
     { "target-sets",  [this]() { return RunListTargetSets(); } },
     { "debuggers",    [this]() { return RunListDebuggers(); } },
     { "generators",   [this]() { return RunListGenerators(); } },

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -4503,6 +4503,11 @@ TEST_F(ProjMgrUnitTests, RunProjMgr_help) {
   EXPECT_EQ(0, RunProjMgr(4, argv, 0));
 
   argv[1] = (char*)"list";
+  argv[2] = (char*)"targets";
+  argv[3] = (char*)"-h";
+  EXPECT_EQ(0, RunProjMgr(4, argv, 0));
+
+  argv[1] = (char*)"list";
   argv[2] = (char*)"target-sets";
   argv[3] = (char*)"-h";
   EXPECT_EQ(0, RunProjMgr(4, argv, 0));
@@ -7434,7 +7439,7 @@ TEST_F(ProjMgrUnitTests, ListTargetSets) {
   StdStreamRedirect streamRedirect;
   const string& csolution = testinput_folder + "/TestTargetSet/solution.csolution.yml";
   argv[1] = (char*)"list";
-  argv[2] = (char*)"target-sets";
+  argv[2] = (char*)"targets";
   argv[3] = (char*)csolution.c_str();
   EXPECT_EQ(0, RunProjMgr(4, argv, 0));
 
@@ -7442,6 +7447,14 @@ TEST_F(ProjMgrUnitTests, ListTargetSets) {
   EXPECT_STREQ(outStr.c_str(), "Type1\nType1@Custom2\nType1@Custom3\nType2@Default2\n");
 
   streamRedirect.ClearStringStreams();
+  argv[2] = (char*)"target-sets";
+  EXPECT_EQ(0, RunProjMgr(4, argv, 0));
+
+  outStr = streamRedirect.GetOutString();
+  EXPECT_STREQ(outStr.c_str(), "Type1\nType1@Custom2\nType1@Custom3\nType2@Default2\n");
+
+  streamRedirect.ClearStringStreams();
+  argv[2] = (char*)"targets";
   argv[4] = (char*)"--filter";
   argv[5] = (char*)"TYPE2";
   EXPECT_EQ(0, RunProjMgr(6, argv, 0));


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/pull/511#issuecomment-5570483118

## Changes
- Add `list targets` as the preferred command for listing `<target-type>[@<target-set>]` selections.
- Retain `list target-sets` as a backward-compatible alias.
- Update CLI help, API comments, and schema descriptions to distinguish targets from target sets.
- Extend unit tests to cover the new command and legacy alias.

The terminology now reflects that selections may identify either a target type alone or a target type with a target set. Existing scripts using `list target-sets` remain supported.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).

**Note:** the [global / copyright (pull_request)](https://github.com/Open-CMSIS-Pack/devtools/actions/runs/34127683164/job/101760118012?pr=2598) failure is unrelated to the changes in this PR. It was introduced earlier by a defect in PR https://github.com/Open-CMSIS-Pack/devtools/pull/2587 and has already been reported in issue https://github.com/Open-CMSIS-Pack/devtools/issues/2599.