### PR TITLE
fix(ctrace): tolerate null optional trace-run values

### DIFF
--- a/tools/ctrace/src/tracerun/YmlTraceRunConfigReader.cpp
+++ b/tools/ctrace/src/tracerun/YmlTraceRunConfigReader.cpp
@@ -76,11 +76,8 @@ static Node childContainer(const Node& element, const std::string_view& tag)
 static std::optional<std::string> optionalAttribute(const Node& element, const std::string_view& name)
 {
   const auto node = childNode(element, name);
-  if (!node) {
+  if (!node || node.IsNull()) {
     return std::nullopt;
-  }
-  if (node.IsNull()) {
-    return std::string{};
   }
   if (!node.IsScalar()) {
     return std::nullopt;
@@ -163,7 +160,7 @@ static std::optional<std::uint64_t> deferredReferenceUnsignedAttribute(
     std::optional<std::string>& error)
 {
   const auto node = childNode(element, name);
-  if (!node) {
+  if (!node || node.IsNull()) {
     return std::nullopt;
   }
   if (!node.IsScalar()) {
@@ -183,7 +180,7 @@ static std::optional<std::string> deferredReferenceStringAttribute(const Node& e
                                                                    std::optional<std::string>& error)
 {
   const auto node = childNode(element, name);
-  if (!node) {
+  if (!node || node.IsNull()) {
     return std::nullopt;
   }
   if (!node.IsScalar()) {
@@ -264,18 +261,20 @@ static Node traceRunRoot(const std::string& path, const Node& document)
 static std::vector<std::uint32_t> parseSources(const std::string& path, const Node& reference)
 {
   const auto sourceNode = childNode(reference, "source");
-  if (!sourceNode) {
+  if (!sourceNode || sourceNode.IsNull()) {
     return {};
   }
-  if (sourceNode.IsScalar() || sourceNode.IsNull()) {
-    const auto scalarSource = sourceNode.IsScalar() ? sourceNode.Scalar() : std::string{};
+  if (sourceNode.IsScalar()) {
     return {static_cast<std::uint32_t>(
-        unsignedValue(path, sourceNode, "source", scalarSource, std::numeric_limits<std::uint32_t>::max()))};
+        unsignedValue(path, sourceNode, "source", sourceNode.Scalar(), std::numeric_limits<std::uint32_t>::max()))};
   }
 
   requireSequence(path, sourceNode, "source");
   std::vector<std::uint32_t> sources;
   for (const auto& item : sourceNode) {
+    if (item.IsNull()) {
+      continue;
+    }
     if (!item.IsScalar() || item.Scalar().empty()) {
       fail(path, item, "each 'source' entry must be an unsigned integer");
     }
@@ -298,11 +297,8 @@ static ReferenceDiagnostics parseReferenceDiagnostics(const std::string& path, c
 {
   const auto messages = [&](const std::string_view& name) {
     const auto node = childNode(element, name);
-    if (!node) {
+    if (!node || node.IsNull()) {
       return std::vector<std::string>{};
-    }
-    if (node.IsNull()) {
-      return std::vector<std::string>{std::string{}};
     }
     if (node.IsScalar()) {
       return std::vector<std::string>{node.Scalar()};
@@ -312,6 +308,9 @@ static ReferenceDiagnostics parseReferenceDiagnostics(const std::string& path, c
     }
     std::vector<std::string> result;
     for (const auto& item : node) {
+      if (item.IsNull()) {
+        continue;
+      }
       if (!item.IsScalar()) {
         fail(path, item, "each '" + std::string(name) + "' entry must be a string");
       }
@@ -329,6 +328,9 @@ static ReferenceDiagnostics parseReferenceDiagnostics(const std::string& path, c
 /** @brief Parses one relevant trace-run reference. */
 static std::optional<TraceRunReference> parseReference(const std::string& path, const Node& element)
 {
+  if (element.IsNull()) {
+    return std::nullopt;
+  }
   if (!element.IsMap()) {
     fail(path, element, "each 'ctrace-refs' entry must be a map");
   }
@@ -471,19 +473,22 @@ static std::optional<TraceRunTimestampSetup> parseTimestampSetup(const std::stri
   return timestamps;
 }
 
-/** @brief Parses ITM enable-mask metadata from one consumed setup. */
+/** @brief Parses ITM enable-mask metadata from one consumed setup, if available. */
 static std::optional<TraceRunItmSetup> parseItmSetup(const std::string& path, const Node& element)
 {
   const auto itmNode = childNode(element, "itm");
-  if (!itmNode) {
+  if (!itmNode || itmNode.IsNull()) {
     return std::nullopt;
   }
   if (!itmNode.IsMap()) {
     fail(path, itmNode, "'itm' must be a map containing 'enable'");
   }
   const auto enableNode = childNode(itmNode, "enable");
-  if (!enableNode || !enableNode.IsScalar() || enableNode.Scalar().empty()) {
-    fail(path, enableNode ? enableNode : itmNode, "'itm.enable' is required and must be a scalar unsigned integer");
+  if (!enableNode || enableNode.IsNull()) {
+    return std::nullopt;
+  }
+  if (!enableNode.IsScalar() || enableNode.Scalar().empty()) {
+    fail(path, enableNode, "'itm.enable' must be a scalar unsigned integer");
   }
   return TraceRunItmSetup{static_cast<std::uint32_t>(
       unsignedValue(path, enableNode, "itm.enable", enableNode.Scalar(), std::numeric_limits<std::uint32_t>::max()))};
@@ -544,13 +549,16 @@ static std::vector<TraceRunSetup> parseSetups(const std::string& path, const Nod
                                               const std::vector<TraceRunReference>& references)
 {
   const auto setupNode = childNode(root, "ctrace-setup");
-  if (!setupNode) {
+  if (!setupNode || setupNode.IsNull()) {
     return {};
   }
   requireSequence(path, setupNode, "ctrace-setup");
 
   std::vector<TraceRunSetup> setups;
   for (const auto& item : setupNode) {
+    if (item.IsNull()) {
+      continue;
+    }
     if (!item.IsMap()) {
       fail(path, item, "each 'ctrace-setup' entry must be a map");
     }

--- a/tools/ctrace/test/unit/src/tracerun/TraceRunConfigReaderTests.cpp
+++ b/tools/ctrace/test/unit/src/tracerun/TraceRunConfigReaderTests.cpp
@@ -259,6 +259,7 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedReferenceContainers)
 {
   TraceRunFixture file("ctrace-run-reader-reference-container-errors-test");
   expectReadError(file, "ctrace-run: {}\n", "missing required 'ctrace-refs' array");
+  expectReadError(file, "ctrace-run:\n  ctrace-refs: null\n", "'ctrace-refs' must be an array");
   expectReadError(file, "ctrace-run:\n  ctrace-refs: {}\n", "'ctrace-refs' must be an array");
   expectReadError(file, "ctrace-run:\n  ctrace-refs: []\n  ctrace-refs: []\n", "map keys must be unique");
   expectReadError(file, "ctrace-run:\n  ctrace-refs: [invalid]\n", "each 'ctrace-refs' entry must be a map");
@@ -266,11 +267,15 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedReferenceContainers)
                   "missing required 'type' scalar");
   expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: [], ctrace-ref: core/itm, source: 1 }\n",
                   "missing required 'type' scalar");
+  expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: null, ctrace-ref: core/itm, source: 1 }\n",
+                  "missing required 'type' scalar");
   expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: '', ctrace-ref: core/itm, source: 1 }\n",
                   "missing required 'type' scalar");
   expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - type: itm\n      source: 1\n",
                   "missing required 'ctrace-ref' scalar");
   expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: itm, ctrace-ref: [], source: 1 }\n",
+                  "missing required 'ctrace-ref' scalar");
+  expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: itm, ctrace-ref: null, source: 1 }\n",
                   "missing required 'ctrace-ref' scalar");
   expectReadError(file, "ctrace-run:\n  ctrace-refs:\n    - { type: itm, ctrace-ref: '', source: 1 }\n",
                   "missing required 'ctrace-ref' scalar");
@@ -288,7 +293,6 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedReferenceRoutes)
       {"pname: []\n      source: 1", "'pname' must be a scalar string"},
       {"stream: []\n      source: 1", "'stream' must be a scalar unsigned integer"},
       {"source: {}", "'source' must be an array"},
-      {"source: null", "'source' must be an unsigned integer"},
       {"source: 0x", "'source' must be an unsigned integer"},
       {"source: -1", "'source' must be an unsigned integer in range"},
       {"source: 4294967296", "'source' must be an unsigned integer in range"},
@@ -304,6 +308,56 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedReferenceRoutes)
                       testCase.fields + "\n";
     expectReadError(file, yaml, testCase.error);
   }
+}
+
+TEST(CtraceUnitTests, TraceRunReaderIgnoresNullOptionalReferenceValues)
+{
+  TraceRunFixture file("ctrace-run-reader-null-optional-reference-test");
+  const auto config = file.read(R"yml(ctrace-run:
+  ctrace-setup: null
+  ctrace-refs:
+    - null
+    - type: dwt
+      ctrace-ref: data#0
+      pname: null
+      stream: null
+      source: null
+      address: null
+      data-type: null
+      size: null
+      label: null
+      info: null
+      warning: null
+      error: null
+    - type: itm
+      ctrace-ref: itm
+      source: [1, null]
+      info: [note, null]
+      warning: [null]
+      error: [null]
+)yml");
+
+  EXPECT_TRUE(config.setups.empty());
+  ASSERT_EQ(config.references.size(), 2U);
+  const auto& emptyRoute = config.references[0];
+  EXPECT_FALSE(emptyRoute.processorName.has_value());
+  EXPECT_FALSE(emptyRoute.stream.has_value());
+  EXPECT_TRUE(emptyRoute.sources.empty());
+  EXPECT_FALSE(emptyRoute.address.has_value());
+  EXPECT_FALSE(emptyRoute.addressError.has_value());
+  EXPECT_FALSE(emptyRoute.dataType.has_value());
+  EXPECT_FALSE(emptyRoute.dataTypeError.has_value());
+  EXPECT_FALSE(emptyRoute.dataSize.has_value());
+  EXPECT_FALSE(emptyRoute.dataSizeError.has_value());
+  EXPECT_FALSE(emptyRoute.label.has_value());
+  EXPECT_TRUE(emptyRoute.info.empty());
+  EXPECT_TRUE(emptyRoute.warning.empty());
+  EXPECT_TRUE(emptyRoute.error.empty());
+
+  EXPECT_EQ(config.references[1].sources, (std::vector<std::uint32_t>{1U}));
+  EXPECT_EQ(config.references[1].info, (std::vector<std::string>{"note"}));
+  EXPECT_TRUE(config.references[1].warning.empty());
+  EXPECT_TRUE(config.references[1].error.empty());
 }
 
 TEST(CtraceUnitTests, TraceRunReaderPreservesDiagnosticReferences)
@@ -336,9 +390,9 @@ TEST(CtraceUnitTests, TraceRunReaderPreservesDiagnosticReferences)
   EXPECT_FALSE(config.references[3].dataSetupIndex.has_value());
   EXPECT_FALSE(config.references[4].stream.has_value());
   EXPECT_FALSE(config.references[4].dataSetupIndex.has_value());
-  EXPECT_EQ(config.references[5].error, (std::vector<std::string>{""}));
+  EXPECT_TRUE(config.references[5].error.empty());
   EXPECT_TRUE(config.references[6].sources == std::vector<std::uint32_t>{0U});
-  EXPECT_EQ(config.references[7].label, std::optional<std::string>(""));
+  EXPECT_FALSE(config.references[7].label.has_value());
 }
 
 TEST(CtraceUnitTests, TraceRunReaderParsesTimestampSetupVariants)
@@ -362,7 +416,8 @@ TEST(CtraceUnitTests, TraceRunReaderParsesTimestampSetupVariants)
   EXPECT_EQ(config.setups[3].timestamps->clockError,
             std::optional<std::string>("'timestamps.clock' must be a scalar unsigned integer"));
   EXPECT_TRUE(config.setups[4].timestamps->clockError.has_value());
-  EXPECT_TRUE(config.setups[5].timestamps->clockError.has_value());
+  EXPECT_FALSE(config.setups[5].timestamps->clockHz.has_value());
+  EXPECT_FALSE(config.setups[5].timestamps->clockError.has_value());
   EXPECT_EQ(config.setups[6].timestamps->clockHz, std::optional<std::uint64_t>(16U));
   EXPECT_EQ(config.setups[6].timestamps->timestampPrescaler, std::optional<std::uint32_t>(4U));
 
@@ -370,6 +425,49 @@ TEST(CtraceUnitTests, TraceRunReaderParsesTimestampSetupVariants)
                   "map keys must be unique");
   expectReadError(file, "ctrace-run:\n  ctrace-setup:\n    - timestamps: {}\n      timestamps: {}\n",
                   "map keys must be unique");
+}
+
+TEST(CtraceUnitTests, TraceRunReaderTreatsNullOptionalSetupValuesAsAbsent)
+{
+  TraceRunFixture file("ctrace-run-reader-null-optional-setup-test");
+  const auto config = file.read(R"yml(ctrace-run:
+  ctrace-setup:
+    - timestamps:
+        clock: null
+        itm-prescaler: null
+      itm: null
+  ctrace-refs: []
+)yml");
+
+  ASSERT_EQ(config.setups.size(), 1U);
+  ASSERT_TRUE(config.setups[0].timestamps.has_value());
+  EXPECT_FALSE(config.setups[0].timestamps->clockHz.has_value());
+  EXPECT_FALSE(config.setups[0].timestamps->timestampPrescaler.has_value());
+  EXPECT_FALSE(config.setups[0].timestamps->clockError.has_value());
+  EXPECT_FALSE(config.setups[0].itm.has_value());
+
+  const auto meta = CtraceRunMeta::fromConfig(config);
+  EXPECT_FALSE(meta.timestampClockHz().has_value());
+  EXPECT_EQ(meta.timestampPrescaler(),
+            std::optional<std::uint32_t>(TraceRunSchema::kDefaultTimestampPrescaler));
+
+  const auto generatedSetup = file.read(R"yml(ctrace-run:
+  ctrace-setup:
+    - null
+    - pname: null-enable
+      timestamps: null
+      itm:
+        enable: null
+        atbid: 1
+    - pname: absent-enable
+      timestamps: null
+      itm:
+        atbid: 2
+  ctrace-refs: []
+)yml");
+  ASSERT_EQ(generatedSetup.setups.size(), 2U);
+  EXPECT_FALSE(generatedSetup.setups[0].itm.has_value());
+  EXPECT_FALSE(generatedSetup.setups[1].itm.has_value());
 }
 
 TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedConsumedSetups)
@@ -385,9 +483,8 @@ TEST(CtraceUnitTests, TraceRunReaderRejectsMalformedConsumedSetups)
       {"timestamps: { itm-prescaler: [] }", "'timestamps.itm-prescaler' must be a scalar unsigned integer"},
       {"timestamps: { itm-prescaler: invalid }", "'itm-prescaler' must be an unsigned integer in range"},
       {"itm: []", "'itm' must be a map containing 'enable'"},
-      {"itm: {}", "'itm.enable' is required"},
-      {"itm: { enable: [] }", "'itm.enable' is required"},
-      {"itm: { enable: '' }", "'itm.enable' is required"},
+      {"itm: { enable: [] }", "'itm.enable' must be a scalar unsigned integer"},
+      {"itm: { enable: '' }", "'itm.enable' must be a scalar unsigned integer"},
       {"itm: { enable: invalid }", "'itm.enable' must be an unsigned integer in range"},
       {"itm: { enable: 1, enable: 2 }", "map keys must be unique"},
   };


### PR DESCRIPTION
## Summary

- treat optional YAML null values in ctrace-run.yml as absent metadata
- skip null entries in optional reference, setup, source, and diagnostic lists
- accept enriched ITM setup metadata when itm.enable is absent or null
- keep mandatory structure fields and malformed non-null values strict
- preserve downstream behavior: the timestamp prescaler defaults to 1, while CTF still requires an explicit timestamp clock

This keeps parsing separate from mode-specific validation and makes ctrace compatible with the output of Open-CMSIS-Pack/pyTS#47.

## Validation

- built CtraceUnitTests, CtraceIntegTests, and ctrace
- CtraceUnitTests passed
- CtraceIntegTests passed
- pyTS PR 47 compatibility fixtures: 24/24 check runs passed
- pyTS PR 47 compatibility fixtures: 24/24 CSV runs passed
- verified that a missing clock is accepted by the reader and rejected by the CTF requirements check