### PR TITLE
[projmgr] Add active `target` to `cbuild-idx`

### DIFF
--- a/tools/projmgr/include/ProjMgrWorker.h
+++ b/tools/projmgr/include/ProjMgrWorker.h
@@ -961,6 +961,12 @@ public:
   std::vector<std::string> GetSelectedContexts() const;
 
   /**
+   * @brief get the active target in the format <target-type>[@<target-set>]
+   * @return active target
+  */
+  std::string GetActiveTarget() const;
+
+  /**
    * @brief check if context is selected
    * @param context name
    * @return true if it is selected

--- a/tools/projmgr/schemas/common.schema.json
+++ b/tools/projmgr/schemas/common.schema.json
@@ -1305,6 +1305,7 @@
       "properties": {
         "description":  { "type": "string" },
         "generated-by": { "type": "string", "description": "Tool name along with version information used to generate this file." },
+        "target": { "type": "string", "description": "Selected target in the format <target-type>[@<target-set>]." },
         "cdefault": { "type": "string", "description": "Path to cdefault.yml file." },
         "csolution": { "type": "string", "description": "Path to csolution.yml file." },
         "cbuild-run": { "type": "string", "description": "Path to cbuild-run.yml file." },

--- a/tools/projmgr/src/ProjMgrCbuildIdx.cpp
+++ b/tools/projmgr/src/ProjMgrCbuildIdx.cpp
@@ -30,6 +30,7 @@ ProjMgrCbuildIdx::ProjMgrCbuildIdx(YAML::Node node,
   const set<string>& failedContexts, const map<string, ExecutesItem>& executes) : ProjMgrCbuildBase(false) {
   error_code ec;
   SetNodeValue(node[YAML_GENERATED_BY], ORIGINAL_FILENAME + string(" version ") + VERSION_STRING);
+  SetNodeValue(node[YAML_TARGET], worker->GetActiveTarget());
   if (!processedContexts.empty()) {
     const auto& context = processedContexts.front();
     SetNodeValue(node[YAML_DESCRIPTION], context->csolution->description);

--- a/tools/projmgr/src/ProjMgrWorker.cpp
+++ b/tools/projmgr/src/ProjMgrWorker.cpp
@@ -6319,6 +6319,10 @@ bool ProjMgrWorker::PopulateActiveTargetSet(const string& activeTargetSet) {
   return true;
 }
 
+string ProjMgrWorker::GetActiveTarget() const {
+  return m_activeTargetType + (m_activeTargetSet.set.empty() ? "" : "@" + m_activeTargetSet.set);
+}
+
 bool ProjMgrWorker::IsLibOnly(const std::vector<ContextItem*>& contexts) {
   for (auto& context : contexts) {
     if (!context->outputTypes.lib.on) {

--- a/tools/projmgr/test/data/ImageOnly/ref/image-only.cbuild-idx.yml
+++ b/tools/projmgr/test/data/ImageOnly/ref/image-only.cbuild-idx.yml
@@ -1,5 +1,6 @@
 build-idx:
   generated-by: csolution version 0.0.0
+  target: CM0
   csolution: image-only.csolution.yml
   cbuild-run: out/image-only+CM0.cbuild-run.yml
   tmpdir: tmp/CM0/default

--- a/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
+++ b/tools/projmgr/test/data/WestSupport/ref/solution.cbuild-idx.yml
@@ -1,5 +1,6 @@
 build-idx:
   generated-by: csolution version 0.0.0
+  target: CM0
   csolution: solution.csolution.yml
   cbuild-run: out/solution+CM0.cbuild-run.yml
   tmpdir: tmp/CM0/default

--- a/tools/projmgr/test/src/ProjMgrUnitTests.cpp
+++ b/tools/projmgr/test/src/ProjMgrUnitTests.cpp
@@ -7630,11 +7630,15 @@ TEST_F(ProjMgrUnitTests, ConvertActiveTargetSet) {
   argv[3] = (char*)"--active";
   argv[4] = (char*)"Type1@Custom2";
   EXPECT_EQ(0, RunProjMgr(5, argv, 0));
+  const YAML::Node& cbuildIdx1 = YAML::LoadFile(testinput_folder + "/TestTargetSet/solution.cbuild-idx.yml");
+  EXPECT_EQ("Type1@Custom2", cbuildIdx1["build-idx"]["target"].as<string>());
   const YAML::Node& cbuildRun1 = YAML::LoadFile(testinput_folder + "/TestTargetSet/out/solution+Type1.cbuild-run.yml");
   EXPECT_EQ("Custom2", cbuildRun1["cbuild-run"]["target-set"].as<string>());
 
   argv[4] = (char*)"Type1";
   EXPECT_EQ(0, RunProjMgr(5, argv, 0));
+  const YAML::Node& cbuildIdx2 = YAML::LoadFile(testinput_folder + "/TestTargetSet/solution.cbuild-idx.yml");
+  EXPECT_EQ("Type1", cbuildIdx2["build-idx"]["target"].as<string>());
   const YAML::Node& cbuildRun2 = YAML::LoadFile(testinput_folder + "/TestTargetSet/out/solution+Type1.cbuild-run.yml");
   EXPECT_EQ("<default>", cbuildRun2["cbuild-run"]["target-set"].as<string>());
 


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/pull/692#discussion_r3955247801

## Changes
- Add the selected target to generated `cbuild-idx.yml` files using `<target-type>[@<target-set>]`.
- Extend the common schema with the new `build-idx.target` property.
- Add unit test assertions for targets with and without an active target set, and update reference outputs.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).